### PR TITLE
feat: add conc_value_raw/conc_unit_raw to Attestation, refactor triplets into subpackages

### DIFF
--- a/backend/kgc/src/models/attestation.py
+++ b/backend/kgc/src/models/attestation.py
@@ -22,6 +22,8 @@ class Attestation(BaseModel):
     tail_name_raw: str = ""  # raw chemical/disease name from attestation
     conc_value: float | None = None
     conc_unit: str = ""
+    conc_value_raw: str = ""
+    conc_unit_raw: str = ""
     food_part: str = ""
     food_processing: str = ""
     quality_score: float | None = None

--- a/backend/kgc/src/pipeline/ie/conc_parser.py
+++ b/backend/kgc/src/pipeline/ie/conc_parser.py
@@ -1,0 +1,93 @@
+"""Parse raw IE concentration strings into (value, unit) pairs.
+
+Ported from ``examples/preprocessing/_standardize_chemical_conc.py`` with a
+lighter footprint: no pandas/numpy dependency, no unit conversion (that is a
+downstream concern for ``conc_value`` / ``conc_unit``).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Unicode dashes / range separators → kept as-is in the captured value.
+_DASH = r"[\u002d\u2010\u2011\u2012\u2013\u2014\u2015\u2212~\u223c]"
+
+# Approximate prefixes that may precede a numeric value.
+_APPROX = r"[<>\u2248~\u223c]"
+
+# A bare number: digits and dots, optionally with ± deviation.
+_NUM = r"[\d.]+(?:\u00b1[\d.]+)?"
+
+# Full pattern: optional approx, number, optional range, then unit.
+_RE_CONC = re.compile(
+    rf"^({_APPROX}?{_NUM}(?:{_DASH}{_NUM})?)"  # value (with optional range)
+    rf"(.+)$",  # unit
+)
+
+# Weight-type suffixes (longest first to avoid partial matches).
+_WEIGHT_TYPES: list[tuple[str, str]] = sorted(
+    [
+        ("freshweight", "fw"),
+        ("offw", "fw"),
+        ("fw", "fw"),
+        ("dryweight", "dw"),
+        ("dw", "dw"),
+        ("dm", "dw"),
+    ],
+    key=lambda t: len(t[0]),
+    reverse=True,
+)
+
+
+def parse_conc(raw: str) -> tuple[str, str] | None:
+    """Split a raw concentration string into ``(value, unit)``.
+
+    Returns ``("", "")`` for blank input.
+    Returns ``None`` when the string cannot be parsed (no leading number,
+    or no recognisable unit), which signals a diagnostic entry.
+
+    Examples::
+
+        >>> parse_conc("1.5mg/g")
+        ('1.5', 'mg/g')
+        >>> parse_conc("20\\u201350 mg")
+        ('20\\u201350', 'mg')
+        >>> parse_conc("")
+        ('', '')
+        >>> parse_conc("trace") is None
+        True
+    """
+    if not raw:
+        return ("", "")
+
+    # Normalise "X to Y" ranges into "X-Y" before collapsing whitespace.
+    s = re.sub(r"(\d)\s+to\s+(\d)", r"\1-\2", raw)
+    s = "".join(s.split())  # collapse remaining whitespace
+
+    if not s:
+        return ("", "")
+
+    # Strip weight-type suffix (case-insensitive).
+    weight = ""
+    s_lower = s.lower()
+    for suffix, label in _WEIGHT_TYPES:
+        if s_lower.endswith(suffix):
+            s = s[: -len(suffix)]
+            weight = label
+            break
+
+    m = _RE_CONC.match(s)
+    if not m:
+        return None
+
+    value_str = m.group(1)
+    unit_str = m.group(2)
+
+    # Unit must contain at least one letter-like char or '%'.
+    if not unit_str or not any(c.isalpha() or c == "%" for c in unit_str):
+        return None
+
+    if weight:
+        unit_str = f"{unit_str} {weight}"
+
+    return (value_str, unit_str)

--- a/backend/kgc/src/pipeline/ie/loader.py
+++ b/backend/kgc/src/pipeline/ie/loader.py
@@ -10,6 +10,7 @@ import pandas as pd
 from tqdm import tqdm
 
 from ...stores.schema import FILE_IE_PARSE_ERRORS
+from .conc_parser import parse_conc
 from .constants import GREEK_LETTERS, PUNCTUATIONS
 
 if TYPE_CHECKING:
@@ -100,7 +101,16 @@ def load_ie_raw(path: Path, output_dir: Path) -> pd.DataFrame:
                     {"pmcid": rec["pmcid"], "line": line.strip(), "reason": "bad_tuple"}
                 )
                 continue
-            food, food_part, chemical, _quantity = parsed
+            food, food_part, chemical, quantity = parsed
+            conc_value_raw, conc_unit_raw = "", ""
+            if quantity:
+                conc_result = parse_conc(quantity)
+                if conc_result is None:
+                    parse_errors.append(
+                        {"pmcid": rec["pmcid"], "line": quantity, "reason": "bad_conc"}
+                    )
+                else:
+                    conc_value_raw, conc_unit_raw = conc_result
             ref = json.dumps({"pmcid": rec["pmcid"], "text": rec.get("sentence", "")})
             rows.append(
                 {
@@ -113,6 +123,8 @@ def load_ie_raw(path: Path, output_dir: Path) -> pd.DataFrame:
                     "tail_name_raw": standardize_name(chemical),
                     "conc_value": None,
                     "conc_unit": "",
+                    "conc_value_raw": conc_value_raw,
+                    "conc_unit_raw": conc_unit_raw,
                     "food_part": food_part.strip().lower(),
                     "food_processing": "",
                     "quality_score": float(rec["prob"]),

--- a/backend/kgc/src/pipeline/triplets/builder.py
+++ b/backend/kgc/src/pipeline/triplets/builder.py
@@ -9,8 +9,7 @@ from ...utils.timing import log_duration
 from .chemical_chemical import merge_chemical_ontology
 from .chemical_disease import merge_ctd_triplets
 from .disease_disease import merge_disease_ontology
-from .food_chemical import merge_fdc_triplets
-from .food_chemical_dmd import merge_dmd_triplets
+from .food_chemical import merge_dmd_triplets, merge_fdc_triplets
 from .food_food import merge_food_ontology
 
 if TYPE_CHECKING:

--- a/backend/kgc/src/pipeline/triplets/chemical_chemical/__init__.py
+++ b/backend/kgc/src/pipeline/triplets/chemical_chemical/__init__.py
@@ -1,0 +1,5 @@
+"""Chemical ontology (IS_A) triplet builders."""
+
+from .chebi import merge_chemical_ontology
+
+__all__ = ["merge_chemical_ontology"]

--- a/backend/kgc/src/pipeline/triplets/chemical_chemical/chebi.py
+++ b/backend/kgc/src/pipeline/triplets/chemical_chemical/chebi.py
@@ -8,10 +8,10 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
-from .chemical_disease import _explode_external_ids
+from ..utils import explode_external_ids
 
 if TYPE_CHECKING:
-    from ..knowledge_graph import KnowledgeGraph
+    from ...knowledge_graph import KnowledgeGraph
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +34,7 @@ def merge_chemical_ontology(
     is_a["head_native_id"] = is_a["head_native_id"].astype(int).astype(str)
     is_a["tail_native_id"] = is_a["tail_native_id"].astype(int).astype(str)
 
-    lookup = _explode_external_ids(kg.entities._entities, "chebi")
+    lookup = explode_external_ids(kg.entities._entities, "chebi")
     if lookup.empty:
         return
 

--- a/backend/kgc/src/pipeline/triplets/chemical_disease/__init__.py
+++ b/backend/kgc/src/pipeline/triplets/chemical_disease/__init__.py
@@ -1,0 +1,5 @@
+"""Chemical-disease triplet builders."""
+
+from .ctd import merge_ctd_triplets
+
+__all__ = ["merge_ctd_triplets"]

--- a/backend/kgc/src/pipeline/triplets/chemical_disease/ctd.py
+++ b/backend/kgc/src/pipeline/triplets/chemical_disease/ctd.py
@@ -8,10 +8,11 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
-from ...models.relationship import RelationshipType
+from ....models.relationship import RelationshipType
+from ..utils import explode_external_ids
 
 if TYPE_CHECKING:
-    from ..knowledge_graph import KnowledgeGraph
+    from ...knowledge_graph import KnowledgeGraph
 
 logger = logging.getLogger(__name__)
 
@@ -59,8 +60,8 @@ def merge_ctd_triplets(
     direct = direct[direct["_rel_id"].notna()]
 
     # Build ID maps as DataFrames for vectorized join.
-    mesh2fa = _explode_external_ids(kg.entities._entities, "mesh")
-    disease2fa = _explode_external_ids(kg.entities._entities, "ctd")
+    mesh2fa = explode_external_ids(kg.entities._entities, "mesh")
+    disease2fa = explode_external_ids(kg.entities._entities, "ctd")
 
     # Join head (chemical via MeSH).
     df = direct.merge(
@@ -108,23 +109,3 @@ def merge_ctd_triplets(
     logger.info(
         "Merged %d CTD attestations, %d triplets.", len(attestations), len(triplets)
     )
-
-
-def _explode_external_ids(entities: pd.DataFrame, key: str) -> pd.DataFrame:
-    """Build a DataFrame mapping native IDs to entity IDs with candidate lists.
-
-    Returns columns: ``native_id``, ``foodatlas_id``, ``candidates``.
-    ``candidates`` is the full list of entity IDs for that native ID.
-    """
-    rows: list[tuple[str, str]] = []
-    for eid, row in entities.iterrows():
-        for native_id in row["external_ids"].get(key, []):
-            rows.append((str(native_id), str(eid)))
-    if not rows:
-        return pd.DataFrame(columns=["native_id", "foodatlas_id", "candidates"])
-
-    lookup = pd.DataFrame(rows, columns=["native_id", "foodatlas_id"])
-    # Add candidate lists (all entity IDs per native_id).
-    candidates = lookup.groupby("native_id")["foodatlas_id"].apply(list)
-    candidates.name = "candidates"
-    return lookup.merge(candidates, left_on="native_id", right_index=True)

--- a/backend/kgc/src/pipeline/triplets/disease_disease/__init__.py
+++ b/backend/kgc/src/pipeline/triplets/disease_disease/__init__.py
@@ -1,0 +1,5 @@
+"""Disease ontology (IS_A) triplet builders."""
+
+from .ctd import merge_disease_ontology
+
+__all__ = ["merge_disease_ontology"]

--- a/backend/kgc/src/pipeline/triplets/disease_disease/ctd.py
+++ b/backend/kgc/src/pipeline/triplets/disease_disease/ctd.py
@@ -8,10 +8,10 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
-from .chemical_disease import _explode_external_ids
+from ..utils import explode_external_ids
 
 if TYPE_CHECKING:
-    from ..knowledge_graph import KnowledgeGraph
+    from ...knowledge_graph import KnowledgeGraph
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ def merge_disease_ontology(
     edges = ctd["edges"]
     is_a = edges[edges["edge_type"] == "is_a"]
 
-    lookup = _explode_external_ids(kg.entities._entities, "ctd")
+    lookup = explode_external_ids(kg.entities._entities, "ctd")
     if lookup.empty:
         return
 

--- a/backend/kgc/src/pipeline/triplets/food_chemical/__init__.py
+++ b/backend/kgc/src/pipeline/triplets/food_chemical/__init__.py
@@ -1,0 +1,6 @@
+"""Food-chemical (CONTAINS) triplet builders."""
+
+from .dmd import merge_dmd_triplets
+from .fdc import merge_fdc_triplets
+
+__all__ = ["merge_dmd_triplets", "merge_fdc_triplets"]

--- a/backend/kgc/src/pipeline/triplets/food_chemical/dmd.py
+++ b/backend/kgc/src/pipeline/triplets/food_chemical/dmd.py
@@ -8,11 +8,11 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
-from ...models.relationship import RelationshipType
-from .chemical_disease import _explode_external_ids
+from ....models.relationship import RelationshipType
+from ..utils import explode_external_ids
 
 if TYPE_CHECKING:
-    from ..knowledge_graph import KnowledgeGraph
+    from ...knowledge_graph import KnowledgeGraph
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +51,7 @@ def merge_dmd_triplets(
         logger.warning("Cow milk entity (FOODON_02020891) not found; skipping DMD.")
         return
 
-    mol_lookup = _explode_external_ids(kg.entities._entities, "dmd")
+    mol_lookup = explode_external_ids(kg.entities._entities, "dmd")
     if mol_lookup.empty:
         logger.info("No DMD entity mappings.")
         return
@@ -78,6 +78,16 @@ def merge_dmd_triplets(
     )
     df["conc_unit"] = df["raw_attrs"].apply(
         lambda x: x.get("conc_unit", "") if isinstance(x, dict) else ""
+    )
+    df["conc_value_raw"] = df["raw_attrs"].apply(
+        lambda x: (
+            str(x.get("conc_value_raw", ""))
+            if isinstance(x, dict) and x.get("conc_value_raw") is not None
+            else ""
+        )
+    )
+    df["conc_unit_raw"] = df["raw_attrs"].apply(
+        lambda x: x.get("conc_unit_raw", "") if isinstance(x, dict) else ""
     )
 
     df["source_type"] = "dmd"

--- a/backend/kgc/src/pipeline/triplets/food_chemical/fdc.py
+++ b/backend/kgc/src/pipeline/triplets/food_chemical/fdc.py
@@ -8,11 +8,11 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
-from ...models.relationship import RelationshipType
-from .chemical_disease import _explode_external_ids
+from ....models.relationship import RelationshipType
+from ..utils import explode_external_ids
 
 if TYPE_CHECKING:
-    from ..knowledge_graph import KnowledgeGraph
+    from ...knowledge_graph import KnowledgeGraph
 
 logger = logging.getLogger(__name__)
 
@@ -38,8 +38,8 @@ def merge_fdc_triplets(
     )
 
     # Build lookup maps.
-    food_lookup = _explode_external_ids(kg.entities._entities, "fdc")
-    nutrient_lookup = _explode_external_ids(kg.entities._entities, "fdc_nutrient")
+    food_lookup = explode_external_ids(kg.entities._entities, "fdc")
+    nutrient_lookup = explode_external_ids(kg.entities._entities, "fdc_nutrient")
     if food_lookup.empty or nutrient_lookup.empty:
         logger.info("No FDC entity mappings.")
         return

--- a/backend/kgc/src/pipeline/triplets/food_food/__init__.py
+++ b/backend/kgc/src/pipeline/triplets/food_food/__init__.py
@@ -1,0 +1,5 @@
+"""Food ontology (IS_A) triplet builders."""
+
+from .foodon import merge_food_ontology
+
+__all__ = ["merge_food_ontology"]

--- a/backend/kgc/src/pipeline/triplets/food_food/foodon.py
+++ b/backend/kgc/src/pipeline/triplets/food_food/foodon.py
@@ -8,10 +8,10 @@ from typing import TYPE_CHECKING
 
 import pandas as pd
 
-from .chemical_disease import _explode_external_ids
+from ..utils import explode_external_ids
 
 if TYPE_CHECKING:
-    from ..knowledge_graph import KnowledgeGraph
+    from ...knowledge_graph import KnowledgeGraph
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +31,7 @@ def merge_food_ontology(
     edges = foodon["edges"]
     is_a = edges[edges["edge_type"] == "is_a"]
 
-    lookup = _explode_external_ids(kg.entities._entities, "foodon")
+    lookup = explode_external_ids(kg.entities._entities, "foodon")
     if lookup.empty:
         return
 

--- a/backend/kgc/src/pipeline/triplets/utils.py
+++ b/backend/kgc/src/pipeline/triplets/utils.py
@@ -1,0 +1,25 @@
+"""Shared utilities for triplet builders."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+
+def explode_external_ids(entities: pd.DataFrame, key: str) -> pd.DataFrame:
+    """Build a DataFrame mapping native IDs to entity IDs with candidate lists.
+
+    Returns columns: ``native_id``, ``foodatlas_id``, ``candidates``.
+    ``candidates`` is the full list of entity IDs for that native ID.
+    """
+    rows: list[tuple[str, str]] = []
+    for eid, row in entities.iterrows():
+        for native_id in row["external_ids"].get(key, []):
+            rows.append((str(native_id), str(eid)))
+    if not rows:
+        return pd.DataFrame(columns=["native_id", "foodatlas_id", "candidates"])
+
+    lookup = pd.DataFrame(rows, columns=["native_id", "foodatlas_id"])
+    # Add candidate lists (all entity IDs per native_id).
+    candidates = lookup.groupby("native_id")["foodatlas_id"].apply(list)
+    candidates.name = "candidates"
+    return lookup.merge(candidates, left_on="native_id", right_index=True)

--- a/backend/kgc/tests/test_attestation_store.py
+++ b/backend/kgc/tests/test_attestation_store.py
@@ -24,6 +24,8 @@ def _make_row(**overrides: float | str | bool | None) -> dict:
         "tail_name_raw": "vitamin c",
         "conc_value": None,
         "conc_unit": "",
+        "conc_value_raw": "",
+        "conc_unit_raw": "",
         "food_part": "",
         "food_processing": "",
         "quality_score": 0.95,

--- a/backend/kgc/tests/test_conc_parser.py
+++ b/backend/kgc/tests/test_conc_parser.py
@@ -1,0 +1,67 @@
+"""Tests for conc_parser — splitting raw concentration strings."""
+
+import pytest
+from src.pipeline.ie.conc_parser import parse_conc
+
+
+class TestParseConc:
+    def test_empty_string(self) -> None:
+        assert parse_conc("") == ("", "")
+
+    def test_whitespace_only(self) -> None:
+        assert parse_conc("   ") == ("", "")
+
+    def test_simple_value_unit(self) -> None:
+        assert parse_conc("1.5mg/g") == ("1.5", "mg/g")
+
+    def test_value_unit_with_space(self) -> None:
+        assert parse_conc("1.5 mg/g") == ("1.5", "mg/g")
+
+    def test_percentage(self) -> None:
+        assert parse_conc("5%") == ("5", "%")
+
+    def test_unicode_dash_range(self) -> None:
+        assert parse_conc("20\u201350mg") == ("20\u201350", "mg")
+
+    def test_range_with_spaces(self) -> None:
+        assert parse_conc("20 - 50 mg") == ("20-50", "mg")
+
+    def test_to_range(self) -> None:
+        assert parse_conc("20 to 50 mg") == ("20-50", "mg")
+
+    def test_plus_minus(self) -> None:
+        assert parse_conc("0.3\u00b10.1\u00b5g/mL") == ("0.3\u00b10.1", "\u00b5g/mL")
+
+    def test_approx_less_than(self) -> None:
+        assert parse_conc("<0.01mg/g") == ("<0.01", "mg/g")
+
+    def test_approx_greater_than(self) -> None:
+        assert parse_conc(">5mg/g") == (">5", "mg/g")
+
+    def test_weight_type_fw(self) -> None:
+        assert parse_conc("12.5mg/100gfw") == ("12.5", "mg/100g fw")
+
+    def test_weight_type_dw(self) -> None:
+        assert parse_conc("3.2mg/gdw") == ("3.2", "mg/g dw")
+
+    def test_weight_type_freshweight(self) -> None:
+        assert parse_conc("1.0mg/gfreshweight") == ("1.0", "mg/g fw")
+
+    def test_compound_unit(self) -> None:
+        assert parse_conc("50µg/100ml") == ("50", "µg/100ml")
+
+    def test_unparseable_text(self) -> None:
+        assert parse_conc("trace") is None
+
+    def test_unparseable_no_unit(self) -> None:
+        assert parse_conc("42") is None
+
+    def test_unparseable_no_alpha_unit(self) -> None:
+        assert parse_conc("5/100") is None
+
+    @pytest.mark.parametrize(
+        "raw",
+        ["present", "detected", "n/a", "abundant"],
+    )
+    def test_qualitative_strings_unparseable(self, raw: str) -> None:
+        assert parse_conc(raw) is None

--- a/backend/kgc/tests/test_ie_loader.py
+++ b/backend/kgc/tests/test_ie_loader.py
@@ -123,6 +123,54 @@ class TestLoadIeRaw:
         with pytest.raises(ValueError, match="missing columns"):
             load_ie_raw(path, tmp_path)
 
+    def test_quantity_parsed_into_raw_fields(self, tmp_path: Path) -> None:
+        path = tmp_path / "conc.tsv"
+        rows = [
+            {
+                "pmcid": "444",
+                "section": "RESULTS",
+                "matched_query": "apple",
+                "sentence": "Apples contain 1.5mg/g vitamin C.",
+                "prob": 0.95,
+                "response": "(apple, peel, vitamin c, 1.5mg/g)",
+            },
+        ]
+        pd.DataFrame(rows).to_csv(path, sep="\t", index=False)
+        df = load_ie_raw(path, tmp_path)
+        row = df.iloc[0]
+        assert row["conc_value_raw"] == "1.5"
+        assert row["conc_unit_raw"] == "mg/g"
+
+    def test_unparseable_quantity_logged(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad_conc.tsv"
+        rows = [
+            {
+                "pmcid": "555",
+                "section": "RESULTS",
+                "matched_query": "tea",
+                "sentence": "Tea has traces of lead.",
+                "prob": 0.90,
+                "response": "(tea, leaf, lead, trace)",
+            },
+        ]
+        pd.DataFrame(rows).to_csv(path, sep="\t", index=False)
+        df = load_ie_raw(path, tmp_path)
+        # Row is still created, with empty raw fields.
+        assert len(df) == 1
+        assert df.iloc[0]["conc_value_raw"] == ""
+        assert df.iloc[0]["conc_unit_raw"] == ""
+        # Error was written to diagnostics.
+        errors_path = tmp_path / "diagnostics" / "ie_parse_errors.tsv"
+        assert errors_path.exists()
+        errors = pd.read_csv(errors_path, sep="\t")
+        assert (errors["reason"] == "bad_conc").any()
+
+    def test_empty_quantity_no_error(self, ie_tsv: Path) -> None:
+        df = load_ie_raw(ie_tsv, ie_tsv.parent)
+        # All fixtures have empty quantities — should not produce bad_conc errors.
+        assert (df["conc_value_raw"] == "").all()
+        assert (df["conc_unit_raw"] == "").all()
+
     def test_empty_response_skipped(self, tmp_path: Path) -> None:
         path = tmp_path / "empty.tsv"
         lines = [


### PR DESCRIPTION
## Summary

Closes #41.

- **Add `conc_value_raw` and `conc_unit_raw` string fields to Attestation model** for storing original/raw concentration values before normalization
- **Add concentration parser** (`conc_parser.py`) that splits IE quantity strings (e.g., `"20–50 mg"`, `"1.5mg/g"`) into value/unit pairs, handling ranges, ±, weight types (fw/dw), and approximation prefixes. Unparseable strings are logged to the existing `ie_parse_errors.tsv` diagnostics file with `reason=bad_conc`
- **Populate raw conc fields for DMD** by extracting `conc_value_raw`/`conc_unit_raw` from `raw_attrs` in the DMD triplet builder
- **Refactor `triplets/` from flat files into relationship-type subpackages**:
  - `food_chemical/{fdc.py, dmd.py}`
  - `chemical_disease/ctd.py`
  - `food_food/foodon.py`
  - `chemical_chemical/chebi.py`
  - `disease_disease/ctd.py`
- **Extract shared `_explode_external_ids`** into `triplets/utils.py` as a public function (used by 5 builders)

## Test plan

- [x] 22 new tests for `conc_parser` covering all parse cases (ranges, ±, weight types, approx markers, unparseable strings)
- [x] 3 new tests for IE loader quantity flow (parsed fields, unparseable diagnostics, empty quantity)
- [x] Updated `_make_row` helper in attestation store tests for new fields
- [x] All 64 affected tests pass; all pre-push hooks pass across 4 sub-projects