### PR TITLE
docs: update CLAUDE.md and README with port, SSH tunnel, and ETL notes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,7 @@ Each backend sub-project follows the same layout: `src/` is the module, `tests/`
 
 ### Local stack
 
-PostgreSQL 16 (Docker) → DB migrations (Alembic) → Data load (ETL) → FastAPI (port 8000) → Next.js (port 3000)
+PostgreSQL 16 (Docker) → DB migrations (Alembic) → Data load (ETL) → FastAPI (port 8000) → Next.js (port 3001)
 
 ### Configuration split
 
@@ -43,12 +43,12 @@ docker compose -f infra/docker-compose.yml up -d
 cd backend/db && uv run alembic upgrade head
 
 # Load KGC data into PostgreSQL
-cd backend/db && uv run python main.py load --parquet-dir /path/to/kgc/outputs
+cd backend/db && uv run python main.py load --parquet-dir ../kgc/outputs/kg
 
 # Start API server (port 8000)
 cd backend/api && uv run python main.py
 
-# Start frontend (port 3000)
+# Start frontend (port 3001)
 cd frontend && npm run dev
 ```
 
@@ -115,3 +115,9 @@ Pre-commit hooks run automatically — do not run linters manually unless debugg
 2. **No lazy bypasses**: Do not use `# noqa`, `# type: ignore` to bypass errors. Fix the underlying issue.
 3. **No cheating on test coverage**: Do not lower `--cov-fail-under` threshold or add files to `[tool.coverage.run] omit`. Write proper tests instead.
 4. **Rely on pre-commit hooks**: Only run checks manually when debugging.
+
+## ETL Notes
+
+- **COPY text escaping**: PostgreSQL COPY text format applies backslash unescaping before type parsing. Array (`TEXT[]`) and JSONB fields need two-level escaping: type-level first, then COPY-level (doubling backslashes, escaping `\n`/`\t`/`\r`).
+- **Entity dedup**: The entity registry can map multiple `(source, native_id)` pairs to the same `foodatlas_id` via merges/aliases. Entity creation functions must check `store._entities.index` before appending.
+- **Triplet dedup**: `_insert_or_merge` computes `existing_mask` once — intra-batch duplicate keys all pass as "new". The `new_df` must be deduplicated before concat, and attestation accumulation must use `setdefault`+`append` (not overwrite).

--- a/README.md
+++ b/README.md
@@ -82,11 +82,21 @@ cd frontend
 npm run dev
 ```
 
-Open [http://localhost:3000](http://localhost:3001). The frontend connects to the API at `http://localhost:8000` by default.
+The frontend runs at `http://localhost:3001`. It connects to the API at `http://localhost:8000` (configured via `NEXT_PUBLIC_API_URL` in `frontend/.env.local`).
+
+### 7. Remote access (SSH tunnel)
+
+If running on a remote server, forward both ports from your local machine:
+
+```bash
+ssh -L 3001:localhost:3001 -L 8000:localhost:8000 user@your-server
+```
+
+Then open `http://localhost:3001` in your local browser. Both the frontend (3001) and API calls (8000) are tunneled.
 
 ### Environment Variables
 
-All services work with defaults for local development. Override via `.env` files or environment variables:
+Each sub-project reads its own `.env` file (`backend/api/.env`, `frontend/.env.local`). Override via environment variables:
 
 | Variable | Default | Description |
 |---|---|---|
@@ -96,7 +106,7 @@ All services work with defaults for local development. Override via `.env` files
 | `DB_USER` | `foodatlas` | Database user |
 | `DB_PASSWORD` | `foodatlas` | Database password |
 | `API_KEY` | (empty) | API key (skipped in debug mode) |
-| `API_CORS_ORIGINS` | `http://localhost:3000` | Allowed CORS origins |
+| `API_CORS_ORIGINS` | `http://localhost:3000` | Allowed CORS origins (comma-separated) |
 | `API_DEBUG` | `true` | Enable debug mode |
 | `NEXT_PUBLIC_API_URL` | — | Backend API URL (set to `http://localhost:8000`) |
 | `NEXT_PUBLIC_API_KEY` | — | Backend API key (not needed in debug mode) |


### PR DESCRIPTION
## Summary

- Update port references from 3000 to 3001 (frontend now hardcoded to 3001)
- Fix parquet path in CLAUDE.md local dev example
- Add SSH tunnel instructions (step 7) for remote server access
- Add ETL Notes section to CLAUDE.md documenting COPY text escaping, entity dedup, and triplet dedup gotchas
- Clarify `.env` file locations and CORS config in README