### PR TITLE
feat: add setup script and update documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - "backend/**"
       - "frontend/**"
+      - "!**/*.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -33,14 +34,19 @@ jobs:
           filters: |
             api:
               - "backend/api/**"
+              - "!backend/api/**/*.md"
             db:
               - "backend/db/**"
+              - "!backend/db/**/*.md"
             ie:
               - "backend/ie/**"
+              - "!backend/ie/**/*.md"
             kgc:
               - "backend/kgc/**"
+              - "!backend/kgc/**/*.md"
             frontend:
               - "frontend/**"
+              - "!frontend/**/*.md"
 
   backend-lint:
     needs: changes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Each backend sub-project follows the same layout: `src/__init__.py` is the modul
 
 - **Root `pyproject.toml`** — Shared linter/checker configs (ruff, mypy, bandit). NOT a Python package.
 - **Per-project `pyproject.toml`** — Build, dependencies, and pytest config only.
-- **Root `.pre-commit-config.yaml`** — All git hooks. Uses official pre-commit repos (not local/uvx).
+- **Root `.pre-commit-config.yaml`** — All git hooks. Uses official pre-commit repos for Python tools; local hooks for ESLint and pytest.
 
 ## Commands
 
@@ -67,7 +67,7 @@ cd frontend && npm run lint
 
 ## Code Standards
 
-- **Python**: 3.12+ required
+- **Python**: 3.12+ (managed by uv)
 - **Ruff**: linting + formatting (E, W, F, I, B, C4, UP, ARG, SIM, TCH, PTH, ERA, PL, RUF rules)
 - **MyPy**: strict mode with `explicit_package_bases` for monorepo support
 - **Bandit**: security scanning (excludes tests, skips B101/B311)

--- a/README.md
+++ b/README.md
@@ -22,42 +22,35 @@ A food knowledge graph platform. This monorepo contains the frontend, backend se
 
 ### Prerequisites
 
-- Python 3.12+
-- [uv](https://docs.astral.sh/uv/) (Python package manager)
+- [uv](https://docs.astral.sh/uv/) (Python package manager; handles Python installation automatically)
+- Node.js 20+
+- npm
 
 ### Clone and set up
 
 ```bash
 git clone https://github.com/AI-Institute-Food-Systems/foodatlas.git
 cd foodatlas
+./scripts/check-prereqs.sh
 ```
 
-### Install uv (if not already installed)
+The setup script auto-installs uv, git hooks, backend dependencies, and frontend dependencies. Node.js and npm must be installed separately.
 
-```bash
-curl -LsSf https://astral.sh/uv/install.sh | sh
-```
-
-### Set up git hooks
-
-```bash
-./scripts/setup-git-hooks.sh
-```
-
-### Install dependencies for a backend sub-project
-
-Each backend sub-project is independent. Navigate to it and install:
-
-```bash
-cd backend/api
-uv sync
-```
-
-### Run tests
+### Backend
 
 ```bash
 cd backend/api
 uv run pytest
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm run dev     # dev server
+npm run build   # production build
+npm run lint    # ESLint + type check
+npm test        # Vitest
 ```
 
 ## Contributing

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,36 +1,54 @@
-This is a [Next.js](https://nextjs.org/) project bootstrapped with [`create-next-app`](https://github.com/vercel/next.js/tree/canary/packages/create-next-app).
+# FoodAtlas Frontend
+
+Next.js 14 web application with React 18, TypeScript, and Tailwind CSS using the App Router.
 
 ## Getting Started
 
-First, run the development server:
-
 ```bash
+npm ci
 npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open [http://localhost:3000](http://localhost:3000) to view the app.
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+## Commands
 
-This project uses [`next/font`](https://nextjs.org/docs/basic-features/font-optimization) to automatically optimize and load Inter, a custom Google Font.
+| Command         | Description                      |
+|-----------------|----------------------------------|
+| `npm run dev`   | Start development server         |
+| `npm run build` | Production build                 |
+| `npm run lint`  | ESLint + TypeScript type check   |
+| `npm test`      | Run tests (Vitest)               |
 
-## Learn More
+## Project Structure
 
-To learn more about Next.js, take a look at the following resources:
+```
+frontend/
+├── app/                    # Next.js App Router pages and layouts
+│   ├── (home)/             # Landing page route group
+│   ├── (everything-else)/  # All other pages (about, contact, entities, etc.)
+│   └── api/                # API routes (auth, contact form)
+├── components/             # Reusable React components
+│   ├── basic/              # UI primitives (Button, Card, Modal, etc.)
+│   ├── entities/           # Entity detail page components (food, chemical, disease)
+│   ├── icons/              # SVG icon components
+│   ├── landing/            # Landing page sections
+│   ├── navigation/         # Navbar and Footer
+│   └── search/             # Search bar and results
+├── context/                # React context providers
+├── hooks/                  # Custom React hooks
+├── styles/                 # Global CSS and font config
+├── types/                  # TypeScript type definitions
+└── utils/                  # Utility functions (fetching, downloads)
+```
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+## Environment Variables
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js/) - your feedback and contributions are welcome!
-
-## Deploy on Vercel
-
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
-
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
+| Variable               | Description                        |
+|------------------------|------------------------------------|
+| `NEXT_PUBLIC_API_URL`  | Backend API base URL               |
+| `NEXT_PUBLIC_API_KEY`  | Backend API key                    |
+| `RESEND_API_KEY`       | Resend API key (contact form)      |
+| `EMAIL_FROM`           | Sender email address               |
+| `EMAIL_TO`             | Recipient email address(es)        |
+| `NEXTAUTH_SECRET`      | NextAuth.js secret                 |

--- a/scripts/check-prereqs.sh
+++ b/scripts/check-prereqs.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+#
+# Check and install development prerequisites.
+# Auto-installs: uv, git hooks, backend deps, frontend deps.
+# Reports only: Node.js, npm (too many competing version managers).
+#
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+errors=0
+
+check_version() {
+  local actual="$1" required="$2" name="$3"
+  if [ "$(printf '%s\n' "$required" "$actual" | sort -V | head -n1)" != "$required" ]; then
+    echo "  OUTDATED: $name $actual (need $required+)"
+    errors=$((errors + 1))
+    return 1
+  fi
+  echo "  OK: $name $actual"
+  return 0
+}
+
+echo "Checking prerequisites..."
+echo ""
+
+# uv
+echo "[uv]"
+if command -v uv &>/dev/null; then
+  uv_version="$(uv --version | awk '{print $2}')"
+  echo "  OK: uv $uv_version"
+else
+  echo "  Installing uv..."
+  curl -LsSf https://astral.sh/uv/install.sh | sh
+  echo "  OK: uv installed"
+fi
+
+# Node.js
+echo "[Node.js]"
+if command -v node &>/dev/null; then
+  node_version="$(node --version | sed 's/^v//')"
+  check_version "$node_version" "20" "node" || true
+else
+  echo "  MISSING: node — install from https://nodejs.org/"
+  errors=$((errors + 1))
+fi
+
+# npm
+echo "[npm]"
+if command -v npm &>/dev/null; then
+  npm_version="$(npm --version)"
+  echo "  OK: npm $npm_version"
+else
+  echo "  MISSING: npm — installed with Node.js"
+  errors=$((errors + 1))
+fi
+
+echo ""
+
+# Git hooks
+echo "[Git hooks]"
+if [ -f "$PROJECT_ROOT/.git/hooks/pre-commit" ] && [ -f "$PROJECT_ROOT/.git/hooks/pre-push" ]; then
+  echo "  OK: pre-commit and pre-push hooks installed"
+else
+  echo "  Installing git hooks..."
+  "$SCRIPT_DIR/setup-git-hooks.sh"
+  echo "  OK: git hooks installed"
+fi
+
+# Backend dependencies
+echo "[Backend dependencies]"
+for project in api db ie kgc; do
+  dir="$PROJECT_ROOT/backend/$project"
+  if [ -d "$dir/.venv" ]; then
+    echo "  OK: backend/$project"
+  else
+    echo "  Installing backend/$project..."
+    (cd "$dir" && uv sync)
+    echo "  OK: backend/$project"
+  fi
+done
+
+# Frontend dependencies
+echo "[Frontend dependencies]"
+if [ -d "$PROJECT_ROOT/frontend/node_modules" ]; then
+  echo "  OK: frontend"
+else
+  echo "  Installing frontend..."
+  (cd "$PROJECT_ROOT/frontend" && npm ci)
+  echo "  OK: frontend"
+fi
+
+echo ""
+if [ "$errors" -eq 0 ]; then
+  echo "All prerequisites satisfied."
+else
+  echo "$errors issue(s) found. See above for details."
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- Add `scripts/check-prereqs.sh` that auto-installs uv, git hooks, backend dependencies (`uv sync`), and frontend dependencies (`npm ci`); reports Node.js/npm if missing
- Streamline root README setup to a single `./scripts/check-prereqs.sh` command after clone
- Replace boilerplate frontend README with project-specific docs (structure, commands, env vars)
- Fix CLAUDE.md to reflect that Python is managed by uv and pre-commit uses local hooks for ESLint/pytest