### PR TITLE
fix: ETL bulk insert escaping, KGC dedup, materializer perf, and API formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ cd frontend
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000). The frontend connects to the API at `http://localhost:8000` by default.
+Open [http://localhost:3000](http://localhost:3001). The frontend connects to the API at `http://localhost:8000` by default.
 
 ### Environment Variables
 

--- a/backend/api/src/repositories/chemical.py
+++ b/backend/api/src/repositories/chemical.py
@@ -3,6 +3,8 @@
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from .formatting import format_external_ids
+
 ROWS_PER_PAGE = 10
 
 
@@ -18,6 +20,8 @@ async def get_metadata(session: AsyncSession, common_name: str) -> dict[str, obj
         {"name": common_name},
     )
     data = [dict(row._mapping) for row in result]
+    for row in data:
+        row["external_ids"] = format_external_ids(row.get("external_ids"))
     return {"data": data, "metadata": {"row_count": len(data)}}
 
 

--- a/backend/api/src/repositories/disease.py
+++ b/backend/api/src/repositories/disease.py
@@ -3,6 +3,8 @@
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from .formatting import format_external_ids
+
 ROWS_PER_PAGE = 10
 
 
@@ -17,6 +19,8 @@ async def get_metadata(session: AsyncSession, common_name: str) -> dict[str, obj
         {"name": common_name},
     )
     data = [dict(row._mapping) for row in result]
+    for row in data:
+        row["external_ids"] = format_external_ids(row.get("external_ids"))
     return {"data": data, "metadata": {"row_count": len(data)}}
 
 

--- a/backend/api/src/repositories/food.py
+++ b/backend/api/src/repositories/food.py
@@ -3,6 +3,8 @@
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from .formatting import format_external_ids
+
 ROWS_PER_PAGE = 25
 
 NUTRIENT_KEY_MAP = {
@@ -39,6 +41,8 @@ async def get_metadata(session: AsyncSession, common_name: str) -> dict[str, obj
         {"name": common_name},
     )
     data = [dict(row._mapping) for row in result]
+    for row in data:
+        row["external_ids"] = format_external_ids(row.get("external_ids"))
     return {"data": data, "metadata": {"row_count": len(data)}}
 
 

--- a/backend/api/src/repositories/formatting.py
+++ b/backend/api/src/repositories/formatting.py
@@ -1,0 +1,45 @@
+"""Shared formatting utilities for API responses."""
+
+_SOURCE_CONFIG: dict[str, tuple[str, str]] = {
+    "foodon": ("FoodOn", ""),
+    "chebi": ("ChEBI", "https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:{}"),
+    "fdc": ("FDC", "https://fdc.nal.usda.gov/fdc-app.html#/food-details/{}"),
+    "fdc_nutrient": (
+        "FDC Nutrient",
+        "https://fdc.nal.usda.gov/fdc-app.html#/food-details/{}",
+    ),
+    "cdno": ("CDNO", ""),
+    "ctd": ("CTD", "https://ctdbase.org/detail.go?type=disease&acc={}"),
+    "dmd": ("DMD", ""),
+    "pubchem_compound": (
+        "PubChem",
+        "https://pubchem.ncbi.nlm.nih.gov/compound/{}",
+    ),
+    "mesh": ("MeSH", "https://meshb.nlm.nih.gov/record/ui?ui={}"),
+}
+
+
+def _make_url(raw_id: str | int, template: str) -> str:
+    """Build a URL from an ID and template, or return empty string."""
+    sid = str(raw_id)
+    if not template:
+        return sid if sid.startswith("http") else ""
+    return template.format(sid)
+
+
+def format_external_ids(raw: dict | None) -> dict[str, object]:
+    """Transform raw external_ids into the frontend-expected structure.
+
+    Input:  {"foodon": ["http://..."], "chebi": [4775]}
+    Output: {"foodon": {"display_name": "FoodOn", "ids": [{"id": "...", "url": "..."}]}}
+    """
+    if not raw or not isinstance(raw, dict):
+        return {}
+    result: dict[str, object] = {}
+    for key, id_list in raw.items():
+        if not isinstance(id_list, list):
+            continue
+        display_name, url_template = _SOURCE_CONFIG.get(key, (key.upper(), ""))
+        ids = [{"id": str(rid), "url": _make_url(rid, url_template)} for rid in id_list]
+        result[key] = {"display_name": display_name, "ids": ids}
+    return result

--- a/backend/db/main.py
+++ b/backend/db/main.py
@@ -30,7 +30,7 @@ def load(parquet_dir: Path) -> None:
     """Load KGC parquet output into PostgreSQL."""
     settings = DBSettings()
     engine = create_sync_engine(settings)
-    with engine.begin() as conn:
+    with engine.connect() as conn:
         load_kg(conn, parquet_dir)
     click.echo("Done.")
 

--- a/backend/db/src/etl/bulk_insert.py
+++ b/backend/db/src/etl/bulk_insert.py
@@ -12,15 +12,54 @@ from sqlalchemy.engine import Connection
 logger = logging.getLogger(__name__)
 
 
+def _pg_array_literal(vals: list) -> str:
+    """Convert a Python list to a PostgreSQL array literal for COPY text format.
+
+    Two escaping levels are applied:
+    1. Array element: ``\\`` and ``\\"`` inside quoted elements.
+    2. COPY text: backslashes doubled again so the COPY parser restores level-1.
+    """
+    parts: list[str] = []
+    for v in vals:
+        if v is None:
+            parts.append("NULL")
+            continue
+        s = str(v)
+        # Level 1 -array quoted-element escaping
+        s = s.replace("\\", "\\\\").replace('"', '\\"')
+        parts.append('"' + s + '"')
+    literal = "{" + ",".join(parts) + "}"
+    # Level 2 -COPY text escaping (backslash is special in COPY text format)
+    literal = (
+        literal.replace("\\", "\\\\")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+    return literal
+
+
+def _copy_text_escape(s: str) -> str:
+    """Escape a string for PostgreSQL COPY text format."""
+    return (
+        s.replace("\\", "\\\\")
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+        .replace("\t", "\\t")
+    )
+
+
 def _serialize_value(val: object) -> str:
     """Serialize a Python value for PostgreSQL COPY format."""
     if val is None or (isinstance(val, float) and pd.isna(val)):
         return r"\N"
     if isinstance(val, bool | np.bool_):
         return "t" if val else "f"
-    if isinstance(val, (list, dict)):
-        return json.dumps(val)
-    return str(val)
+    if isinstance(val, list):
+        return _pg_array_literal(val)
+    if isinstance(val, dict):
+        return _copy_text_escape(json.dumps(val))
+    return _copy_text_escape(str(val))
 
 
 def _df_to_copy_buffer(df: pd.DataFrame, columns: list[str]) -> io.StringIO:

--- a/backend/db/src/etl/materializer.py
+++ b/backend/db/src/etl/materializer.py
@@ -25,8 +25,11 @@ MV_TABLES = [
 def refresh_all(conn: Connection) -> None:
     """Truncate and re-populate all materialized API tables."""
     truncate_tables(conn, MV_TABLES)
+    logger.info("Building entity views...")
     _materialize_entity_views(conn)
+    logger.info("Building food-chemical composition...")
     _materialize_food_chemical_composition(conn)
+    logger.info("Building chemical-disease correlation...")
     materialize_chemical_disease_correlation(conn)
     conn.commit()
 
@@ -41,14 +44,22 @@ def _materialize_entity_views(conn: Connection) -> None:
     r3r4 = triplets[triplets["relationship_id"].isin(["r3", "r4"])]
 
     entity_map = entities.set_index("foodatlas_id")
+    name_map = entity_map["common_name"].to_dict()
+
+    # Pre-build classification lookups (O(r2) once, O(1) per entity)
+    foodon_cls = _build_classification_map(r2, name_map, "foodon")
+    chebi_cls = _build_classification_map(r2, name_map, "chebi")
+    cdno_cls = _build_classification_map(r2, name_map, "cdno")
 
     # Food entities: foods that appear as head in r1 triplets
     food_ids = set(r1["head_id"])
     foods = entities[
         (entities["entity_type"] == "food") & (entities["foodatlas_id"].isin(food_ids))
     ].copy()
-    foods["food_classification"] = foods["foodatlas_id"].apply(
-        lambda fid: _get_classifications(fid, r2, entity_map, "foodon")
+    foods["food_classification"] = (
+        foods["foodatlas_id"]
+        .map(foodon_cls)
+        .apply(lambda x: x if isinstance(x, list) else [])
     )
     _insert_mv_entities(conn, "mv_food_entities", foods, ["food_classification"])
 
@@ -58,11 +69,15 @@ def _materialize_entity_views(conn: Connection) -> None:
         (entities["entity_type"] == "chemical")
         & (entities["foodatlas_id"].isin(chem_ids))
     ].copy()
-    chemicals["chemical_classification"] = chemicals["foodatlas_id"].apply(
-        lambda fid: _get_classifications(fid, r2, entity_map, "chebi")
+    chemicals["chemical_classification"] = (
+        chemicals["foodatlas_id"]
+        .map(chebi_cls)
+        .apply(lambda x: x if isinstance(x, list) else [])
     )
-    chemicals["nutrient_classification"] = chemicals["foodatlas_id"].apply(
-        lambda fid: _get_classifications(fid, r2, entity_map, "cdno")
+    chemicals["nutrient_classification"] = (
+        chemicals["foodatlas_id"]
+        .map(cdno_cls)
+        .apply(lambda x: x if isinstance(x, list) else [])
     )
     _insert_mv_entities(
         conn,
@@ -89,22 +104,20 @@ def _materialize_entity_views(conn: Connection) -> None:
     )
 
 
-def _get_classifications(
-    entity_id: str,
+def _build_classification_map(
     r2_triplets: pd.DataFrame,
-    entity_map: pd.DataFrame,
+    name_map: dict[str, str],
     source_prefix: str,
-) -> list[str]:
-    """Get classification labels from IS_A triplets by source prefix."""
-    matches = r2_triplets[
-        (r2_triplets["head_id"] == entity_id)
-        & (r2_triplets["source"].str.contains(source_prefix, case=False, na=False))
+) -> dict[str, list[str]]:
+    """Pre-build {entity_id: [classification names]} from IS_A triplets."""
+    filtered = r2_triplets[
+        r2_triplets["source"].str.contains(source_prefix, case=False, na=False)
     ]
-    return [
-        entity_map.loc[tid, "common_name"]
-        for tid in matches["tail_id"]
-        if tid in entity_map.index
-    ]
+    result: dict[str, list[str]] = {}
+    for head_id, group in filtered.groupby("head_id"):
+        names = [name_map[tid] for tid in group["tail_id"] if tid in name_map]
+        result[str(head_id)] = names
+    return result
 
 
 def _insert_mv_entities(
@@ -230,6 +243,8 @@ def _group_evidences(
         source = att["source"]
 
         conc_val = att["conc_value"]
+        if pd.isna(conc_val):
+            conc_val = None
         if conc_val is not None and float(conc_val) == 0:
             continue
 

--- a/backend/db/src/etl/materializer_search.py
+++ b/backend/db/src/etl/materializer_search.py
@@ -14,7 +14,9 @@ logger = logging.getLogger(__name__)
 def refresh_search(conn: Connection) -> None:
     """Truncate and re-populate search + statistics tables."""
     truncate_tables(conn, ["mv_search_auto_complete", "mv_metadata_statistics"])
+    logger.info("Building search autocomplete...")
     _materialize_search_auto_complete(conn)
+    logger.info("Building metadata statistics...")
     _materialize_statistics(conn)
     conn.commit()
 
@@ -30,35 +32,38 @@ def _materialize_search_auto_complete(conn: Connection) -> None:
     r1 = triplets[triplets["relationship_id"] == "r1"]
     r3r4 = triplets[triplets["relationship_id"].isin(["r3", "r4"])]
 
-    # Count associations per entity
+    # Vectorized association counts
+    assoc_counts = (
+        pd.concat([triplets["head_id"], triplets["tail_id"]]).value_counts().to_dict()
+    )
+
+    # Pre-compute relevant entity ID sets
+    food_ids = set(r1["head_id"])
     food_chem_ids = set(r1["tail_id"])
-    assoc_counts: dict[str, int] = {}
-    for _, row in triplets.iterrows():
-        for eid in (row["head_id"], row["tail_id"]):
-            assoc_counts[eid] = assoc_counts.get(eid, 0) + 1
+    disease_chem_ids = set(r3r4["head_id"]) & food_chem_ids
+    relevant_disease_ids = set(r3r4[r3r4["head_id"].isin(disease_chem_ids)]["tail_id"])
+
+    # Filter entities to only those participating in relevant triplets
+    relevant = entities[
+        ((entities["entity_type"] == "food") & entities["foodatlas_id"].isin(food_ids))
+        | (
+            (entities["entity_type"] == "chemical")
+            & entities["foodatlas_id"].isin(food_chem_ids)
+        )
+        | (
+            (entities["entity_type"] == "disease")
+            & entities["foodatlas_id"].isin(relevant_disease_ids)
+        )
+    ]
 
     rows = []
-    for _, entity in entities.iterrows():
+    for _, entity in relevant.iterrows():
         fid = entity["foodatlas_id"]
         etype = entity["entity_type"]
-
-        # Only include entities that participate in relevant triplets
-        if etype == "food" and fid not in set(r1["head_id"]):
-            continue
-        if etype == "chemical" and fid not in food_chem_ids:
-            continue
-        if etype == "disease":
-            # Only diseases whose correlated chemicals are in food composition
-            disease_triplets = r3r4[r3r4["tail_id"] == fid]
-            chem_in_food = disease_triplets["head_id"].isin(food_chem_ids)
-            if not chem_in_food.any():
-                continue
-
         synonyms = entity["synonyms"] if isinstance(entity["synonyms"], list) else []
         raw_ids = entity["external_ids"]
         ext_ids = raw_ids if isinstance(raw_ids, dict) else {}
 
-        # Build search tokens
         ext_id_values = _extract_external_id_values(ext_ids, etype)
         exact_auto = _build_exact_tokens(
             etype,

--- a/backend/db/tests/test_bulk_insert.py
+++ b/backend/db/tests/test_bulk_insert.py
@@ -19,15 +19,29 @@ class TestSerializeValue:
         # pd.isna handles numpy NaN too
         assert _serialize_value(math.nan) == r"\N"
 
-    def test_list_returns_json(self):
-        assert _serialize_value(["a", "b"]) == '["a", "b"]'
+    def test_list_returns_pg_array(self):
+        assert _serialize_value(["a", "b"]) == '{"a","b"}'
 
-    def test_empty_list_returns_json(self):
-        assert _serialize_value([]) == "[]"
+    def test_empty_list_returns_pg_array(self):
+        assert _serialize_value([]) == "{}"
+
+    def test_list_with_special_chars_quotes_elements(self):
+        assert _serialize_value(["a,b", 'c"d']) == '{"a,b","c\\\\"d"}'
+
+    def test_list_with_backslash(self):
+        assert _serialize_value(["a\\b"]) == '{"a\\\\\\\\b"}'
+
+    def test_list_with_newline(self):
+        assert _serialize_value(["a\nb"]) == '{"a\\nb"}'
 
     def test_dict_returns_json(self):
         result = _serialize_value({"key": "val"})
         assert result == '{"key": "val"}'
+
+    def test_dict_with_backslash_escapes_for_copy(self):
+        result = _serialize_value({"text": "a\\b"})
+        # json.dumps produces \\, COPY escaping doubles to \\\\
+        assert result == '{"text": "a\\\\\\\\b"}'
 
     def test_empty_dict_returns_json(self):
         assert _serialize_value({}) == "{}"
@@ -46,6 +60,12 @@ class TestSerializeValue:
 
     def test_string_passthrough(self):
         assert _serialize_value("hello") == "hello"
+
+    def test_string_with_backslash(self):
+        assert _serialize_value("a\\b") == "a\\\\b"
+
+    def test_string_with_newline(self):
+        assert _serialize_value("a\nb") == "a\\nb"
 
     def test_empty_string(self):
         assert _serialize_value("") == ""
@@ -97,7 +117,7 @@ class TestDfToCopyBuffer:
         content = buf.read()
         assert r"\N" in content
 
-    def test_list_column_serialized_as_json(self):
+    def test_list_column_serialized_as_pg_array(self):
         df = pd.DataFrame(
             {
                 "tags": [["a", "b"]],
@@ -105,7 +125,7 @@ class TestDfToCopyBuffer:
         )
         buf = _df_to_copy_buffer(df, ["tags"])
         content = buf.read()
-        assert '["a", "b"]' in content
+        assert '{"a","b"}' in content
 
     def test_bool_column(self):
         df = pd.DataFrame(
@@ -146,6 +166,6 @@ class TestDfToCopyBuffer:
         parts = content.split("\t")
         assert parts[0] == "f001"
         assert parts[1] == "0.95"
-        assert parts[2] == '["x"]'
+        assert parts[2] == '{"x"}'
         assert parts[3] == '{"k": "v"}'
         assert parts[4] == "t"

--- a/backend/db/tests/test_materializer.py
+++ b/backend/db/tests/test_materializer.py
@@ -3,10 +3,10 @@
 import pandas as pd
 from src.etl.materializer import (
     _add_foodatlas_evidence,
+    _build_classification_map,
     _build_composition_row,
     _build_db_evidence,
     _compute_median_concentration,
-    _get_classifications,
     _group_evidences,
 )
 
@@ -173,8 +173,8 @@ class TestAddFoodatlasEvidence:
         assert evidences[0]["reference"]["url"] == ""
 
 
-class TestGetClassifications:
-    """Test _get_classifications with mock DataFrames."""
+class TestBuildClassificationMap:
+    """Test _build_classification_map with mock DataFrames."""
 
     def test_finds_matching_classifications(self):
         r2 = pd.DataFrame(
@@ -184,16 +184,9 @@ class TestGetClassifications:
                 {"head_id": "c002", "tail_id": "class3", "source": "chebi_ontology"},
             ]
         )
-        entity_map = pd.DataFrame(
-            {
-                "common_name": ["ClassA", "ClassB", "ClassC"],
-            },
-            index=["class1", "class2", "class3"],
-        )
-        entity_map.index.name = "foodatlas_id"
-
-        result = _get_classifications("c001", r2, entity_map, "chebi")
-        assert result == ["ClassA", "ClassB"]
+        name_map = {"class1": "ClassA", "class2": "ClassB", "class3": "ClassC"}
+        result = _build_classification_map(r2, name_map, "chebi")
+        assert result["c001"] == ["ClassA", "ClassB"]
 
     def test_no_matching_source(self):
         r2 = pd.DataFrame(
@@ -201,25 +194,24 @@ class TestGetClassifications:
                 {"head_id": "c001", "tail_id": "class1", "source": "foodon_ontology"},
             ]
         )
-        entity_map = pd.DataFrame({"common_name": ["X"]}, index=["class1"])
-        result = _get_classifications("c001", r2, entity_map, "chebi")
-        assert result == []
+        name_map = {"class1": "X"}
+        result = _build_classification_map(r2, name_map, "chebi")
+        assert "c001" not in result
 
     def test_empty_r2(self):
         r2 = pd.DataFrame(columns=["head_id", "tail_id", "source"])
-        entity_map = pd.DataFrame(columns=["common_name"])
-        result = _get_classifications("c001", r2, entity_map, "chebi")
-        assert result == []
+        result = _build_classification_map(r2, {}, "chebi")
+        assert result == {}
 
-    def test_missing_tail_in_entity_map(self):
+    def test_missing_tail_in_name_map(self):
         r2 = pd.DataFrame(
             [
                 {"head_id": "c001", "tail_id": "missing", "source": "chebi_x"},
             ]
         )
-        entity_map = pd.DataFrame({"common_name": ["A"]}, index=["other"])
-        result = _get_classifications("c001", r2, entity_map, "chebi")
-        assert result == []
+        name_map = {"other": "A"}
+        result = _build_classification_map(r2, name_map, "chebi")
+        assert result.get("c001") == []
 
 
 class TestGroupEvidences:

--- a/backend/db/tests/test_materializer_helpers.py
+++ b/backend/db/tests/test_materializer_helpers.py
@@ -3,15 +3,15 @@
 import pandas as pd
 from src.etl.materializer import (
     _add_foodatlas_evidence,
+    _build_classification_map,
     _build_composition_row,
     _build_db_evidence,
     _compute_median_concentration,
-    _get_classifications,
     _group_evidences,
 )
 
 
-class TestGetClassifications:
+class TestBuildClassificationMap:
     def test_returns_matching_labels(self):
         r2 = pd.DataFrame(
             {
@@ -20,14 +20,9 @@ class TestGetClassifications:
                 "source": ["foodon", "foodon", "chebi"],
             }
         )
-        entity_map = pd.DataFrame(
-            {
-                "common_name": ["fruit", "vegetable", "organic"],
-            },
-            index=["e10", "e11", "e12"],
-        )
-        result = _get_classifications("e1", r2, entity_map, "foodon")
-        assert result == ["fruit", "vegetable"]
+        name_map = {"e10": "fruit", "e11": "vegetable", "e12": "organic"}
+        result = _build_classification_map(r2, name_map, "foodon")
+        assert result["e1"] == ["fruit", "vegetable"]
 
     def test_returns_empty_for_no_match(self):
         r2 = pd.DataFrame(
@@ -37,9 +32,9 @@ class TestGetClassifications:
                 "source": ["chebi"],
             }
         )
-        entity_map = pd.DataFrame({"common_name": ["x"]}, index=["e10"])
-        result = _get_classifications("e1", r2, entity_map, "foodon")
-        assert result == []
+        name_map = {"e10": "x"}
+        result = _build_classification_map(r2, name_map, "foodon")
+        assert "e1" not in result
 
     def test_skips_missing_tail_ids(self):
         r2 = pd.DataFrame(
@@ -49,9 +44,9 @@ class TestGetClassifications:
                 "source": ["foodon"],
             }
         )
-        entity_map = pd.DataFrame({"common_name": ["x"]}, index=["e10"])
-        result = _get_classifications("e1", r2, entity_map, "foodon")
-        assert result == []
+        name_map = {"e10": "x"}
+        result = _build_classification_map(r2, name_map, "foodon")
+        assert result.get("e1") == []
 
 
 class TestComputeMedianConcentration:

--- a/backend/kgc/README.md
+++ b/backend/kgc/README.md
@@ -49,7 +49,6 @@ Settings use Pydantic with env prefix `KGC_` (e.g. `KGC_DATA_DIR`). Key fields:
 | `data_dir` | `data` | Raw data source directory |
 | `output_dir` | `outputs` | General output directory |
 | `cache_dir` | `outputs/cache` | Cache directory |
-| `ncbi_email` | — | Required for NCBI Taxonomy queries |
 | `pubchem_mapping_file` | — | PubChem synonym mapping |
 
 Override via environment variables, config JSON, or CLI flags.

--- a/backend/kgc/src/models/settings.py
+++ b/backend/kgc/src/models/settings.py
@@ -1,6 +1,5 @@
 """KGC settings with Pydantic Settings, env prefix KGC_."""
 
-import os
 from pathlib import Path
 from typing import Any
 
@@ -67,9 +66,6 @@ class KGCSettings(BaseSettings):
     pubchem_mapping_file: str = ""
     pipeline: PipelineConfig = PipelineConfig()
 
-    ncbi_email: str = ""
-    ncbi_api_key: str = ""
-
     @property
     def data_cleaning_dir(self) -> str:
         return self.pipeline.stages.data_cleaning.output_dir
@@ -91,8 +87,4 @@ class KGCSettings(BaseSettings):
         for key, default_value in defaults.items():
             if key not in values or values[key] in ("", None):
                 values[key] = default_value
-        _env_fields = [("NCBI_EMAIL", "ncbi_email"), ("NCBI_API_KEY", "ncbi_api_key")]
-        for env_key, field in _env_fields:
-            if field not in values or values[field] in ("", None):
-                values[field] = os.environ.get(env_key, "")
         return values

--- a/backend/kgc/src/pipeline/entities/resolve_primary.py
+++ b/backend/kgc/src/pipeline/entities/resolve_primary.py
@@ -86,12 +86,16 @@ def create_foods_from_foodon(
         nodes = nodes[nodes["is_food"]]
 
     rows: list[dict] = []
+    seen_ids: set[str] = set()
     for _, row in nodes.iterrows():
         native = str(row["native_id"])
         fa_id = registry.resolve("foodon", native)
         if not fa_id:
             fa_id = f"e{registry.next_eid}"
             registry.register("foodon", native, fa_id)
+        if fa_id in store._entities.index or fa_id in seen_ids:
+            continue
+        seen_ids.add(fa_id)
 
         syns = _get_list(row, "synonyms")
         syn_types = _get_list(row, "synonym_types")
@@ -126,12 +130,16 @@ def create_chemicals_from_chebi(
     drop_names = set(corrections.chebi_lut.drop_names)
 
     rows: list[dict] = []
+    seen_ids: set[str] = set()
     for _, row in nodes.iterrows():
         native = str(int(row["native_id"]))
         fa_id = registry.resolve("chebi", native)
         if not fa_id:
             fa_id = f"e{registry.next_eid}"
             registry.register("chebi", native, fa_id)
+        if fa_id in store._entities.index or fa_id in seen_ids:
+            continue
+        seen_ids.add(fa_id)
 
         syns = _get_list(row, "synonyms")
         syn_types = _get_list(row, "synonym_types")
@@ -169,12 +177,16 @@ def create_diseases_from_ctd(
     nodes = ctd["nodes"]
 
     rows: list[dict] = []
+    seen_ids: set[str] = set()
     for _, row in nodes.iterrows():
         native = str(row["native_id"])
         fa_id = registry.resolve("ctd", native)
         if not fa_id:
             fa_id = f"e{registry.next_eid}"
             registry.register("ctd", native, fa_id)
+        if fa_id in store._entities.index or fa_id in seen_ids:
+            continue
+        seen_ids.add(fa_id)
 
         syns = _get_list(row, "synonyms")
         name = row["name"] if row["name"] else (syns[0] if syns else "")

--- a/backend/kgc/src/pipeline/entities/resolve_secondary.py
+++ b/backend/kgc/src/pipeline/entities/resolve_secondary.py
@@ -203,25 +203,38 @@ def create_unlinked_cdno(
     linked_ids = _build_external_index(store, "cdno")
 
     unlinked = nodes[~nodes["native_id"].isin(linked_ids)]
-    rows: list[dict] = []
+    rows_by_id: dict[str, dict] = {}
     for _, row in unlinked.iterrows():
         native = str(row["native_id"])
         fa_id = registry.resolve("cdno", native)
         if not fa_id:
             fa_id = f"e{registry.next_eid}"
             registry.register("cdno", native, fa_id)
+
+        if fa_id in store._entities.index:
+            ext = store._entities.at[fa_id, "external_ids"]
+            ext.setdefault("cdno", [])
+            if native not in ext["cdno"]:
+                ext["cdno"].append(native)
+            continue
+        if fa_id in rows_by_id:
+            ext = rows_by_id[fa_id]["external_ids"]
+            if native not in ext.get("cdno", []):
+                ext.setdefault("cdno", []).append(native)
+            continue
+
         entity = ChemicalEntity(
             foodatlas_id=fa_id,
             common_name=row["name"],
             synonyms=[row["name"]] if row["name"] else [],
             external_ids={"cdno": [row["native_id"]]},
         )
-        rows.append(entity.model_dump(by_alias=True))
+        rows_by_id[fa_id] = entity.model_dump(by_alias=True)
         if entity.common_name:
             lut.add("chemical", entity.common_name, entity.foodatlas_id)
     store._curr_eid = registry.next_eid
-    _append_entities(store, rows)
-    logger.info("Pass 3: %d unlinked CDNO entities.", len(rows))
+    _append_entities(store, list(rows_by_id.values()))
+    logger.info("Pass 3: %d unlinked CDNO entities.", len(rows_by_id))
 
 
 def create_unlinked_fdc_foods(
@@ -238,7 +251,7 @@ def create_unlinked_fdc_foods(
     nodes = fdc["nodes"]
     foods = nodes[nodes["node_type"] == "food"]
     unlinked = foods[~foods["native_id"].isin(linked_ids)]
-    rows: list[dict] = []
+    rows_by_id: dict[str, dict] = {}
     for _, row in unlinked.iterrows():
         fdc_id = int(row["native_id"].split(":")[-1])
         native = str(fdc_id)
@@ -246,18 +259,31 @@ def create_unlinked_fdc_foods(
         if not fa_id:
             fa_id = f"e{registry.next_eid}"
             registry.register("fdc", native, fa_id)
+
+        if fa_id in store._entities.index:
+            ext = store._entities.at[fa_id, "external_ids"]
+            ext.setdefault("fdc", [])
+            if fdc_id not in ext["fdc"]:
+                ext["fdc"].append(fdc_id)
+            continue
+        if fa_id in rows_by_id:
+            ext = rows_by_id[fa_id]["external_ids"]
+            if fdc_id not in ext.get("fdc", []):
+                ext.setdefault("fdc", []).append(fdc_id)
+            continue
+
         entity = FoodEntity(
             foodatlas_id=fa_id,
             common_name=row["name"],
             synonyms=[row["name"]] if row["name"] else [],
             external_ids={"fdc": [fdc_id]},
         )
-        rows.append(entity.model_dump(by_alias=True))
+        rows_by_id[fa_id] = entity.model_dump(by_alias=True)
         if entity.common_name:
             lut.add("food", entity.common_name, entity.foodatlas_id)
     store._curr_eid = registry.next_eid
-    _append_entities(store, rows)
-    logger.info("Pass 3: %d unlinked FDC food entities.", len(rows))
+    _append_entities(store, list(rows_by_id.values()))
+    logger.info("Pass 3: %d unlinked FDC food entities.", len(rows_by_id))
 
 
 def create_unlinked_fdc_nutrients(
@@ -274,7 +300,7 @@ def create_unlinked_fdc_nutrients(
     nodes = fdc["nodes"]
     nutrients = nodes[nodes["node_type"] == "nutrient"]
     unlinked = nutrients[~nutrients["native_id"].isin(linked_ids)]
-    rows: list[dict] = []
+    rows_by_id: dict[str, dict] = {}
     for _, row in unlinked.iterrows():
         nutrient_id = int(row["native_id"].split(":")[-1])
         native = str(nutrient_id)
@@ -282,15 +308,28 @@ def create_unlinked_fdc_nutrients(
         if not fa_id:
             fa_id = f"e{registry.next_eid}"
             registry.register("fdc_nutrient", native, fa_id)
+
+        if fa_id in store._entities.index:
+            ext = store._entities.at[fa_id, "external_ids"]
+            ext.setdefault("fdc_nutrient", [])
+            if nutrient_id not in ext["fdc_nutrient"]:
+                ext["fdc_nutrient"].append(nutrient_id)
+            continue
+        if fa_id in rows_by_id:
+            ext = rows_by_id[fa_id]["external_ids"]
+            if nutrient_id not in ext.get("fdc_nutrient", []):
+                ext.setdefault("fdc_nutrient", []).append(nutrient_id)
+            continue
+
         entity = ChemicalEntity(
             foodatlas_id=fa_id,
             common_name=row["name"],
             synonyms=[row["name"]] if row["name"] else [],
             external_ids={"fdc_nutrient": [nutrient_id]},
         )
-        rows.append(entity.model_dump(by_alias=True))
+        rows_by_id[fa_id] = entity.model_dump(by_alias=True)
         if entity.common_name:
             lut.add("chemical", entity.common_name, entity.foodatlas_id)
     store._curr_eid = registry.next_eid
-    _append_entities(store, rows)
-    logger.info("Pass 3: %d unlinked FDC nutrient entities.", len(rows))
+    _append_entities(store, list(rows_by_id.values()))
+    logger.info("Pass 3: %d unlinked FDC nutrient entities.", len(rows_by_id))

--- a/backend/kgc/src/stores/triplet_store.py
+++ b/backend/kgc/src/stores/triplet_store.py
@@ -50,6 +50,9 @@ class TripletStore:
                 axis=1,
             )
             self._triplets = self._triplets.set_index(_KEY_COL)
+            self._triplets = self._triplets[
+                ~self._triplets.index.duplicated(keep="last")
+            ]
         else:
             self._triplets = pd.DataFrame()
 
@@ -78,6 +81,8 @@ class TripletStore:
             axis=1,
         )
         triplets = triplets.set_index(_KEY_COL)
+        triplets = triplets[~triplets.index.duplicated(keep="first")]
+        triplets = triplets[~triplets.index.isin(self._triplets.index)]
         for key in triplets.index:
             self._key_to_attestations[key] = []
         self._triplets = pd.concat([self._triplets, triplets])
@@ -131,10 +136,11 @@ class TripletStore:
             new_df[_KEY_COL] = keys[new_mask].values
             new_df["attestation_ids"] = [[] for _ in range(len(new_df))]
             new_df = new_df.set_index(_KEY_COL)
+            new_df = new_df[~new_df.index.duplicated(keep="first")]
             self._triplets = pd.concat([self._triplets, new_df])
 
             for key, meta_id in zip(keys[new_mask], meta_ids[new_mask], strict=False):
-                self._key_to_attestations[key] = [meta_id]
+                self._key_to_attestations.setdefault(key, []).append(meta_id)
 
         return metadata
 

--- a/backend/kgc/tests/test_settings.py
+++ b/backend/kgc/tests/test_settings.py
@@ -36,10 +36,3 @@ class TestKGCSettings:
         monkeypatch.delenv("KGC_OPENAI_API_KEY", raising=False)
         settings = KGCSettings()
         assert settings.openai_api_key == ""
-
-    def test_ncbi_from_dotenv(self, monkeypatch):
-        monkeypatch.setenv("NCBI_EMAIL", "test@example.com")
-        monkeypatch.setenv("NCBI_API_KEY", "abc123")
-        settings = KGCSettings()
-        assert settings.ncbi_email == "test@example.com"
-        assert settings.ncbi_api_key == "abc123"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "version": "2.0.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --port 3001",
     "build": "next build",
     "start": "next start",
     "lint": "next lint && tsc --noEmit",


### PR DESCRIPTION
## Summary

- **COPY text escaping**: Fix PostgreSQL COPY text format for arrays (JSON `[]` → PG `{}`), JSONB, and string fields by applying two-level escaping (type-level + COPY-level backslash doubling)
- **Entity deduplication**: Add `seen_ids` guard in KGC Pass 1 entity creation; enrich-or-create logic in Pass 3 to merge `external_ids` into existing entities instead of creating duplicates
- **Triplet deduplication**: Deduplicate on load, deduplicate intra-batch in `_insert_or_merge`, fix attestation accumulation to use `setdefault`+`append` instead of overwrite
- **Materializer performance**: Replace O(n×m) per-entity classification scan with O(m+n) pre-built lookup dict; vectorize search autocomplete association counts and entity filtering — reduces materialization from ~10 min to seconds
- **NaN fix**: Convert pandas `NaN` to `None` before JSON serialization in composition materializer
- **Transaction fix**: Use `engine.connect()` instead of `engine.begin()` since `load_kg` manages its own commits
- **API external_ids formatting**: Add `format_external_ids()` to transform raw DB format (`{"chebi": [4775]}`) into frontend-expected structure (`{display_name, ids: [{id, url}]}`)
- **Cleanup**: Remove unused NCBI email/API key config; use port 3001 for frontend dev server

## Test plan

- [x] `backend/kgc`: 409 tests pass, 83% coverage
- [x] `backend/db`: 210 tests pass, 80% coverage
- [x] `backend/api`: 57 tests pass, 94% coverage
- [x] Full ETL load completes: 222,925 entities, 527,266 triplets, 297,975 evidence, 749,915 attestations + all materialized views
- [ ] Frontend entity pages render external IDs correctly