### PR TITLE
docs: update READMEs and CLAUDE.md with local dev setup guide

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,13 +11,19 @@ FoodAtlas is a monorepo containing frontend, backend, and infrastructure code fo
 This is a polyglot monorepo with independent sub-projects:
 
 - **`backend/`** — Four independent Python sub-projects, each with its own `pyproject.toml`, `uv.lock`, and `.venv`:
-  - `api/` — API service
-  - `db/` — Database layer
-  - `ie/` — Information extraction
-  - `kgc/` — Knowledge graph construction
+  - `api/` — FastAPI REST service (uvicorn, port 8000). Routes, repositories, config, auth.
+  - `db/` — PostgreSQL schema (Alembic migrations), ETL pipeline (parquet → Postgres), SQLAlchemy models.
+  - `ie/` — Information extraction (stub, not yet implemented)
+  - `kgc/` — Knowledge graph construction pipeline (Click CLI, multi-stage: ingest → entities → triplets → postprocessing)
 - **`frontend/`** — Next.js 14 app (React 18, TypeScript, Tailwind, App Router)
-- **`infra/`** — AWS CDK infrastructure (Python, not yet initialized)
-Each backend sub-project follows the same layout: `src/__init__.py` is the module, `tests/` for tests, `main.py` as entry point.
+- **`infra/`** — Local dev infrastructure: `docker-compose.yml` for PostgreSQL 16
+- **`docs/`** — Architecture and planning documents (e.g., `bmad/backend-integration-plan.md`)
+
+Each backend sub-project follows the same layout: `src/` is the module, `tests/` for tests, `main.py` as entry point.
+
+### Local stack
+
+PostgreSQL 16 (Docker) → DB migrations (Alembic) → Data load (ETL) → FastAPI (port 8000) → Next.js (port 3000)
 
 ### Configuration split
 
@@ -26,6 +32,27 @@ Each backend sub-project follows the same layout: `src/__init__.py` is the modul
 - **Root `.pre-commit-config.yaml`** — All git hooks. Uses official pre-commit repos for Python tools; local hooks for ESLint and pytest.
 
 ## Commands
+
+### Local dev setup (full stack)
+
+```bash
+# Start PostgreSQL
+docker compose -f infra/docker-compose.yml up -d
+
+# Run DB migrations
+cd backend/db && uv run alembic upgrade head
+
+# Load KGC data into PostgreSQL
+cd backend/db && uv run python main.py load --parquet-dir /path/to/kgc/outputs
+
+# Start API server (port 8000)
+cd backend/api && uv run python main.py
+
+# Start frontend (port 3000)
+cd frontend && npm run dev
+```
+
+### Backend commands
 
 All backend work must be done from within the sub-project directory:
 

--- a/README.md
+++ b/README.md
@@ -6,27 +6,33 @@ A food knowledge graph platform. This monorepo contains the frontend, backend se
 
 ```
 .
-├── frontend/               # Next.js web app (deployed on Vercel)
+├── frontend/               # Next.js 14 web app (React 18, TypeScript, Tailwind)
 ├── backend/
-│   ├── api/                # API service
-│   ├── db/                 # Database layer
-│   ├── ie/                 # Information extraction
-│   └── kgc/                # Knowledge graph construction
-├── infra/                  # AWS CDK infrastructure (Python)
+│   ├── api/                # FastAPI REST service (port 8000)
+│   ├── db/                 # PostgreSQL schema, migrations, and ETL
+│   ├── ie/                 # Information extraction (stub)
+│   └── kgc/                # Knowledge graph construction pipeline
+├── infra/
+│   └── docker-compose.yml  # Local PostgreSQL 16
+├── docs/                   # Architecture and planning docs
+├── scripts/                # Setup and utility scripts
 ├── .github/workflows/      # CI/CD pipelines
 ├── pyproject.toml          # Shared linter/checker configs (ruff, mypy, bandit)
 └── .pre-commit-config.yaml # Git hooks
 ```
 
-## Getting Started
+## Running Locally
+
+The full stack is: **PostgreSQL → DB migrations & data load → FastAPI → Next.js**.
 
 ### Prerequisites
 
+- [Docker](https://docs.docker.com/get-docker/) (for PostgreSQL)
 - [uv](https://docs.astral.sh/uv/) (Python package manager; handles Python installation automatically)
 - Node.js 20+
 - npm
 
-### Clone and set up
+### 1. Clone and install dependencies
 
 ```bash
 git clone https://github.com/AI-Institute-Food-Systems/foodatlas.git
@@ -36,50 +42,69 @@ cd foodatlas
 
 The setup script auto-installs uv, git hooks, backend dependencies, and frontend dependencies. Node.js and npm must be installed separately.
 
-### Backend
+### 2. Start PostgreSQL
+
+```bash
+docker compose -f infra/docker-compose.yml up -d
+```
+
+This starts a PostgreSQL 16 container on port 5432 with database `foodatlas` (user: `foodatlas`, password: `foodatlas`).
+
+### 3. Run database migrations
+
+```bash
+cd backend/db
+uv run alembic upgrade head
+```
+
+### 4. Load knowledge graph data
+
+```bash
+cd backend/db
+uv run python main.py load --parquet-dir ../kgc/outputs/kg
+```
+
+This loads KGC parquet output into PostgreSQL. See [`backend/kgc/README.md`](backend/kgc/README.md) for how to generate the parquet files.
+
+### 5. Start the API server
 
 ```bash
 cd backend/api
-uv run pytest
+uv run python main.py
 ```
 
-### Frontend
+The FastAPI server runs at `http://localhost:8000`. In debug mode (default), API key authentication is skipped.
+
+### 6. Start the frontend
 
 ```bash
 cd frontend
-npm run dev     # dev server
-npm run build   # production build
-npm run lint    # ESLint + type check
-npm test        # Vitest
+npm run dev
 ```
+
+Open [http://localhost:3000](http://localhost:3000). The frontend connects to the API at `http://localhost:8000` by default.
+
+### Environment Variables
+
+All services work with defaults for local development. Override via `.env` files or environment variables:
+
+| Variable | Default | Description |
+|---|---|---|
+| `DB_HOST` | `localhost` | PostgreSQL host |
+| `DB_PORT` | `5432` | PostgreSQL port |
+| `DB_NAME` | `foodatlas` | Database name |
+| `DB_USER` | `foodatlas` | Database user |
+| `DB_PASSWORD` | `foodatlas` | Database password |
+| `API_KEY` | (empty) | API key (skipped in debug mode) |
+| `API_CORS_ORIGINS` | `http://localhost:3000` | Allowed CORS origins |
+| `API_DEBUG` | `true` | Enable debug mode |
+| `NEXT_PUBLIC_API_URL` | — | Backend API URL (set to `http://localhost:8000`) |
+| `NEXT_PUBLIC_API_KEY` | — | Backend API key (not needed in debug mode) |
 
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup, branching strategy, and code quality standards.
 
-## Authors
-
-- [Your Name] - [@github_username](https://github.com/[username])
-
-## Contact
-
-[Your email or preferred contact method]
-
-## Citation
-
-```bibtex
-@misc{foodatlas,
-  author = {[Your Name]},
-  title = {FoodAtlas},
-  year = {2026},
-  url = {https://github.com/AI-Institute-Food-Systems/foodatlas}
-}
-```
-
 ## License
 
 See [LICENSE](LICENSE) for details.
-
-## Acknowledgements
-
-- [Acknowledge contributors, funding, or inspirations]

--- a/backend/README.md
+++ b/backend/README.md
@@ -4,12 +4,12 @@ The backend is organized into four independent Python sub-projects, each with it
 
 ## Sub-projects
 
-| Directory | Description |
-|-----------|-------------|
-| [`api/`](api/) | API service |
-| [`db/`](db/) | Database layer |
-| [`ie/`](ie/) | Information extraction |
-| [`kgc/`](kgc/) | Knowledge graph construction |
+| Directory | Description | Status |
+|-----------|-------------|--------|
+| [`api/`](api/) | FastAPI REST service (port 8000) | Active |
+| [`db/`](db/) | PostgreSQL schema, migrations, and ETL | Active |
+| [`ie/`](ie/) | Information extraction | Stub |
+| [`kgc/`](kgc/) | Knowledge graph construction pipeline | Active |
 
 ## Getting Started
 
@@ -20,23 +20,11 @@ cd backend/<project>
 uv sync
 ```
 
+See the root [README](../README.md) for full local stack setup (Docker → DB → API → frontend).
+
 ## Running Tests
 
 ```bash
 cd backend/<project>
 uv run pytest
-```
-
-## Project Structure
-
-Each sub-project follows the same layout:
-
-```
-backend/<project>/
-├── pyproject.toml
-├── main.py
-├── src/<project>/
-│   └── __init__.py
-└── tests/
-    └── test_example.py
 ```

--- a/backend/api/README.md
+++ b/backend/api/README.md
@@ -1,35 +1,75 @@
 # FoodAtlas API
 
-API service for FoodAtlas.
+FastAPI REST service for the FoodAtlas knowledge graph.
 
 ## Getting Started
 
-### Install dependencies
+Requires a running PostgreSQL instance (see root README for Docker setup).
 
 ```bash
 uv sync
-```
-
-### Run the service
-
-```bash
 uv run python main.py
 ```
 
-### Run tests
+The server starts at `http://localhost:8000` with auto-reload enabled.
 
-```bash
-uv run pytest
-```
+## Configuration
+
+Settings are read from `API_*` and `DB_*` environment variables (or a `.env` file):
+
+| Variable | Default | Description |
+|---|---|---|
+| `API_KEY` | (empty) | Bearer token for authentication |
+| `API_CORS_ORIGINS` | `http://localhost:3000` | Comma-separated allowed origins |
+| `API_DEBUG` | `true` | Skip API key verification when true |
+| `DB_HOST` | `localhost` | PostgreSQL host |
+| `DB_PORT` | `5432` | PostgreSQL port |
+| `DB_NAME` | `foodatlas` | Database name |
+| `DB_USER` | `foodatlas` | Database user |
+| `DB_PASSWORD` | `foodatlas` | Database password |
+
+## API Endpoints
+
+| Method | Path | Description |
+|---|---|---|
+| GET | `/food/metadata` | Food entity metadata |
+| GET | `/food/profile` | Macro and micro nutrient profile |
+| GET | `/food/composition` | Food-chemical composition (paginated) |
+| GET | `/chemical/metadata` | Chemical entity metadata |
+| GET | `/chemical/composition` | Foods containing a chemical |
+| GET | `/disease/metadata` | Disease entity metadata |
+| GET | `/disease/correlation` | Chemical-disease correlations (paginated) |
+| GET | `/metadata/statistics` | Database statistics |
+| GET | `/metadata/search` | Autocomplete search |
+| GET | `/download` | Download entries |
 
 ## Project Structure
 
 ```
 api/
+├── main.py                 # Uvicorn entry point
 ├── pyproject.toml
-├── main.py
-├── src/api/
-│   └── __init__.py
+├── src/
+│   ├── app.py              # FastAPI application factory
+│   ├── config.py           # APISettings (pydantic-settings)
+│   ├── dependencies.py     # DB session and auth dependencies
+│   ├── routes/             # Route handlers
+│   │   ├── food.py
+│   │   ├── chemical.py
+│   │   ├── disease.py
+│   │   ├── metadata.py
+│   │   └── download.py
+│   ├── repositories/       # Database query logic
+│   │   ├── food.py
+│   │   ├── chemical.py
+│   │   ├── disease.py
+│   │   └── search.py
+│   └── schemas/            # Pydantic response models
 └── tests/
-    └── test_example.py
+```
+
+## Running Tests
+
+```bash
+uv run pytest
 ```

--- a/backend/db/README.md
+++ b/backend/db/README.md
@@ -1,35 +1,88 @@
 # FoodAtlas DB
 
-Database layer for FoodAtlas.
+PostgreSQL database layer: schema migrations, ORM models, and ETL pipeline for loading KGC output.
 
 ## Getting Started
 
-### Install dependencies
+Requires a running PostgreSQL instance (see root README for Docker setup).
 
 ```bash
 uv sync
+
+# Run migrations
+uv run alembic upgrade head
+
+# Load KGC parquet output into the database
+uv run python main.py load --parquet-dir /path/to/kgc/outputs
 ```
 
-### Run
+## Configuration
 
-```bash
-uv run python main.py
-```
+Settings are read from `DB_*` environment variables (or a `.env` file):
 
-### Run tests
+| Variable | Default | Description |
+|---|---|---|
+| `DB_HOST` | `localhost` | PostgreSQL host |
+| `DB_PORT` | `5432` | PostgreSQL port |
+| `DB_NAME` | `foodatlas` | Database name |
+| `DB_USER` | `foodatlas` | Database user |
+| `DB_PASSWORD` | `foodatlas` | Database password |
 
-```bash
-uv run pytest
-```
+## Schema
+
+The database has two layers:
+
+- **Base tables** — Normalized data loaded directly from KGC parquet files:
+  `base_entities`, `relationships`, `base_triplets`, `base_evidence`, `base_attestations`
+- **Materialized API tables** — Pre-joined, denormalized tables optimized for API queries:
+  `mv_food_entities`, `mv_chemical_entities`, `mv_disease_entities`,
+  `mv_food_chemical_composition`, `mv_chemical_disease_correlation`,
+  `mv_search_auto_complete`, `mv_metadata_statistics`
+
+Migrations are managed by Alembic (see `alembic.ini` and `migrations/`).
+
+## ETL Pipeline
+
+The `load` CLI command reads KGC parquet output and populates the database:
+
+1. **Load** base tables from parquet files (entities, relationships, triplets, evidence, attestations)
+2. **Materialize** API tables by joining and denormalizing base data
+3. **Build** search indexes (trigram-based autocomplete)
 
 ## Project Structure
 
 ```
 db/
+├── main.py                 # Click CLI entry point
 ├── pyproject.toml
-├── main.py
-├── src/db/
-│   └── __init__.py
+├── alembic.ini             # Alembic configuration
+├── migrations/
+│   ├── env.py              # Alembic environment
+│   └── versions/
+│       └── 001_initial_schema.py
+├── src/
+│   ├── config.py           # DBSettings (pydantic-settings)
+│   ├── engine.py           # SQLAlchemy engine factory
+│   ├── models/             # SQLAlchemy ORM models
+│   │   ├── base.py
+│   │   ├── entities.py
+│   │   ├── relationships.py
+│   │   ├── triplets.py
+│   │   ├── attestations.py
+│   │   ├── evidence.py
+│   │   └── views.py        # Materialized API table models
+│   └── etl/                # ETL pipeline
+│       ├── parquet_reader.py
+│       ├── bulk_insert.py
+│       ├── loader.py       # Orchestrates load
+│       ├── materializer.py
+│       ├── materializer_correlation.py
+│       └── materializer_search.py
 └── tests/
-    └── test_example.py
+```
+
+## Running Tests
+
+```bash
+uv run pytest
 ```

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -44,11 +44,14 @@ frontend/
 
 ## Environment Variables
 
-| Variable               | Description                        |
-|------------------------|------------------------------------|
-| `NEXT_PUBLIC_API_URL`  | Backend API base URL               |
-| `NEXT_PUBLIC_API_KEY`  | Backend API key                    |
-| `RESEND_API_KEY`       | Resend API key (contact form)      |
-| `EMAIL_FROM`           | Sender email address               |
-| `EMAIL_TO`             | Recipient email address(es)        |
-| `NEXTAUTH_SECRET`      | NextAuth.js secret                 |
+Create a `.env.local` file (or set env vars) before running:
+
+| Variable | Default | Description |
+|---|---|---|
+| `NEXT_PUBLIC_API_URL` | — | Backend API URL (`http://localhost:8000` for local dev) |
+| `NEXT_PUBLIC_API_KEY` | — | Backend API key (not needed when API runs in debug mode) |
+| `VALIDATION_PAGE_PASSWORD` | — | Password for the validation page (NextAuth) |
+| `NEXTAUTH_SECRET` | — | NextAuth.js secret |
+| `RESEND_API_KEY` | — | Resend API key (contact form) |
+| `EMAIL_FROM` | — | Sender email address |
+| `EMAIL_TO` | — | Recipient email address(es) |


### PR DESCRIPTION
## Summary

- Add step-by-step "Running Locally" section to root README covering the full stack: Docker (PostgreSQL) → DB migrations (Alembic) → data load (ETL) → API server (FastAPI) → frontend (Next.js)
- Update CLAUDE.md architecture section to reflect current state: FastAPI API, PostgreSQL + Alembic DB layer, Docker infrastructure, docs directory
- Rewrite backend/api/README.md with endpoints table, config, and project structure
- Rewrite backend/db/README.md with schema overview, ETL pipeline, and project structure
- Update backend/README.md with sub-project status (Active/Stub)
- Add local dev defaults and VALIDATION_PAGE_PASSWORD to frontend/README.md env vars table

## Files changed

- `README.md` — full local dev guide, updated repo tree, environment variables table
- `CLAUDE.md` — updated architecture, added local stack commands
- `backend/README.md` — added status column, link to root setup guide
- `backend/api/README.md` — full rewrite with FastAPI details
- `backend/db/README.md` — full rewrite with Alembic/ETL details
- `frontend/README.md` — expanded env vars with defaults and local dev hints