### PR TITLE
fix: DMD entity dedup, concentration converter, materializer perf, and UI fixes

### DIFF
--- a/backend/api/src/app.py
+++ b/backend/api/src/app.py
@@ -7,7 +7,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from src.config import APISettings
 from src.dependencies import init_session_factory
-from src.routes import chemical, disease, download, food, metadata
+from src.routes import chemical, disease, download, food, metadata, resolve
 
 
 def create_app(settings: APISettings | None = None) -> FastAPI:
@@ -34,6 +34,7 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
     app.include_router(disease.router)
     app.include_router(metadata.router)
     app.include_router(download.router)
+    app.include_router(resolve.router)
 
     return app
 

--- a/backend/api/src/repositories/food.py
+++ b/backend/api/src/repositories/food.py
@@ -19,7 +19,7 @@ NUTRIENT_KEY_MAP = {
 VALID_SOURCES = {"fdc", "foodatlas", "dmd"}
 VALID_SORT_COLS = {
     "common_name": "chemical_name",
-    "median_concentration": "median_concentration",
+    "median_concentration": "(median_concentration->>'value')::NUMERIC",
 }
 VALID_DIRECTIONS = {"ASC", "DESC"}
 
@@ -54,7 +54,7 @@ async def get_profile(session: AsyncSession, common_name: str) -> dict[str, obje
                    nutrient_classification, median_concentration
             FROM mv_food_chemical_composition
             WHERE food_name = :name
-            ORDER BY median_concentration DESC NULLS LAST
+            ORDER BY (median_concentration->>'value')::NUMERIC DESC NULLS LAST
         """),
         {"name": common_name},
     )
@@ -70,6 +70,7 @@ async def get_profile(session: AsyncSession, common_name: str) -> dict[str, obje
         mapping = row._mapping
         classifications = mapping["nutrient_classification"] or []
         entry = {
+            "id": mapping["id"],
             "name": mapping["name"],
             "median_concentration": mapping["median_concentration"],
         }

--- a/backend/api/src/routes/resolve.py
+++ b/backend/api/src/routes/resolve.py
@@ -1,0 +1,28 @@
+"""Resolve entity ID to common_name for URL redirects."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.dependencies import get_db, verify_api_key
+
+router = APIRouter(prefix="/resolve", dependencies=[Depends(verify_api_key)])
+
+
+@router.get("")
+async def resolve_entity(
+    entity_id: str = Query(...),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Return entity_type and common_name for a given foodatlas_id."""
+    result = await db.execute(
+        text(
+            "SELECT entity_type, common_name FROM base_entities"
+            " WHERE foodatlas_id = :id"
+        ),
+        {"id": entity_id},
+    )
+    row = result.fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="Entity not found.")
+    return {"entity_type": row[0], "common_name": row[1]}

--- a/backend/db/pyproject.toml
+++ b/backend/db/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "pydantic>=2.6",
     "pydantic-settings>=2.1",
     "numpy>=1.26",
+    "tqdm>=4.67.3",
 ]
 
 [tool.uv]

--- a/backend/db/src/etl/materializer.py
+++ b/backend/db/src/etl/materializer.py
@@ -1,18 +1,16 @@
 """Materialize denormalized API tables from base tables."""
 
-import json
 import logging
 
-import numpy as np
 import pandas as pd
 from sqlalchemy import text
 from sqlalchemy.engine import Connection
 
 from .bulk_insert import bulk_copy, truncate_tables
+from .materializer_composition import materialize_food_chemical_composition
 from .materializer_correlation import materialize_chemical_disease_correlation
 
 logger = logging.getLogger(__name__)
-PMC_URL = "https://www.ncbi.nlm.nih.gov/pmc/?term="
 MV_TABLES = [
     "mv_food_entities",
     "mv_chemical_entities",
@@ -28,7 +26,7 @@ def refresh_all(conn: Connection) -> None:
     logger.info("Building entity views...")
     _materialize_entity_views(conn)
     logger.info("Building food-chemical composition...")
-    _materialize_food_chemical_composition(conn)
+    materialize_food_chemical_composition(conn)
     logger.info("Building chemical-disease correlation...")
     materialize_chemical_disease_correlation(conn)
     conn.commit()
@@ -46,12 +44,10 @@ def _materialize_entity_views(conn: Connection) -> None:
     entity_map = entities.set_index("foodatlas_id")
     name_map = entity_map["common_name"].to_dict()
 
-    # Pre-build classification lookups (O(r2) once, O(1) per entity)
     foodon_cls = _build_classification_map(r2, name_map, "foodon")
     chebi_cls = _build_classification_map(r2, name_map, "chebi")
     cdno_cls = _build_classification_map(r2, name_map, "cdno")
 
-    # Food entities: foods that appear as head in r1 triplets
     food_ids = set(r1["head_id"])
     foods = entities[
         (entities["entity_type"] == "food") & (entities["foodatlas_id"].isin(food_ids))
@@ -63,7 +59,6 @@ def _materialize_entity_views(conn: Connection) -> None:
     )
     _insert_mv_entities(conn, "mv_food_entities", foods, ["food_classification"])
 
-    # Chemical entities: chemicals that appear as tail in r1 triplets
     chem_ids = set(r1["tail_id"])
     chemicals = entities[
         (entities["entity_type"] == "chemical")
@@ -86,8 +81,6 @@ def _materialize_entity_views(conn: Connection) -> None:
         ["chemical_classification", "nutrient_classification"],
     )
 
-    # Disease entities: diseases in r3/r4 triplets (tail_id)
-    # Only diseases whose correlated chemicals are also in food composition
     disease_chem_ids = set(r3r4["head_id"]) & chem_ids
     relevant_disease_ids = set(r3r4[r3r4["head_id"].isin(disease_chem_ids)]["tail_id"])
     diseases = entities[
@@ -136,193 +129,3 @@ def _insert_mv_entities(
         "external_ids",
     ]
     bulk_copy(conn, table_name, df, base_cols + extra_cols)
-
-
-def _materialize_food_chemical_composition(conn: Connection) -> None:
-    """Build mv_food_chemical_composition from r1 triplets + attestations."""
-    r1_triplets = pd.read_sql(
-        text("SELECT * FROM base_triplets WHERE relationship_id = 'r1'"), conn
-    )
-    attestations = pd.read_sql(text("SELECT * FROM base_attestations"), conn)
-    evidence = pd.read_sql(text("SELECT * FROM base_evidence"), conn)
-    entities = pd.read_sql(
-        text("SELECT foodatlas_id, common_name FROM base_entities"), conn
-    )
-    # Get nutrient classification from mv_chemical_entities
-    chem_class = pd.read_sql(
-        text("SELECT foodatlas_id, nutrient_classification FROM mv_chemical_entities"),
-        conn,
-    )
-
-    name_map = entities.set_index("foodatlas_id")["common_name"].to_dict()
-    att_map = attestations.set_index("attestation_id")
-    ev_map = evidence.set_index("evidence_id")
-    nutr_map = chem_class.set_index("foodatlas_id")["nutrient_classification"].to_dict()
-
-    rows = []
-    for _, triplet in r1_triplets.iterrows():
-        row = _build_composition_row(triplet, name_map, att_map, ev_map, nutr_map)
-        if row is not None:
-            rows.append(row)
-
-    if not rows:
-        return
-
-    result = pd.DataFrame(rows)
-    columns = [
-        "food_name",
-        "food_foodatlas_id",
-        "chemical_name",
-        "chemical_foodatlas_id",
-        "nutrient_classification",
-        "median_concentration",
-        "fdc_evidences",
-        "foodatlas_evidences",
-        "dmd_evidences",
-    ]
-    bulk_copy(conn, "mv_food_chemical_composition", result, columns)
-    logger.info("Food-chemical composition: %d rows", len(result))
-
-
-def _build_composition_row(
-    triplet: pd.Series,
-    name_map: dict[str, str],
-    att_map: pd.DataFrame,
-    ev_map: pd.DataFrame,
-    nutr_map: dict[str, list[str]],
-) -> dict | None:
-    """Build one mv_food_chemical_composition row from a triplet."""
-    food_id = triplet["head_id"]
-    chem_id = triplet["tail_id"]
-    att_ids = triplet["attestation_ids"] or []
-
-    food_name = name_map.get(food_id, "")
-    chem_name = name_map.get(chem_id, "")
-
-    fdc_ev, fa_ev, dmd_ev = _group_evidences(
-        att_ids, att_map, ev_map, food_name, chem_name
-    )
-    if not fdc_ev and not fa_ev and not dmd_ev:
-        return None
-
-    all_ev = (fdc_ev or []) + (fa_ev or []) + (dmd_ev or [])
-    median_conc = _compute_median_concentration(all_ev)
-
-    return {
-        "food_name": food_name,
-        "food_foodatlas_id": food_id,
-        "chemical_name": chem_name,
-        "chemical_foodatlas_id": chem_id,
-        "nutrient_classification": nutr_map.get(chem_id, []),
-        "median_concentration": json.dumps(median_conc) if median_conc else None,
-        "fdc_evidences": json.dumps(fdc_ev) if fdc_ev else None,
-        "foodatlas_evidences": json.dumps(fa_ev) if fa_ev else None,
-        "dmd_evidences": json.dumps(dmd_ev) if dmd_ev else None,
-    }
-
-
-def _group_evidences(
-    att_ids: list[str],
-    att_map: pd.DataFrame,
-    ev_map: pd.DataFrame,
-    food_name: str,
-    chem_name: str,
-) -> tuple[list | None, list | None, list | None]:
-    """Group attestations into fdc/foodatlas/dmd evidence lists."""
-    fdc: list[dict] = []
-    foodatlas: list[dict] = []
-    dmd: list[dict] = []
-
-    for att_id in att_ids:
-        if att_id not in att_map.index:
-            continue
-        att = att_map.loc[att_id]
-        ev_id = att["evidence_id"]
-        ev = ev_map.loc[ev_id] if ev_id in ev_map.index else None
-        ref = ev["reference"] if ev is not None else {}
-        source = att["source"]
-
-        conc_val = att["conc_value"]
-        if pd.isna(conc_val):
-            conc_val = None
-        if conc_val is not None and float(conc_val) == 0:
-            continue
-
-        extraction = {
-            "extracted_food_name": att["head_name_raw"] or food_name,
-            "extracted_chemical_name": att["tail_name_raw"] or chem_name,
-            "extracted_concentration": att["conc_value_raw"] or None,
-            "converted_concentration": {
-                "value": conc_val,
-                "unit": att["conc_unit"] or "",
-            },
-            "method": source,
-        }
-
-        if source in ("fdc", "dmd"):
-            bucket = fdc if source == "fdc" else dmd
-            evidence_obj = _build_db_evidence(source, ref, extraction)
-            bucket.append(evidence_obj)
-        else:
-            _add_foodatlas_evidence(foodatlas, ref, extraction)
-
-    return (fdc or None, foodatlas or None, dmd or None)
-
-
-def _build_db_evidence(source: str, ref: dict, extraction: dict) -> dict:
-    """Build a FoodEvidence object for FDC/DMD sources."""
-    source_upper = source.upper()
-    ref_id = ref.get("dmd_concentration_id", ref.get("url", ""))
-    if source == "fdc":
-        ref_id = ref.get("fdc_id", ref.get("url", ""))
-    return {
-        "premise": None,
-        "reference": {
-            "id": str(ref_id),
-            "url": ref.get("url", ""),
-            "source_name": source_upper,
-            "display_name": f"{source_upper} ID",
-        },
-        "extraction": [extraction],
-    }
-
-
-def _add_foodatlas_evidence(evidences: list, ref: dict, extraction: dict) -> None:
-    """Add a FoodAtlas (lit2kg) evidence, grouping by premise."""
-    pmcid = ref.get("pmcid", "")
-    premise = ref.get("text", "")
-
-    for existing in evidences:
-        if existing["premise"] == premise:
-            existing["extraction"].append(extraction)
-            return
-
-    evidences.append(
-        {
-            "premise": premise,
-            "reference": {
-                "id": str(pmcid),
-                "url": f"{PMC_URL}{pmcid}" if pmcid else "",
-                "source_name": "FoodAtlas",
-                "display_name": "PMC ID",
-            },
-            "extraction": [extraction],
-        }
-    )
-
-
-def _compute_median_concentration(evidences: list) -> dict | None:
-    """Compute median concentration across all evidence extractions."""
-    values = []
-    for ev in evidences:
-        for ext in ev.get("extraction", []):
-            conc = ext.get("converted_concentration", {})
-            val = conc.get("value")
-            unit = conc.get("unit", "")
-            if val is not None and float(val) != 0 and unit == "mg/100g":
-                values.append(float(val))
-    if not values:
-        return None
-    median = float(np.median(values))
-    formatted = f"{median:.6f}".rstrip("0").rstrip(".")
-    return {"unit": "mg/100g", "value": formatted}

--- a/backend/db/src/etl/materializer_composition.py
+++ b/backend/db/src/etl/materializer_composition.py
@@ -7,6 +7,7 @@ import numpy as np
 import pandas as pd
 from sqlalchemy import text
 from sqlalchemy.engine import Connection
+from tqdm import tqdm
 
 from .bulk_insert import bulk_copy
 
@@ -70,8 +71,11 @@ def materialize_food_chemical_composition(conn: Connection) -> None:
     )
 
     # Group by triplet and build evidence JSON.
+    grouped = merged.groupby(["head_id", "tail_id"])
     result_rows = []
-    for (head_id, tail_id), group in merged.groupby(["head_id", "tail_id"]):
+    for (head_id, tail_id), group in tqdm(
+        grouped, total=len(grouped), desc="composition", leave=True
+    ):
         ev = _build_evidence_json(group)
         if not any(ev.values()):
             continue
@@ -127,7 +131,9 @@ def _build_evidence_json(group: pd.DataFrame) -> dict[str, list | None]:
         extraction = {
             "extracted_food_name": row["show_food"],
             "extracted_chemical_name": row["show_chem"],
-            "extracted_concentration": row["conc_value_raw"] or None,
+            "extracted_concentration": (
+                f"{row['conc_value_raw']} {row['conc_unit_raw']}".strip() or None
+            ),
             "converted_concentration": {
                 "value": conc_val,
                 "unit": row["conc_unit"] or "",

--- a/backend/db/src/etl/materializer_composition.py
+++ b/backend/db/src/etl/materializer_composition.py
@@ -1,0 +1,197 @@
+"""Build mv_food_chemical_composition (vectorized)."""
+
+import json
+import logging
+
+import numpy as np
+import pandas as pd
+from sqlalchemy import text
+from sqlalchemy.engine import Connection
+
+from .bulk_insert import bulk_copy
+
+logger = logging.getLogger(__name__)
+PMC_URL = "https://www.ncbi.nlm.nih.gov/pmc/?term="
+
+
+def materialize_food_chemical_composition(conn: Connection) -> None:
+    """Build mv_food_chemical_composition from r1 triplets + attestations.
+
+    Vectorized: explodes attestation_ids, joins attestations + evidence
+    in bulk, then groups by (head_id, tail_id) to build evidence JSON.
+    """
+    r1 = pd.read_sql(
+        text(
+            "SELECT head_id, tail_id, attestation_ids"
+            " FROM base_triplets WHERE relationship_id = 'r1'"
+        ),
+        conn,
+    )
+    attestations = pd.read_sql(text("SELECT * FROM base_attestations"), conn)
+    evidence = pd.read_sql(text("SELECT * FROM base_evidence"), conn)
+    entities = pd.read_sql(
+        text("SELECT foodatlas_id, common_name FROM base_entities"), conn
+    )
+    chem_class = pd.read_sql(
+        text("SELECT foodatlas_id, nutrient_classification FROM mv_chemical_entities"),
+        conn,
+    )
+
+    name_map = entities.set_index("foodatlas_id")["common_name"].to_dict()
+    nutr_map = chem_class.set_index("foodatlas_id")["nutrient_classification"].to_dict()
+
+    # Explode so each (triplet, att_id) is one row, then join.
+    r1_ex = r1.explode("attestation_ids").rename(
+        columns={"attestation_ids": "attestation_id"}
+    )
+    r1_ex = r1_ex.dropna(subset=["attestation_id"])
+    merged = r1_ex.merge(attestations, on="attestation_id", how="inner")
+    merged = merged.merge(evidence, on="evidence_id", how="left", suffixes=("", "_ev"))
+
+    # Filter zero concentrations.
+    merged["conc_value"] = pd.to_numeric(merged["conc_value"], errors="coerce")
+    merged = merged[~((merged["conc_value"].notna()) & (merged["conc_value"] == 0))]
+
+    # Map entity names + build display names.
+    merged["food_name"] = merged["head_id"].map(name_map)
+    merged["chem_name"] = merged["tail_id"].map(name_map)
+    is_db = merged["source"].isin(["fdc", "dmd"])
+    merged["show_food"] = merged["food_name"].where(
+        is_db,
+        merged["head_name_raw"].where(
+            merged["head_name_raw"] != "", merged["food_name"]
+        ),
+    )
+    merged["show_chem"] = merged["chem_name"].where(
+        is_db,
+        merged["tail_name_raw"].where(
+            merged["tail_name_raw"] != "", merged["chem_name"]
+        ),
+    )
+
+    # Group by triplet and build evidence JSON.
+    result_rows = []
+    for (head_id, tail_id), group in merged.groupby(["head_id", "tail_id"]):
+        ev = _build_evidence_json(group)
+        if not any(ev.values()):
+            continue
+        all_ev = (ev["fdc"] or []) + (ev["foodatlas"] or []) + (ev["dmd"] or [])
+        median_conc = _compute_median(all_ev)
+        result_rows.append(
+            {
+                "food_name": name_map.get(head_id, ""),
+                "food_foodatlas_id": head_id,
+                "chemical_name": name_map.get(tail_id, ""),
+                "chemical_foodatlas_id": tail_id,
+                "nutrient_classification": nutr_map.get(tail_id, []),
+                "median_concentration": json.dumps(median_conc)
+                if median_conc
+                else None,
+                "fdc_evidences": json.dumps(ev["fdc"]) if ev["fdc"] else None,
+                "foodatlas_evidences": json.dumps(ev["foodatlas"])
+                if ev["foodatlas"]
+                else None,
+                "dmd_evidences": json.dumps(ev["dmd"]) if ev["dmd"] else None,
+            }
+        )
+
+    if not result_rows:
+        return
+    result = pd.DataFrame(result_rows)
+    columns = [
+        "food_name",
+        "food_foodatlas_id",
+        "chemical_name",
+        "chemical_foodatlas_id",
+        "nutrient_classification",
+        "median_concentration",
+        "fdc_evidences",
+        "foodatlas_evidences",
+        "dmd_evidences",
+    ]
+    bulk_copy(conn, "mv_food_chemical_composition", result, columns)
+    logger.info("Food-chemical composition: %d rows", len(result))
+
+
+def _build_evidence_json(group: pd.DataFrame) -> dict[str, list | None]:
+    """Build {fdc, foodatlas, dmd} evidence lists from a grouped DataFrame."""
+    fdc: list[dict] = []
+    foodatlas: list[dict] = []
+    dmd: list[dict] = []
+
+    for _, row in group.iterrows():
+        source = row["source"]
+        ref = row["reference"] if isinstance(row["reference"], dict) else {}
+        conc_val = row["conc_value"] if pd.notna(row["conc_value"]) else None
+
+        extraction = {
+            "extracted_food_name": row["show_food"],
+            "extracted_chemical_name": row["show_chem"],
+            "extracted_concentration": row["conc_value_raw"] or None,
+            "converted_concentration": {
+                "value": conc_val,
+                "unit": row["conc_unit"] or "",
+            },
+            "method": source,
+        }
+
+        if source in ("fdc", "dmd"):
+            bucket = fdc if source == "fdc" else dmd
+            upper = source.upper()
+            key = "fdc_id" if source == "fdc" else "dmd_concentration_id"
+            ref_id = ref.get(key, ref.get("url", ""))
+            bucket.append(
+                {
+                    "premise": None,
+                    "reference": {
+                        "id": str(ref_id),
+                        "url": ref.get("url", ""),
+                        "source_name": upper,
+                        "display_name": f"{upper} ID",
+                    },
+                    "extraction": [extraction],
+                }
+            )
+        else:
+            _add_foodatlas_evidence(foodatlas, ref, extraction)
+
+    return {"fdc": fdc or None, "foodatlas": foodatlas or None, "dmd": dmd or None}
+
+
+def _add_foodatlas_evidence(evidences: list, ref: dict, extraction: dict) -> None:
+    """Add a FoodAtlas evidence, grouping by premise."""
+    pmcid = ref.get("pmcid", "")
+    premise = ref.get("text", "")
+    for existing in evidences:
+        if existing["premise"] == premise:
+            existing["extraction"].append(extraction)
+            return
+    evidences.append(
+        {
+            "premise": premise,
+            "reference": {
+                "id": str(pmcid),
+                "url": f"{PMC_URL}{pmcid}" if pmcid else "",
+                "source_name": "FoodAtlas",
+                "display_name": "PMC ID",
+            },
+            "extraction": [extraction],
+        }
+    )
+
+
+def _compute_median(evidences: list) -> dict | None:
+    """Compute median concentration across all evidence extractions."""
+    values = []
+    for ev in evidences:
+        for ext in ev.get("extraction", []):
+            conc = ext.get("converted_concentration", {})
+            val = conc.get("value")
+            unit = conc.get("unit", "")
+            if val is not None and float(val) != 0 and unit == "mg/100g":
+                values.append(float(val))
+    if not values:
+        return None
+    median = float(np.median(values))
+    formatted = f"{median:.6f}".rstrip("0").rstrip(".")
+    return {"unit": "mg/100g", "value": formatted}

--- a/backend/db/src/etl/materializer_correlation.py
+++ b/backend/db/src/etl/materializer_correlation.py
@@ -6,6 +6,7 @@ import logging
 import pandas as pd
 from sqlalchemy import text
 from sqlalchemy.engine import Connection
+from tqdm import tqdm
 
 from .bulk_insert import bulk_copy
 
@@ -29,7 +30,9 @@ def materialize_chemical_disease_correlation(conn: Connection) -> None:
     ev_map = evidence.set_index("evidence_id")
 
     rows = []
-    for _, triplet in r3r4.iterrows():
+    for _, triplet in tqdm(
+        r3r4.iterrows(), total=len(r3r4), desc="correlation", leave=True
+    ):
         chem_id = triplet["head_id"]
         disease_id = triplet["tail_id"]
         att_ids = triplet["attestation_ids"] or []

--- a/backend/db/src/etl/materializer_search.py
+++ b/backend/db/src/etl/materializer_search.py
@@ -121,6 +121,9 @@ def _extract_external_id_values(ext_ids: dict, entity_type: str) -> list[str]:
     return values
 
 
+_MAX_TOKEN_LEN = 200
+
+
 def _build_exact_tokens(
     entity_type: str,
     common_name: str,
@@ -128,11 +131,15 @@ def _build_exact_tokens(
     synonyms: list[str],
     ext_id_values: list[str],
 ) -> list[str]:
-    """Build exact-match search tokens for an entity."""
+    """Build exact-match search tokens for an entity.
+
+    Synonyms longer than ``_MAX_TOKEN_LEN`` (e.g. amino acid sequences)
+    are excluded to stay within the GIN index page-size limit.
+    """
     tokens: list[str] = [entity_type, common_name]
     if scientific_name:
         tokens.append(scientific_name)
-    tokens.extend(synonyms)
+    tokens.extend(s for s in synonyms if len(s) <= _MAX_TOKEN_LEN)
     tokens.extend(ext_id_values)
     return [str(t) for t in tokens]
 

--- a/backend/db/tests/test_materializer.py
+++ b/backend/db/tests/test_materializer.py
@@ -1,18 +1,17 @@
-"""Tests for src.etl.materializer — pure helper functions."""
+"""Tests for materializer helper functions."""
+
+from unittest.mock import MagicMock
 
 import pandas as pd
-from src.etl.materializer import (
+from src.etl.materializer import _build_classification_map, _insert_mv_entities
+from src.etl.materializer_composition import (
     _add_foodatlas_evidence,
-    _build_classification_map,
-    _build_composition_row,
-    _build_db_evidence,
-    _compute_median_concentration,
-    _group_evidences,
+    _compute_median,
 )
 
 
-class TestComputeMedianConcentration:
-    """Test _compute_median_concentration with various inputs."""
+class TestComputeMedian:
+    """Test _compute_median with various inputs."""
 
     def test_single_value(self):
         evidences = [
@@ -22,7 +21,7 @@ class TestComputeMedianConcentration:
                 ]
             },
         ]
-        result = _compute_median_concentration(evidences)
+        result = _compute_median(evidences)
         assert result is not None
         assert result["unit"] == "mg/100g"
         assert result["value"] == "10"
@@ -36,7 +35,7 @@ class TestComputeMedianConcentration:
                 ]
             },
         ]
-        result = _compute_median_concentration(evidences)
+        result = _compute_median(evidences)
         assert result is not None
         assert result["value"] == "5"
 
@@ -49,7 +48,7 @@ class TestComputeMedianConcentration:
                 ]
             },
         ]
-        result = _compute_median_concentration(evidences)
+        result = _compute_median(evidences)
         assert result is not None
         assert result["value"] == "6"
 
@@ -61,7 +60,7 @@ class TestComputeMedianConcentration:
                 ]
             },
         ]
-        result = _compute_median_concentration(evidences)
+        result = _compute_median(evidences)
         assert result is None
 
     def test_skips_none_values(self):
@@ -72,16 +71,16 @@ class TestComputeMedianConcentration:
                 ]
             },
         ]
-        result = _compute_median_concentration(evidences)
+        result = _compute_median(evidences)
         assert result is None
 
     def test_empty_evidences(self):
-        result = _compute_median_concentration([])
+        result = _compute_median([])
         assert result is None
 
     def test_no_extraction_key(self):
         evidences = [{"other": "data"}]
-        result = _compute_median_concentration(evidences)
+        result = _compute_median(evidences)
         assert result is None
 
     def test_decimal_precision(self):
@@ -94,42 +93,9 @@ class TestComputeMedianConcentration:
                 ]
             },
         ]
-        result = _compute_median_concentration(evidences)
+        result = _compute_median(evidences)
         assert result is not None
         assert result["value"] == "2.5"
-
-
-class TestBuildDbEvidence:
-    """Test _build_db_evidence for FDC and DMD sources."""
-
-    def test_fdc_evidence(self):
-        ref = {"fdc_id": 12345, "url": "https://fdc.example.com/12345"}
-        extraction = {"extracted_food_name": "Apple", "method": "fdc"}
-        result = _build_db_evidence("fdc", ref, extraction)
-        assert result["premise"] is None
-        assert result["reference"]["id"] == "12345"
-        assert result["reference"]["source_name"] == "FDC"
-        assert result["reference"]["display_name"] == "FDC ID"
-        assert result["extraction"] == [extraction]
-
-    def test_dmd_evidence(self):
-        ref = {"dmd_concentration_id": "dmd_99", "url": "https://dmd.example.com"}
-        extraction = {"extracted_food_name": "Banana", "method": "dmd"}
-        result = _build_db_evidence("dmd", ref, extraction)
-        assert result["reference"]["id"] == "dmd_99"
-        assert result["reference"]["source_name"] == "DMD"
-
-    def test_fdc_missing_fdc_id_falls_back_to_url(self):
-        ref = {"url": "https://fallback.example.com"}
-        ext: dict[str, str] = {}
-        result = _build_db_evidence("fdc", ref, ext)
-        assert result["reference"]["id"] == "https://fallback.example.com"
-
-    def test_dmd_missing_id_falls_back_to_url(self):
-        ref = {"url": "https://dmd.example.com/fallback"}
-        ext: dict[str, str] = {}
-        result = _build_db_evidence("dmd", ref, ext)
-        assert result["reference"]["id"] == "https://dmd.example.com/fallback"
 
 
 class TestAddFoodatlasEvidence:
@@ -173,6 +139,34 @@ class TestAddFoodatlasEvidence:
         assert evidences[0]["reference"]["url"] == ""
 
 
+class TestInsertMvEntities:
+    """Test _insert_mv_entities delegates to bulk_copy."""
+
+    def test_calls_bulk_copy_with_base_and_extra_cols(self):
+        conn = MagicMock()
+        df = pd.DataFrame()
+        with __import__("unittest.mock", fromlist=["patch"]).patch(
+            "src.etl.materializer.bulk_copy"
+        ) as mock_copy:
+            _insert_mv_entities(conn, "mv_test", df, ["extra_col"])
+            mock_copy.assert_called_once()
+            args = mock_copy.call_args[0]
+            assert args[1] == "mv_test"
+            assert "foodatlas_id" in args[3]
+            assert "extra_col" in args[3]
+
+    def test_no_extra_cols(self):
+        conn = MagicMock()
+        df = pd.DataFrame()
+        with __import__("unittest.mock", fromlist=["patch"]).patch(
+            "src.etl.materializer.bulk_copy"
+        ) as mock_copy:
+            _insert_mv_entities(conn, "mv_test", df, [])
+            cols = mock_copy.call_args[0][3]
+            assert len(cols) == 6
+            assert "external_ids" in cols
+
+
 class TestBuildClassificationMap:
     """Test _build_classification_map with mock DataFrames."""
 
@@ -212,125 +206,3 @@ class TestBuildClassificationMap:
         name_map = {"other": "A"}
         result = _build_classification_map(r2, name_map, "chebi")
         assert result.get("c001") == []
-
-
-class TestGroupEvidences:
-    """Test _group_evidences with mock attestation/evidence maps."""
-
-    def _make_maps(self):
-        att_data = pd.DataFrame(
-            [
-                {
-                    "attestation_id": "att1",
-                    "evidence_id": "ev1",
-                    "source": "fdc",
-                    "head_name_raw": "A",
-                    "tail_name_raw": "B",
-                    "conc_value": 5.0,
-                    "conc_unit": "mg/100g",
-                    "conc_value_raw": "5",
-                    "conc_unit_raw": "mg/100 g",
-                },
-                {
-                    "attestation_id": "att2",
-                    "evidence_id": "ev2",
-                    "source": "lit2kg",
-                    "head_name_raw": "",
-                    "tail_name_raw": "",
-                    "conc_value": None,
-                    "conc_unit": "",
-                    "conc_value_raw": "",
-                    "conc_unit_raw": "",
-                },
-            ]
-        ).set_index("attestation_id")
-        ev_data = pd.DataFrame(
-            [
-                {"evidence_id": "ev1", "reference": {"fdc_id": 1, "url": "u1"}},
-                {"evidence_id": "ev2", "reference": {"pmcid": "P1", "text": "t"}},
-            ]
-        ).set_index("evidence_id")
-        return att_data, ev_data
-
-    def test_fdc_evidence_grouped(self):
-        att_map, ev_map = self._make_maps()
-        fdc, fa, dmd = _group_evidences(["att1"], att_map, ev_map, "Apple", "VitC")
-        assert fdc is not None
-        assert len(fdc) == 1
-        assert fa is None
-        assert dmd is None
-
-    def test_foodatlas_evidence_grouped(self):
-        att_map, ev_map = self._make_maps()
-        fdc, fa, dmd = _group_evidences(["att2"], att_map, ev_map, "Apple", "VitC")
-        assert fdc is None
-        assert fa is not None
-        assert dmd is None
-
-    def test_missing_attestation_skipped(self):
-        att_map, ev_map = self._make_maps()
-        fdc, fa, dmd = _group_evidences(["nonexistent"], att_map, ev_map, "X", "Y")
-        assert fdc is None
-        assert fa is None
-        assert dmd is None
-
-    def test_zero_conc_skipped(self):
-        att_map, ev_map = self._make_maps()
-        att_map.loc["att1", "conc_value"] = 0.0
-        fdc, _fa, _dmd = _group_evidences(["att1"], att_map, ev_map, "X", "Y")
-        assert fdc is None
-
-
-class TestBuildCompositionRow:
-    """Test _build_composition_row with mock data."""
-
-    def test_returns_row_dict(self):
-        triplet = pd.Series(
-            {
-                "head_id": "f001",
-                "tail_id": "c001",
-                "attestation_ids": ["att1"],
-            }
-        )
-        att_map = pd.DataFrame(
-            [
-                {
-                    "attestation_id": "att1",
-                    "evidence_id": "ev1",
-                    "source": "fdc",
-                    "head_name_raw": "Apple",
-                    "tail_name_raw": "VitC",
-                    "conc_value": 5.0,
-                    "conc_unit": "mg/100g",
-                    "conc_value_raw": "5",
-                    "conc_unit_raw": "mg/100 g",
-                }
-            ]
-        ).set_index("attestation_id")
-        ev_map = pd.DataFrame(
-            [
-                {
-                    "evidence_id": "ev1",
-                    "reference": {"fdc_id": 1, "url": "u1"},
-                }
-            ]
-        ).set_index("evidence_id")
-        name_map = {"f001": "Apple", "c001": "Vitamin C"}
-        nutr_map = {"c001": ["vitamin"]}
-
-        result = _build_composition_row(triplet, name_map, att_map, ev_map, nutr_map)
-        assert result is not None
-        assert result["food_name"] == "Apple"
-        assert result["chemical_name"] == "Vitamin C"
-        assert result["nutrient_classification"] == ["vitamin"]
-
-    def test_returns_none_with_no_evidence(self):
-        triplet = pd.Series(
-            {
-                "head_id": "f001",
-                "tail_id": "c001",
-                "attestation_ids": [],
-            }
-        )
-        result = _build_composition_row(triplet, {}, pd.DataFrame(), pd.DataFrame(), {})
-        assert result is None

--- a/backend/db/tests/test_materializer_helpers.py
+++ b/backend/db/tests/test_materializer_helpers.py
@@ -143,6 +143,7 @@ class TestBuildEvidenceJson:
                     "conc_value": conc_value,
                     "conc_unit": "mg/100g",
                     "conc_value_raw": str(conc_value),
+                    "conc_unit_raw": "mg/100g",
                     "show_food": "apple",
                     "show_chem": "vitamin c",
                 }
@@ -197,6 +198,7 @@ class TestBuildEvidenceJson:
                     "conc_value": 10.0,
                     "conc_unit": "mg/100g",
                     "conc_value_raw": "10",
+                    "conc_unit_raw": "mg/100g",
                     "show_food": "apple",
                     "show_chem": "vit c",
                 }
@@ -218,6 +220,7 @@ class TestBuildEvidenceJson:
                     "conc_value": 20.0,
                     "conc_unit": "mg/100g",
                     "conc_value_raw": "20",
+                    "conc_unit_raw": "mg/100g",
                     "show_food": "milk",
                     "show_chem": "casein",
                 }
@@ -236,6 +239,7 @@ class TestBuildEvidenceJson:
                     "conc_value": 5.0,
                     "conc_unit": "mg/100g",
                     "conc_value_raw": "5",
+                    "conc_unit_raw": "mg/100g",
                     "show_food": "apple",
                     "show_chem": "vit c",
                 },
@@ -245,6 +249,7 @@ class TestBuildEvidenceJson:
                     "conc_value": 10.0,
                     "conc_unit": "mg/100g",
                     "conc_value_raw": "10",
+                    "conc_unit_raw": "mg/100g",
                     "show_food": "apple",
                     "show_chem": "vit c",
                 },
@@ -264,6 +269,7 @@ class TestBuildEvidenceJson:
                     "conc_value": 10.0,
                     "conc_unit": "mg/100g",
                     "conc_value_raw": "10",
+                    "conc_unit_raw": "mg/100g",
                     "show_food": "apple",
                     "show_chem": "vit c",
                 }
@@ -280,6 +286,7 @@ class TestBuildEvidenceJson:
                 "conc_value",
                 "conc_unit",
                 "conc_value_raw",
+                "conc_unit_raw",
                 "show_food",
                 "show_chem",
             ]
@@ -304,6 +311,7 @@ class TestBuildEvidenceJson:
                     "conc_value": 5.0,
                     "conc_unit": "mg/100g",
                     "conc_value_raw": "5",
+                    "conc_unit_raw": "mg/100g",
                     "show_food": "apple",
                     "show_chem": "vit c",
                 }

--- a/backend/db/tests/test_materializer_helpers.py
+++ b/backend/db/tests/test_materializer_helpers.py
@@ -1,13 +1,14 @@
-"""Tests for materializer helper functions."""
+"""Tests for materializer helper functions (composition + classification)."""
+
+from unittest.mock import MagicMock, patch
 
 import pandas as pd
-from src.etl.materializer import (
+from src.etl.materializer import _build_classification_map
+from src.etl.materializer_composition import (
     _add_foodatlas_evidence,
-    _build_classification_map,
-    _build_composition_row,
-    _build_db_evidence,
-    _compute_median_concentration,
-    _group_evidences,
+    _build_evidence_json,
+    _compute_median,
+    materialize_food_chemical_composition,
 )
 
 
@@ -49,7 +50,7 @@ class TestBuildClassificationMap:
         assert result.get("e1") == []
 
 
-class TestComputeMedianConcentration:
+class TestComputeMedian:
     def test_returns_median(self):
         evidences = [
             {
@@ -59,11 +60,11 @@ class TestComputeMedianConcentration:
                 ]
             },
         ]
-        result = _compute_median_concentration(evidences)
+        result = _compute_median(evidences)
         assert result == {"unit": "mg/100g", "value": "15"}
 
     def test_returns_none_for_empty(self):
-        assert _compute_median_concentration([]) is None
+        assert _compute_median([]) is None
 
     def test_skips_zero_values(self):
         evidences = [
@@ -74,7 +75,7 @@ class TestComputeMedianConcentration:
                 ]
             },
         ]
-        result = _compute_median_concentration(evidences)
+        result = _compute_median(evidences)
         assert result is not None
         assert result["value"] == "5"
 
@@ -86,7 +87,7 @@ class TestComputeMedianConcentration:
                 ]
             },
         ]
-        assert _compute_median_concentration(evidences) is None
+        assert _compute_median(evidences) is None
 
     def test_skips_none_values(self):
         evidences = [
@@ -96,24 +97,7 @@ class TestComputeMedianConcentration:
                 ]
             },
         ]
-        assert _compute_median_concentration(evidences) is None
-
-
-class TestBuildDbEvidence:
-    def test_fdc_evidence(self):
-        ref = {"fdc_id": "12345", "url": "https://fdc.example.com/12345"}
-        extraction = {"method": "fdc"}
-        result = _build_db_evidence("fdc", ref, extraction)
-        assert result["reference"]["source_name"] == "FDC"
-        assert result["reference"]["id"] == "12345"
-        assert result["premise"] is None
-
-    def test_dmd_evidence(self):
-        ref = {"dmd_concentration_id": "dmd99", "url": "https://dmd.example.com"}
-        extraction = {"method": "dmd"}
-        result = _build_db_evidence("dmd", ref, extraction)
-        assert result["reference"]["source_name"] == "DMD"
-        assert result["reference"]["id"] == "dmd99"
+        assert _compute_median(evidences) is None
 
 
 class TestAddFoodatlasEvidence:
@@ -145,155 +129,216 @@ class TestAddFoodatlasEvidence:
         assert len(evidences) == 2
 
 
-class TestGroupEvidences:
-    def _make_att_map(self):
+class TestBuildEvidenceJson:
+    def _make_group(self, source, conc_value=10.0):
         return pd.DataFrame(
-            {
-                "evidence_id": ["ev1", "ev2", "ev3"],
-                "source": ["fdc", "lit2kg:gpt-3.5-ft", "dmd"],
-                "head_name_raw": ["food1", "food1", "food1"],
-                "tail_name_raw": ["chem1", "chem1", "chem1"],
-                "conc_value": [10.0, 5.0, 20.0],
-                "conc_unit": ["mg/100g", "mg/100g", "mg/100g"],
-                "conc_value_raw": ["10", "5", "20"],
-            },
-            index=["at1", "at2", "at3"],
+            [
+                {
+                    "source": source,
+                    "reference": {
+                        "url": "https://example.com",
+                        "pmcid": "PMC1",
+                        "text": "t",
+                    },
+                    "conc_value": conc_value,
+                    "conc_unit": "mg/100g",
+                    "conc_value_raw": str(conc_value),
+                    "show_food": "apple",
+                    "show_chem": "vitamin c",
+                }
+            ]
         )
 
-    def _make_ev_map(self):
-        return pd.DataFrame(
-            {
-                "reference": [
-                    {"url": "https://fdc.example.com/1"},
-                    {"pmcid": "PMC1", "text": "premise"},
-                    {"dmd_concentration_id": "d1", "url": "https://dmd.com"},
-                ],
-            },
-            index=["ev1", "ev2", "ev3"],
-        )
+    def test_fdc_grouped(self):
+        group = self._make_group("fdc")
+        result = _build_evidence_json(group)
+        assert result["fdc"] is not None
+        assert len(result["fdc"]) == 1
+        assert result["foodatlas"] is None
+        assert result["dmd"] is None
 
-    def test_groups_by_source(self):
-        att_map = self._make_att_map()
-        ev_map = self._make_ev_map()
-        fdc, fa, dmd = _group_evidences(
-            ["at1", "at2", "at3"], att_map, ev_map, "food1", "chem1"
-        )
-        assert fdc is not None and len(fdc) == 1
-        assert fa is not None and len(fa) == 1
-        assert dmd is not None and len(dmd) == 1
+    def test_dmd_grouped(self):
+        group = self._make_group("dmd")
+        result = _build_evidence_json(group)
+        assert result["dmd"] is not None
+        assert result["fdc"] is None
 
-    def test_returns_none_for_empty_groups(self):
-        att_map = pd.DataFrame(
-            {
-                "evidence_id": ["ev1"],
-                "source": ["fdc"],
-                "head_name_raw": ["f"],
-                "tail_name_raw": ["c"],
-                "conc_value": [10.0],
-                "conc_unit": ["mg/100g"],
-                "conc_value_raw": ["10"],
-            },
-            index=["at1"],
-        )
-        ev_map = pd.DataFrame(
-            {
-                "reference": [{"url": "x"}],
-            },
-            index=["ev1"],
-        )
-        fdc, fa, dmd = _group_evidences(["at1"], att_map, ev_map, "f", "c")
-        assert fdc is not None
-        assert fa is None
-        assert dmd is None
+    def test_foodatlas_grouped(self):
+        group = self._make_group("lit2kg")
+        result = _build_evidence_json(group)
+        assert result["foodatlas"] is not None
+        assert result["fdc"] is None
 
-    def test_skips_zero_concentration(self):
-        att_map = pd.DataFrame(
-            {
-                "evidence_id": ["ev1"],
-                "source": ["fdc"],
-                "head_name_raw": ["f"],
-                "tail_name_raw": ["c"],
-                "conc_value": [0.0],
-                "conc_unit": ["mg/100g"],
-                "conc_value_raw": ["0"],
-            },
-            index=["at1"],
+    def test_mixed_sources(self):
+        group = pd.concat(
+            [
+                self._make_group("fdc"),
+                self._make_group("lit2kg", 5.0),
+            ],
+            ignore_index=True,
         )
-        ev_map = pd.DataFrame(
-            {
-                "reference": [{"url": "x"}],
-            },
-            index=["ev1"],
-        )
-        fdc, _fa, _dmd = _group_evidences(["at1"], att_map, ev_map, "f", "c")
-        assert fdc is None
+        result = _build_evidence_json(group)
+        assert result["fdc"] is not None
+        assert result["foodatlas"] is not None
 
-    def test_skips_missing_attestation(self):
-        att_map = pd.DataFrame(
+    def test_null_conc_value(self):
+        group = self._make_group("fdc", conc_value=float("nan"))
+        result = _build_evidence_json(group)
+        assert result["fdc"] is not None
+        ext = result["fdc"][0]["extraction"][0]
+        assert ext["converted_concentration"]["value"] is None
+
+    def test_fdc_reference_id(self):
+        group = pd.DataFrame(
+            [
+                {
+                    "source": "fdc",
+                    "reference": {"fdc_id": "12345", "url": "https://fdc.example.com"},
+                    "conc_value": 10.0,
+                    "conc_unit": "mg/100g",
+                    "conc_value_raw": "10",
+                    "show_food": "apple",
+                    "show_chem": "vit c",
+                }
+            ]
+        )
+        result = _build_evidence_json(group)
+        assert result["fdc"][0]["reference"]["id"] == "12345"
+        assert result["fdc"][0]["reference"]["source_name"] == "FDC"
+
+    def test_dmd_reference_id(self):
+        group = pd.DataFrame(
+            [
+                {
+                    "source": "dmd",
+                    "reference": {
+                        "dmd_concentration_id": "dmd99",
+                        "url": "https://dmd.com",
+                    },
+                    "conc_value": 20.0,
+                    "conc_unit": "mg/100g",
+                    "conc_value_raw": "20",
+                    "show_food": "milk",
+                    "show_chem": "casein",
+                }
+            ]
+        )
+        result = _build_evidence_json(group)
+        assert result["dmd"][0]["reference"]["id"] == "dmd99"
+        assert result["dmd"][0]["reference"]["source_name"] == "DMD"
+
+    def test_foodatlas_groups_by_premise(self):
+        group = pd.DataFrame(
+            [
+                {
+                    "source": "lit2kg",
+                    "reference": {"pmcid": "PMC1", "text": "same premise"},
+                    "conc_value": 5.0,
+                    "conc_unit": "mg/100g",
+                    "conc_value_raw": "5",
+                    "show_food": "apple",
+                    "show_chem": "vit c",
+                },
+                {
+                    "source": "lit2kg",
+                    "reference": {"pmcid": "PMC1", "text": "same premise"},
+                    "conc_value": 10.0,
+                    "conc_unit": "mg/100g",
+                    "conc_value_raw": "10",
+                    "show_food": "apple",
+                    "show_chem": "vit c",
+                },
+            ]
+        )
+        result = _build_evidence_json(group)
+        assert result["foodatlas"] is not None
+        assert len(result["foodatlas"]) == 1
+        assert len(result["foodatlas"][0]["extraction"]) == 2
+
+    def test_non_dict_reference(self):
+        group = pd.DataFrame(
+            [
+                {
+                    "source": "fdc",
+                    "reference": "not_a_dict",
+                    "conc_value": 10.0,
+                    "conc_unit": "mg/100g",
+                    "conc_value_raw": "10",
+                    "show_food": "apple",
+                    "show_chem": "vit c",
+                }
+            ]
+        )
+        result = _build_evidence_json(group)
+        assert result["fdc"] is not None
+
+    def test_empty_group_returns_all_none(self):
+        group = pd.DataFrame(
             columns=[
-                "evidence_id",
                 "source",
-                "head_name_raw",
-                "tail_name_raw",
+                "reference",
                 "conc_value",
                 "conc_unit",
                 "conc_value_raw",
+                "show_food",
+                "show_chem",
             ]
         )
-        ev_map = pd.DataFrame(columns=["reference"])
-        fdc, _fa, _dmd = _group_evidences(["missing"], att_map, ev_map, "f", "c")
-        assert fdc is None
+        result = _build_evidence_json(group)
+        assert result["fdc"] is None
+        assert result["foodatlas"] is None
+        assert result["dmd"] is None
+
+    def test_foodatlas_url_with_pmcid(self):
+        group = self._make_group("lit2kg")
+        result = _build_evidence_json(group)
+        url = result["foodatlas"][0]["reference"]["url"]
+        assert "PMC1" in url
+
+    def test_foodatlas_empty_pmcid(self):
+        group = pd.DataFrame(
+            [
+                {
+                    "source": "lit2kg",
+                    "reference": {"pmcid": "", "text": "premise"},
+                    "conc_value": 5.0,
+                    "conc_unit": "mg/100g",
+                    "conc_value_raw": "5",
+                    "show_food": "apple",
+                    "show_chem": "vit c",
+                }
+            ]
+        )
+        result = _build_evidence_json(group)
+        assert result["foodatlas"][0]["reference"]["url"] == ""
 
 
-class TestBuildCompositionRow:
-    def test_builds_valid_row(self):
-        triplet = pd.Series(
-            {
-                "head_id": "e1",
-                "tail_id": "e2",
-                "attestation_ids": ["at1"],
-            }
-        )
-        name_map = {"e1": "tomato", "e2": "vitamin c"}
-        att_map = pd.DataFrame(
-            {
-                "evidence_id": ["ev1"],
-                "source": ["fdc"],
-                "head_name_raw": ["tomato"],
-                "tail_name_raw": ["vit c"],
-                "conc_value": [50.0],
-                "conc_unit": ["mg/100g"],
-                "conc_value_raw": ["50"],
-            },
-            index=["at1"],
-        )
-        ev_map = pd.DataFrame(
-            {
-                "reference": [{"url": "https://fdc.example.com/1"}],
-            },
-            index=["ev1"],
-        )
-        nutr_map = {"e2": ["vitamin"]}
+class TestMaterializeCompositionEmpty:
+    """Test materialize_food_chemical_composition with empty data."""
 
-        row = _build_composition_row(triplet, name_map, att_map, ev_map, nutr_map)
-        assert row is not None
-        assert row["food_name"] == "tomato"
-        assert row["chemical_name"] == "vitamin c"
-        assert row["nutrient_classification"] == ["vitamin"]
-
-    def test_returns_none_for_no_evidence(self):
-        triplet = pd.Series(
-            {
-                "head_id": "e1",
-                "tail_id": "e2",
-                "attestation_ids": [],
-            }
-        )
-        row = _build_composition_row(
-            triplet,
-            {"e1": "a", "e2": "b"},
-            pd.DataFrame(),
-            pd.DataFrame(),
-            {},
-        )
-        assert row is None
+    @patch("src.etl.materializer_composition.bulk_copy")
+    @patch("src.etl.materializer_composition.pd.read_sql")
+    def test_empty_triplets_produces_no_rows(self, mock_sql, mock_copy):
+        """No r1 triplets → no rows inserted."""
+        mock_sql.side_effect = [
+            pd.DataFrame(columns=["head_id", "tail_id", "attestation_ids"]),
+            pd.DataFrame(
+                columns=[
+                    "attestation_id",
+                    "evidence_id",
+                    "source",
+                    "head_name_raw",
+                    "tail_name_raw",
+                    "conc_value",
+                    "conc_unit",
+                    "conc_value_raw",
+                    "conc_unit_raw",
+                ]
+            ),
+            pd.DataFrame(columns=["evidence_id", "source_type", "reference"]),
+            pd.DataFrame(columns=["foodatlas_id", "common_name"]),
+            pd.DataFrame(columns=["foodatlas_id", "nutrient_classification"]),
+        ]
+        conn = MagicMock()
+        materialize_food_chemical_composition(conn)
+        mock_copy.assert_not_called()

--- a/backend/db/tests/test_materializer_orchestration.py
+++ b/backend/db/tests/test_materializer_orchestration.py
@@ -20,7 +20,7 @@ class TestRefreshAll:
     """Test refresh_all orchestration."""
 
     @patch("src.etl.materializer.materialize_chemical_disease_correlation")
-    @patch("src.etl.materializer._materialize_food_chemical_composition")
+    @patch("src.etl.materializer.materialize_food_chemical_composition")
     @patch("src.etl.materializer._materialize_entity_views")
     @patch("src.etl.materializer.truncate_tables")
     def test_calls_truncate_then_materialize(

--- a/backend/db/uv.lock
+++ b/backend/db/uv.lock
@@ -173,6 +173,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "sqlalchemy" },
+    { name = "tqdm" },
 ]
 
 [package.dev-dependencies]
@@ -195,6 +196,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pydantic-settings", specifier = ">=2.1" },
     { name = "sqlalchemy", specifier = ">=2.0" },
+    { name = "tqdm", specifier = ">=4.67.3" },
 ]
 
 [package.metadata.requires-dev]
@@ -999,6 +1001,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+]
+
+[[package]]
+name = "tqdm"
+version = "4.67.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/a9/6ba95a270c6f1fbcd8dac228323f2777d886cb206987444e4bce66338dd4/tqdm-4.67.3.tar.gz", hash = "sha256:7d825f03f89244ef73f1d4ce193cb1774a8179fd96f31d7e1dcde62092b960bb", size = 169598, upload-time = "2026-02-03T17:35:53.048Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/16/e1/3079a9ff9b8e11b846c6ac5c8b5bfb7ff225eee721825310c91b3b50304f/tqdm-4.67.3-py3-none-any.whl", hash = "sha256:ee1e4c0e59148062281c49d80b25b67771a127c85fc9676d3be5f243206826bf", size = 78374, upload-time = "2026-02-03T17:35:50.982Z" },
 ]
 
 [[package]]

--- a/backend/kgc/src/pipeline/entities/resolve_dmd.py
+++ b/backend/kgc/src/pipeline/entities/resolve_dmd.py
@@ -17,6 +17,7 @@ from .resolve_dmd_helpers import (
     _append_entities,
     _build_entity,
     _build_ext_index,
+    _collect_unlinked,
     _get_molecules,
     _get_xrefs,
     _pick_display_xref,
@@ -43,11 +44,16 @@ def create_chemicals_from_dmd(
     lut: EntityLUT,
     registry: EntityRegistry,
 ) -> None:
-    """Pass 1: create entities for DMD molecules with seeded registry IDs."""
+    """Pass 1: create entities for seeded DMD molecules already in the store.
+
+    Only creates entities whose seeded ``fa_id`` is already in the store
+    (i.e. created by a primary source like ChEBI). DMD-only seeded
+    molecules are left for Pass 2 (xref linking) or Pass 3 (new entity).
+    """
     molecules = _get_molecules(sources)
     if molecules is None:
         return
-    created_rows: list[dict] = []
+    linked = 0
     seen: set[str] = set()
     for _, row in molecules.iterrows():
         native = str(row["native_id"])
@@ -55,17 +61,19 @@ def create_chemicals_from_dmd(
             continue
         seen.add(native)
         fa_id = registry.resolve("dmd", native)
-        if not fa_id or fa_id in store._entities.index:
+        if not fa_id:
             continue
-        data = _build_entity(row, {"dmd": [native]}, row["name"])
-        data["foodatlas_id"] = fa_id
-        created_rows.append(data)
+        # Only enrich if the entity already exists (seeded from another
+        # source like ChEBI).  DMD-only seeds skip to Pass 2/3.
+        if fa_id not in store._entities.index:
+            continue
+        _add_dmd_to_entity(store, fa_id, native)
         if row["name"]:
             lut.add("chemical", row["name"], fa_id)
+        linked += 1
 
     store._curr_eid = registry.next_eid
-    _append_entities(store, created_rows)
-    logger.info("Pass 1: %d chemical entities from DMD.", len(created_rows))
+    logger.info("Pass 1: DMD enriched %d existing entities.", linked)
 
 
 # ---------------------------------------------------------------------------
@@ -100,7 +108,11 @@ def link_dmd(
 
     for _, row in molecules.iterrows():
         native = str(row["native_id"])
-        if registry.resolve("dmd", native):
+        # Skip if already resolved to an entity that exists in the store
+        # (handled in Pass 1).  Seeded molecules whose entity was NOT
+        # created by another source still need xref linking here.
+        existing_id = registry.resolve("dmd", native)
+        if existing_id and existing_id in store._entities.index:
             continue
         mol_xrefs = xref_map.get(native, {})
 
@@ -165,18 +177,7 @@ def create_unlinked_dmd(
     if molecules is None:
         return
     xref_map = _get_xrefs(sources)
-
-    # Collect unlinked molecules grouped by name for disambiguation.
-    unlinked: list[tuple[str, pd.Series]] = []
-    seen: set[str] = set()
-    for _, row in molecules.iterrows():
-        native = str(row["native_id"])
-        if native in seen:
-            continue
-        seen.add(native)
-        if registry.resolve("dmd", native):
-            continue
-        unlinked.append((native, row))
+    unlinked = _collect_unlinked(molecules, registry, store)
 
     name_groups: dict[str, list[tuple[str, pd.Series]]] = {}
     for native, row in unlinked:
@@ -202,8 +203,12 @@ def create_unlinked_dmd(
             else:
                 display_name = name
 
-            fa_id = f"e{registry.next_eid}"
-            registry.register("dmd", native, fa_id)
+            existing_id = registry.resolve("dmd", native)
+            if existing_id:
+                fa_id = existing_id
+            else:
+                fa_id = f"e{registry.next_eid}"
+                registry.register("dmd", native, fa_id)
 
             data = _build_entity(row, ext_ids, display_name)
             data["foodatlas_id"] = fa_id

--- a/backend/kgc/src/pipeline/entities/resolve_dmd.py
+++ b/backend/kgc/src/pipeline/entities/resolve_dmd.py
@@ -1,10 +1,10 @@
 """Resolve DMD molecules across all three entity resolution passes.
 
-DMD is a primary source — each DMD ID maps 1-to-1 to one chemical.
-
 Pass 1: Create entities for DMD molecules with seeded registry IDs.
-Pass 2: Enrich existing entities (e.g. ChEBI) with DMD external IDs.
-Pass 3: Create entities for genuinely new DMD molecules (no registry entry).
+Pass 2: Link DMD molecules to existing entities via ChEBI/PubChem xrefs,
+        adding DMD native IDs to their external_ids.
+Pass 3: Create entities for unlinked DMD molecules, disambiguating
+        duplicate names with an xref-ID suffix.
 """
 
 from __future__ import annotations
@@ -12,11 +12,19 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-import pandas as pd
-
-from ...models.entity import ChemicalEntity
+from .resolve_dmd_helpers import (
+    _add_dmd_to_entity,
+    _append_entities,
+    _build_entity,
+    _build_ext_index,
+    _get_molecules,
+    _get_xrefs,
+    _pick_display_xref,
+)
 
 if TYPE_CHECKING:
+    import pandas as pd
+
     from ...stores.entity_registry import EntityRegistry
     from ...stores.entity_store import EntityStore
     from .utils.lut import EntityLUT
@@ -24,40 +32,9 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _get_molecules(
-    sources: dict[str, dict[str, pd.DataFrame]],
-) -> pd.DataFrame | None:
-    dmd = sources.get("dmd")
-    if dmd is None:
-        return None
-    nodes = dmd["nodes"]
-    return nodes[nodes["node_type"] == "molecule"]
-
-
-def _build_entity(native: str, row: pd.Series) -> dict[str, object]:
-    composition = ""
-    synonyms_raw = row.get("synonyms", [])
-    if isinstance(synonyms_raw, list) and len(synonyms_raw) > 1:
-        composition = synonyms_raw[1]
-
-    syns = [row["name"]] if row["name"] else []
-    if composition:
-        syns.append(composition)
-
-    entity = ChemicalEntity(
-        foodatlas_id="",  # caller sets this
-        common_name=row["name"],
-        synonyms=syns,
-        external_ids={"dmd": [native]},
-    )
-    result: dict[str, object] = entity.model_dump(by_alias=True)
-    return result
-
-
-def _append_entities(store: EntityStore, rows: list[dict]) -> None:
-    if rows:
-        new_df = pd.DataFrame(rows).set_index("foodatlas_id")
-        store._entities = pd.concat([store._entities, new_df])
+# ---------------------------------------------------------------------------
+# Pass 1 — Create entities for DMD molecules with seeded registry IDs
+# ---------------------------------------------------------------------------
 
 
 def create_chemicals_from_dmd(
@@ -80,7 +57,7 @@ def create_chemicals_from_dmd(
         fa_id = registry.resolve("dmd", native)
         if not fa_id or fa_id in store._entities.index:
             continue
-        data = _build_entity(native, row)
+        data = _build_entity(row, {"dmd": [native]}, row["name"])
         data["foodatlas_id"] = fa_id
         created_rows.append(data)
         if row["name"]:
@@ -91,28 +68,85 @@ def create_chemicals_from_dmd(
     logger.info("Pass 1: %d chemical entities from DMD.", len(created_rows))
 
 
+# ---------------------------------------------------------------------------
+# Pass 2 — Link DMD molecules to existing entities via xrefs
+# ---------------------------------------------------------------------------
+
+
 def link_dmd(
     sources: dict[str, dict[str, pd.DataFrame]],
     store: EntityStore,
     registry: EntityRegistry,
 ) -> None:
-    """Pass 2: enrich existing entities with DMD external IDs."""
+    """Pass 2: link DMD molecules to existing entities via xrefs.
+
+    Tier 1 — ChEBI: 1:1, highest confidence.
+    Tier 2 — PubChem: good confidence, may have ambiguous matches.
+
+    Only the DMD native ID is added to linked entities; other xrefs are
+    NOT propagated to avoid contaminating curated external_ids.
+    """
     molecules = _get_molecules(sources)
     if molecules is None:
         return
-    enriched = 0
+    xref_map = _get_xrefs(sources)
+
+    chebi_index = _build_ext_index(store, "chebi")
+    pubchem_index = _build_ext_index(store, "pubchem_compound")
+
+    linked_chebi = 0
+    linked_pubchem = 0
+    ambiguous = 0
+
     for _, row in molecules.iterrows():
         native = str(row["native_id"])
-        fa_id = registry.resolve("dmd", native)
-        if not fa_id or fa_id not in store._entities.index:
+        if registry.resolve("dmd", native):
             continue
-        ext = store._entities.at[fa_id, "external_ids"]
-        if "dmd" not in ext:
-            ext["dmd"] = []
-        if native not in ext["dmd"]:
-            ext["dmd"].append(native)
-        enriched += 1
-    logger.info("Pass 2: DMD — %d entities enriched.", enriched)
+        mol_xrefs = xref_map.get(native, {})
+
+        # Tier 1: ChEBI match
+        chebi_ids = list(dict.fromkeys(mol_xrefs.get("chebi", [])))
+        matched: set[str] = set()
+        for cid in chebi_ids:
+            fa_id = chebi_index.get(cid)
+            if fa_id:
+                matched.add(fa_id)
+
+        if matched:
+            for fa_id in matched:
+                _add_dmd_to_entity(store, fa_id, native)
+                registry.register_alias("dmd", native, fa_id)
+            linked_chebi += 1 if len(matched) == 1 else 0
+            ambiguous += 1 if len(matched) > 1 else 0
+            continue
+
+        # Tier 2: PubChem match
+        pubchem_ids = mol_xrefs.get("pubchem_cid", [])
+        matched = set()
+        for pid in pubchem_ids:
+            fa_id = pubchem_index.get(pid)
+            if fa_id:
+                matched.add(fa_id)
+
+        if matched:
+            for fa_id in matched:
+                _add_dmd_to_entity(store, fa_id, native)
+                registry.register_alias("dmd", native, fa_id)
+            linked_pubchem += 1 if len(matched) == 1 else 0
+            ambiguous += 1 if len(matched) > 1 else 0
+            continue
+
+    logger.info(
+        "Pass 2: DMD linked %d via ChEBI, %d via PubChem, %d ambiguous.",
+        linked_chebi,
+        linked_pubchem,
+        ambiguous,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Pass 3 — Create entities for unlinked DMD molecules
+# ---------------------------------------------------------------------------
 
 
 def create_unlinked_dmd(
@@ -121,11 +155,19 @@ def create_unlinked_dmd(
     lut: EntityLUT,
     registry: EntityRegistry,
 ) -> None:
-    """Pass 3: create entities for DMD molecules with no registry entry."""
+    """Pass 3: create entities for DMD molecules not linked in Pass 1/2.
+
+    Names are disambiguated when multiple DMD molecules share the same
+    name by appending the primary xref ID (e.g. UNIPROT:P02662).
+    All xrefs are added to the new entity's external_ids.
+    """
     molecules = _get_molecules(sources)
     if molecules is None:
         return
-    created_rows: list[dict] = []
+    xref_map = _get_xrefs(sources)
+
+    # Collect unlinked molecules grouped by name for disambiguation.
+    unlinked: list[tuple[str, pd.Series]] = []
     seen: set[str] = set()
     for _, row in molecules.iterrows():
         native = str(row["native_id"])
@@ -133,14 +175,41 @@ def create_unlinked_dmd(
             continue
         seen.add(native)
         if registry.resolve("dmd", native):
-            continue  # Handled in Pass 1 or 2.
-        fa_id = f"e{registry.next_eid}"
-        registry.register("dmd", native, fa_id)
-        data = _build_entity(native, row)
-        data["foodatlas_id"] = fa_id
-        created_rows.append(data)
-        if row["name"]:
-            lut.add("chemical", row["name"], fa_id)
+            continue
+        unlinked.append((native, row))
+
+    name_groups: dict[str, list[tuple[str, pd.Series]]] = {}
+    for native, row in unlinked:
+        name_groups.setdefault(row["name"], []).append((native, row))
+
+    existing_names: set[str] = set()
+    if not store._entities.empty:
+        existing_names = set(store._entities["common_name"].str.lower().unique())
+
+    created_rows: list[dict] = []
+    for name, group in name_groups.items():
+        needs_disambig = len(group) > 1 or name.lower() in existing_names
+        for native, row in group:
+            mol_xrefs = xref_map.get(native, {})
+
+            ext_ids: dict[str, list] = {"dmd": [native]}
+            for source, ids in mol_xrefs.items():
+                ext_ids[source] = list(dict.fromkeys(ids))
+
+            if needs_disambig:
+                suffix = _pick_display_xref(mol_xrefs, native)
+                display_name = f"{name} ({suffix})"
+            else:
+                display_name = name
+
+            fa_id = f"e{registry.next_eid}"
+            registry.register("dmd", native, fa_id)
+
+            data = _build_entity(row, ext_ids, display_name)
+            data["foodatlas_id"] = fa_id
+            created_rows.append(data)
+            if display_name:
+                lut.add("chemical", display_name, fa_id)
 
     store._curr_eid = registry.next_eid
     _append_entities(store, created_rows)

--- a/backend/kgc/src/pipeline/entities/resolve_dmd_helpers.py
+++ b/backend/kgc/src/pipeline/entities/resolve_dmd_helpers.py
@@ -1,0 +1,112 @@
+"""Shared helpers for DMD entity resolution."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+from ...models.entity import ChemicalEntity
+
+if TYPE_CHECKING:
+    from ...stores.entity_store import EntityStore
+
+# Preferred xref source order for display-name disambiguation.
+_XREF_PREF = ["uniprot", "chebi", "pubchem_cid", "kegg", "hmdb", "mirbase"]
+
+
+def _get_molecules(
+    sources: dict[str, dict[str, pd.DataFrame]],
+) -> pd.DataFrame | None:
+    dmd = sources.get("dmd")
+    if dmd is None:
+        return None
+    nodes = dmd["nodes"]
+    return nodes[nodes["node_type"] == "molecule"]
+
+
+def _get_xrefs(
+    sources: dict[str, dict[str, pd.DataFrame]],
+) -> dict[str, dict[str, list[str]]]:
+    """Build ``{dmd_native_id: {target_source: [target_ids]}}``."""
+    dmd = sources.get("dmd")
+    if dmd is None:
+        return {}
+    xrefs_df = dmd.get("xrefs", pd.DataFrame())
+    if xrefs_df.empty:
+        return {}
+    result: dict[str, dict[str, list[str]]] = {}
+    for _, row in xrefs_df.iterrows():
+        result.setdefault(row["native_id"], {}).setdefault(
+            row["target_source"], []
+        ).append(row["target_id"])
+    return result
+
+
+def _build_ext_index(store: EntityStore, key: str) -> dict[str, str]:
+    """Build ``{external_id_string: foodatlas_id}`` for *key*."""
+    result: dict[str, str] = {}
+    for eid, row in store._entities.iterrows():
+        for val in row["external_ids"].get(key, []):
+            result[str(val)] = str(eid)
+    return result
+
+
+def _pick_display_xref(
+    xrefs: dict[str, list[str]],
+    native_id: str,
+) -> str:
+    """Pick the best xref for a display-name suffix."""
+    for source in _XREF_PREF:
+        ids = xrefs.get(source, [])
+        if ids:
+            return f"{source.upper()}:{ids[0]}"
+    return native_id
+
+
+def _build_entity(
+    row: pd.Series,
+    external_ids: dict[str, list],
+    display_name: str,
+) -> dict[str, object]:
+    """Build an entity dict from a DMD molecule row."""
+    synonyms_raw = row.get("synonyms", [])
+    # Parquet returns numpy arrays, not Python lists.
+    if isinstance(synonyms_raw, np.ndarray):
+        synonyms_raw = synonyms_raw.tolist()
+    if not isinstance(synonyms_raw, list):
+        synonyms_raw = []
+
+    syns: list[str] = [display_name] if display_name else []
+    # Add original name as synonym if different from display name.
+    if row["name"] and row["name"] != display_name and row["name"] not in syns:
+        syns.append(row["name"])
+    # Add extra synonyms (chemical formula, protein sequence, etc.).
+    for s in synonyms_raw:
+        if s and s not in syns:
+            syns.append(s)
+
+    entity = ChemicalEntity(
+        foodatlas_id="",  # caller sets this
+        common_name=display_name,
+        synonyms=syns,
+        external_ids=external_ids,
+    )
+    result: dict[str, object] = entity.model_dump(by_alias=True)
+    return result
+
+
+def _append_entities(store: EntityStore, rows: list[dict]) -> None:
+    if rows:
+        new_df = pd.DataFrame(rows).set_index("foodatlas_id")
+        store._entities = pd.concat([store._entities, new_df])
+
+
+def _add_dmd_to_entity(store: EntityStore, fa_id: str, native: str) -> None:
+    """Append a DMD native ID to an existing entity's external_ids."""
+    ext = store._entities.at[fa_id, "external_ids"]
+    if "dmd" not in ext:
+        ext["dmd"] = []
+    if native not in ext["dmd"]:
+        ext["dmd"].append(native)

--- a/backend/kgc/src/pipeline/entities/resolve_dmd_helpers.py
+++ b/backend/kgc/src/pipeline/entities/resolve_dmd_helpers.py
@@ -10,6 +10,7 @@ import pandas as pd
 from ...models.entity import ChemicalEntity
 
 if TYPE_CHECKING:
+    from ...stores.entity_registry import EntityRegistry
     from ...stores.entity_store import EntityStore
 
 # Preferred xref source order for display-name disambiguation.
@@ -110,3 +111,23 @@ def _add_dmd_to_entity(store: EntityStore, fa_id: str, native: str) -> None:
         ext["dmd"] = []
     if native not in ext["dmd"]:
         ext["dmd"].append(native)
+
+
+def _collect_unlinked(
+    molecules: pd.DataFrame,
+    registry: EntityRegistry,
+    store: EntityStore,
+) -> list[tuple[str, pd.Series]]:
+    """Collect DMD molecules not yet resolved to an entity in the store."""
+    unlinked: list[tuple[str, pd.Series]] = []
+    seen: set[str] = set()
+    for _, row in molecules.iterrows():
+        native = str(row["native_id"])
+        if native in seen:
+            continue
+        seen.add(native)
+        existing_id = registry.resolve("dmd", native)
+        if existing_id and existing_id in store._entities.index:
+            continue
+        unlinked.append((native, row))
+    return unlinked

--- a/backend/kgc/src/pipeline/entities/resolver.py
+++ b/backend/kgc/src/pipeline/entities/resolver.py
@@ -111,11 +111,12 @@ class EntityResolver:
             m,
         )
         link_fdc_nutrients(sources, self._entity_store, self._linked_native_ids, reg, m)
-        link_dmd(sources, self._entity_store, reg)
         # PubChem and MeSH are cross-references, not entity identifiers.
         # They enrich external_ids but are not registered in the registry.
+        # Must run BEFORE link_dmd so DMD Tier 2 can match via pubchem_compound.
         link_pubchem_to_chebi(sources, self._entity_store)
         link_mesh_to_chebi(sources, self._entity_store)
+        link_dmd(sources, self._entity_store, reg)
         logger.info("Pass 2 complete: %d entities.", len(self._entity_store._entities))
 
     def _pass3_unlinked(self, sources: dict[str, dict[str, pd.DataFrame]]) -> None:

--- a/backend/kgc/src/pipeline/ie/conc_parser.py
+++ b/backend/kgc/src/pipeline/ie/conc_parser.py
@@ -1,13 +1,16 @@
-"""Parse raw IE concentration strings into (value, unit) pairs.
+"""Parse and convert raw IE concentration strings.
 
-Ported from ``examples/preprocessing/_standardize_chemical_conc.py`` with a
-lighter footprint: no pandas/numpy dependency, no unit conversion (that is a
-downstream concern for ``conc_value`` / ``conc_unit``).
+Parsing splits a raw string into ``(value, unit)``.
+Conversion normalises the parsed unit to ``mg/100g`` where possible.
 """
 
 from __future__ import annotations
 
 import re
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
 
 # Unicode dashes / range separators → kept as-is in the captured value.
 _DASH = r"[\u002d\u2010\u2011\u2012\u2013\u2014\u2015\u2212~\u223c]"
@@ -91,3 +94,145 @@ def parse_conc(raw: str) -> tuple[str, str] | None:
         unit_str = f"{unit_str} {weight}"
 
     return (value_str, unit_str)
+
+
+# ---------------------------------------------------------------------------
+# Conversion
+# ---------------------------------------------------------------------------
+
+# Mass units → grams.
+_MASS: dict[str, float] = {
+    "kg": 1e3,
+    "g": 1,
+    "grams": 1,
+    "mg": 1e-3,
+    "µg": 1e-6,
+    "ug": 1e-6,
+    "μg": 1e-6,
+    "ng": 1e-9,
+}
+
+# Volume units → litres.
+_VOLUME: dict[str, float] = {
+    "l": 1,
+    "ml": 1e-3,
+    "µl": 1e-6,
+    "ul": 1e-6,
+    "μl": 1e-6,
+}
+
+# Maximum plausible mg/100g (sanity check).
+_MAX_MG_100G = 1e5
+
+# Regex to split a denominator like "100g" into ("100", "g").
+_RE_DEN_FACTOR = re.compile(r"^(\d+)?(.+)$")
+
+# All dashes normalised to ASCII hyphen for range splitting.
+_RANGE_CHARS = re.compile("[\u2010-\u2015\u2212~\u223c]")
+
+
+def _resolve_numeric(value_str: str) -> float | None:
+    """Parse a value string that may contain a range or ± into a float."""
+    # Strip leading approximate markers.
+    s = value_str.lstrip("<>\u2248~\u223c")
+
+    # Strip ± deviation (take the central value).
+    if "±" in s or "\u00b1" in s:
+        s = re.split(r"[±\u00b1]", s)[0]
+
+    # Normalise range separators to ASCII hyphen.
+    s = _RANGE_CHARS.sub("-", s)
+
+    # Handle ranges → midpoint.
+    if "-" in s:
+        parts = s.split("-", 1)
+        try:
+            a, b = float(parts[0]), float(parts[1])
+        except ValueError:
+            return None
+        return (a + b) / 2
+
+    try:
+        return float(s)
+    except ValueError:
+        return None
+
+
+def _convert_unit(unit_str: str) -> float | None:
+    """Return the multiplier to convert ``(value, unit)`` to mg/100g.
+
+    Returns ``None`` for unconvertible units (molar, energy, etc.).
+    """
+    # Strip weight-type suffix (fw/dw) — already informational only.
+    clean = unit_str.strip()
+    for suffix, _ in _WEIGHT_TYPES:
+        if clean.lower().endswith(suffix):
+            clean = clean[: -len(suffix)].strip()
+            break
+
+    if clean == "%":
+        return None
+
+    parts = clean.split("/")
+    if len(parts) != 2:
+        return None
+
+    return _convert_ratio(parts[0].lower(), parts[1].lower())
+
+
+def _convert_ratio(num_unit: str, den_raw: str) -> float | None:
+    """Convert a mass/weight or mass/volume ratio to mg/100g multiplier."""
+    if num_unit not in _MASS:
+        return None
+
+    m = _RE_DEN_FACTOR.match(den_raw)
+    if not m:
+        return None
+    den_factor_str, den_unit = m.group(1), m.group(2)
+    den_factor = float(den_factor_str) if den_factor_str else 1.0
+
+    grams_per_num = _MASS[num_unit]
+
+    if den_unit in _MASS:
+        grams_per_den = _MASS[den_unit]
+        return (grams_per_num / grams_per_den) * (100 / den_factor) * 1e3
+    if den_unit in _VOLUME:
+        # Treat volume as weight (1ml ~ 1g for aqueous solutions).
+        grams_per_den = _VOLUME[den_unit] * 1e3
+        return (grams_per_num / grams_per_den) * (100 / den_factor) * 1e3
+
+    return None
+
+
+def convert_conc(value_str: str, unit_str: str) -> tuple[float, str] | None:
+    """Convert a parsed ``(value, unit)`` to ``(mg/100g_value, "mg/100g")``.
+
+    Returns ``None`` if the value or unit cannot be converted.
+
+    Examples::
+
+        >>> convert_conc("1.5", "mg/g")
+        (150.0, 'mg/100g')
+        >>> convert_conc("20\\u201350", "mg/100g")
+        (35.0, 'mg/100g')
+        >>> convert_conc("910", "mg/kg")
+        (91.0, 'mg/100g')
+        >>> convert_conc("45", "%")
+        (450000.0, 'mg/100g')
+    """
+    if not value_str or not unit_str:
+        return None
+
+    numeric = _resolve_numeric(value_str)
+    if numeric is None or numeric <= 0:
+        return None
+
+    multiplier = _convert_unit(unit_str)
+    if multiplier is None:
+        return None
+
+    result = numeric * multiplier
+    if result > _MAX_MG_100G:
+        return None
+
+    return (result, "mg/100g")

--- a/backend/kgc/src/pipeline/ie/loader.py
+++ b/backend/kgc/src/pipeline/ie/loader.py
@@ -9,8 +9,8 @@ from typing import TYPE_CHECKING
 import pandas as pd
 from tqdm import tqdm
 
-from ...stores.schema import FILE_IE_PARSE_ERRORS
-from .conc_parser import parse_conc
+from ...stores.schema import FILE_IE_CONC_ERRORS, FILE_IE_PARSE_ERRORS
+from .conc_parser import convert_conc, parse_conc
 from .constants import GREEK_LETTERS, PUNCTUATIONS
 
 if TYPE_CHECKING:
@@ -68,6 +68,83 @@ def _parse_tuple(line: str) -> tuple[str, str, str, str] | None:
     return food, food_part, chemical, quantity
 
 
+def _process_line(
+    line: str,
+    rec: pd.Series,
+    rows: list[dict],
+    parse_errors: list[dict],
+    conc_errors: list[dict],
+) -> None:
+    """Parse one response line into a row dict, or log an error."""
+    parsed = _parse_tuple(line)
+    if parsed is None:
+        parse_errors.append(
+            {"pmcid": rec["pmcid"], "line": line.strip(), "reason": "bad_tuple"}
+        )
+        return
+    food, food_part, chemical, quantity = parsed
+    conc_value_raw, conc_unit_raw = _parse_quantity(quantity, rec, parse_errors)
+    conc_value_converted, conc_unit_converted = _convert_quantity(
+        conc_value_raw, conc_unit_raw, rec, conc_errors
+    )
+    ref = json.dumps({"pmcid": rec["pmcid"], "text": rec.get("sentence", "")})
+    rows.append(
+        {
+            "source_type": "pubmed",
+            "reference": ref,
+            "source": "lit2kg",
+            "head_name_raw": standardize_name(food),
+            "tail_name_raw": standardize_name(chemical),
+            "conc_value": conc_value_converted,
+            "conc_unit": conc_unit_converted,
+            "conc_value_raw": conc_value_raw,
+            "conc_unit_raw": conc_unit_raw,
+            "food_part": food_part.strip().lower(),
+            "food_processing": "",
+            "quality_score": float(rec["prob"]),
+            "_food_name": standardize_name(food),
+            "_chemical_name": standardize_name(chemical),
+        }
+    )
+
+
+def _parse_quantity(
+    quantity: str, rec: pd.Series, parse_errors: list[dict]
+) -> tuple[str, str]:
+    """Parse a raw quantity string, logging errors."""
+    if not quantity:
+        return "", ""
+    conc_result = parse_conc(quantity)
+    if conc_result is None:
+        parse_errors.append(
+            {"pmcid": rec["pmcid"], "line": quantity, "reason": "bad_conc"}
+        )
+        return "", ""
+    return conc_result
+
+
+def _convert_quantity(
+    value_raw: str,
+    unit_raw: str,
+    rec: pd.Series,
+    conc_errors: list[dict],
+) -> tuple[float | None, str]:
+    """Convert parsed concentration to mg/100g, logging failures."""
+    if not value_raw or not unit_raw:
+        return None, ""
+    converted = convert_conc(value_raw, unit_raw)
+    if converted is not None:
+        return converted
+    conc_errors.append(
+        {
+            "pmcid": rec["pmcid"],
+            "value_raw": value_raw,
+            "unit_raw": unit_raw,
+        }
+    )
+    return None, ""
+
+
 def load_ie_raw(path: Path, output_dir: Path) -> pd.DataFrame:
     """Parse raw IE file (TSV or pkl) into a MetadataContains-compatible DataFrame.
 
@@ -87,6 +164,7 @@ def load_ie_raw(path: Path, output_dir: Path) -> pd.DataFrame:
 
     rows: list[dict] = []
     parse_errors: list[dict] = []
+    conc_errors: list[dict] = []
     for _, rec in tqdm(raw.iterrows(), total=len(raw), desc="parsing IE", leave=True):
         response = rec["response"]
         if not isinstance(response, str):
@@ -95,50 +173,20 @@ def load_ie_raw(path: Path, output_dir: Path) -> pd.DataFrame:
             )
             continue
         for line in response.split("\n"):
-            parsed = _parse_tuple(line)
-            if parsed is None:
-                parse_errors.append(
-                    {"pmcid": rec["pmcid"], "line": line.strip(), "reason": "bad_tuple"}
-                )
-                continue
-            food, food_part, chemical, quantity = parsed
-            conc_value_raw, conc_unit_raw = "", ""
-            if quantity:
-                conc_result = parse_conc(quantity)
-                if conc_result is None:
-                    parse_errors.append(
-                        {"pmcid": rec["pmcid"], "line": quantity, "reason": "bad_conc"}
-                    )
-                else:
-                    conc_value_raw, conc_unit_raw = conc_result
-            ref = json.dumps({"pmcid": rec["pmcid"], "text": rec.get("sentence", "")})
-            rows.append(
-                {
-                    # Evidence fields
-                    "source_type": "pubmed",
-                    "reference": ref,
-                    # Attestation fields
-                    "source": "lit2kg",
-                    "head_name_raw": standardize_name(food),
-                    "tail_name_raw": standardize_name(chemical),
-                    "conc_value": None,
-                    "conc_unit": "",
-                    "conc_value_raw": conc_value_raw,
-                    "conc_unit_raw": conc_unit_raw,
-                    "food_part": food_part.strip().lower(),
-                    "food_processing": "",
-                    "quality_score": float(rec["prob"]),
-                    # Kept for IE resolver (name lookup)
-                    "_food_name": standardize_name(food),
-                    "_chemical_name": standardize_name(chemical),
-                }
-            )
+            _process_line(line, rec, rows, parse_errors, conc_errors)
 
     if parse_errors:
         errors_path = output_dir / FILE_IE_PARSE_ERRORS
         errors_path.parent.mkdir(exist_ok=True)
         pd.DataFrame(parse_errors).to_csv(errors_path, sep="\t", index=False)
         logger.warning("%d parse errors written to %s.", len(parse_errors), errors_path)
+    if conc_errors:
+        conc_path = output_dir / FILE_IE_CONC_ERRORS
+        conc_path.parent.mkdir(exist_ok=True)
+        pd.DataFrame(conc_errors).to_csv(conc_path, sep="\t", index=False)
+        logger.warning(
+            "%d unconverted concentrations written to %s.", len(conc_errors), conc_path
+        )
     logger.info("Parsed %d IE tuples from %s.", len(rows), path)
 
     return pd.DataFrame(rows) if rows else pd.DataFrame()

--- a/backend/kgc/src/stores/schema.py
+++ b/backend/kgc/src/stores/schema.py
@@ -44,4 +44,5 @@ ATTESTATION_COLUMNS = _get_columns(Attestation)
 DIR_DIAGNOSTICS = "diagnostics"
 FILE_IE_UNRESOLVED = "diagnostics/ie_unresolved.jsonl"
 FILE_IE_PARSE_ERRORS = "diagnostics/ie_parse_errors.tsv"
+FILE_IE_CONC_ERRORS = "diagnostics/ie_conc_unconverted.tsv"
 FILE_ATTESTATIONS_AMBIGUOUS = "attestations_ambiguous.parquet"

--- a/backend/kgc/tests/test_conc_parser.py
+++ b/backend/kgc/tests/test_conc_parser.py
@@ -1,7 +1,7 @@
-"""Tests for conc_parser — splitting raw concentration strings."""
+"""Tests for conc_parser — splitting and converting raw concentration strings."""
 
 import pytest
-from src.pipeline.ie.conc_parser import parse_conc
+from src.pipeline.ie.conc_parser import convert_conc, parse_conc
 
 
 class TestParseConc:
@@ -65,3 +65,68 @@ class TestParseConc:
     )
     def test_qualitative_strings_unparseable(self, raw: str) -> None:
         assert parse_conc(raw) is None
+
+
+class TestConvertConc:
+    def test_mg_per_g(self) -> None:
+        val, unit = convert_conc("1.5", "mg/g")
+        assert unit == "mg/100g"
+        assert abs(val - 150.0) < 0.01
+
+    def test_mg_per_kg(self) -> None:
+        val, unit = convert_conc("910", "mg/kg")
+        assert unit == "mg/100g"
+        assert abs(val - 91.0) < 0.01
+
+    def test_mg_per_100g_passthrough(self) -> None:
+        val, unit = convert_conc("315.1", "mg/100g")
+        assert unit == "mg/100g"
+        assert abs(val - 315.1) < 0.01
+
+    def test_ug_per_g(self) -> None:
+        val, unit = convert_conc("60", "µg/g")
+        assert unit == "mg/100g"
+        assert abs(val - 6.0) < 0.01
+
+    def test_percentage_not_converted(self) -> None:
+        assert convert_conc("5", "%") is None
+
+    def test_range_midpoint(self) -> None:
+        val, unit = convert_conc("20\u201350", "mg/100g")
+        assert unit == "mg/100g"
+        assert abs(val - 35.0) < 0.01
+
+    def test_plus_minus_strips_deviation(self) -> None:
+        val, unit = convert_conc("0.3\u00b10.1", "mg/g")
+        assert unit == "mg/100g"
+        assert abs(val - 30.0) < 0.01
+
+    def test_approx_stripped(self) -> None:
+        val, unit = convert_conc("<0.01", "mg/g")
+        assert unit == "mg/100g"
+        assert abs(val - 1.0) < 0.01
+
+    def test_fw_suffix_ignored(self) -> None:
+        val, unit = convert_conc("12.5", "mg/100g fw")
+        assert unit == "mg/100g"
+        assert abs(val - 12.5) < 0.01
+
+    def test_volume_denominator(self) -> None:
+        val, unit = convert_conc("50", "mg/ml")
+        assert unit == "mg/100g"
+        assert abs(val - 5000.0) < 0.01
+
+    def test_empty_value_returns_none(self) -> None:
+        assert convert_conc("", "mg/g") is None
+
+    def test_empty_unit_returns_none(self) -> None:
+        assert convert_conc("1.5", "") is None
+
+    def test_molar_unit_returns_none(self) -> None:
+        assert convert_conc("1.5", "mmol/l") is None
+
+    def test_bare_mass_returns_none(self) -> None:
+        assert convert_conc("1.5", "mg") is None
+
+    def test_exceeds_max_returns_none(self) -> None:
+        assert convert_conc("999999", "mg/g") is None

--- a/backend/kgc/tests/test_resolve_dmd.py
+++ b/backend/kgc/tests/test_resolve_dmd.py
@@ -89,21 +89,9 @@ _PUBCHEM_ENTITY = {
 
 
 class TestCreateChemicalsFromDmd:
-    """Pass 1: create entities for seeded DMD IDs not yet in the store."""
+    """Pass 1: enrich existing entities with DMD IDs (seeded only)."""
 
-    def test_creates_at_seeded_id(
-        self, tmp_path: Path, registry: EntityRegistry
-    ) -> None:
-        store = _make_store(tmp_path, [])
-        registry.register("dmd", "DMD001", "e50")
-        lut = EntityLUT()
-        create_chemicals_from_dmd(
-            _dmd_sources([("DMD001", "newchem")]), store, lut, registry
-        )
-        assert len(store._entities) == 1
-        assert store._entities.index[0] == "e50"
-
-    def test_skips_if_entity_already_in_store(
+    def test_enriches_existing_entity(
         self, tmp_path: Path, registry: EntityRegistry
     ) -> None:
         store = _make_store(tmp_path, [_CHEBI_ENTITY])
@@ -113,6 +101,19 @@ class TestCreateChemicalsFromDmd:
             _dmd_sources([("DMD001", "caffeine")]), store, lut, registry
         )
         assert len(store._entities) == 1
+        assert "DMD001" in store._entities.at["e1", "external_ids"]["dmd"]
+
+    def test_skips_dmd_only_seed(
+        self, tmp_path: Path, registry: EntityRegistry
+    ) -> None:
+        """Seeded DMD molecule with no existing entity → skip to Pass 2/3."""
+        store = _make_store(tmp_path, [])
+        registry.register("dmd", "DMD001", "e50")
+        lut = EntityLUT()
+        create_chemicals_from_dmd(
+            _dmd_sources([("DMD001", "newchem")]), store, lut, registry
+        )
+        assert len(store._entities) == 0
 
     def test_skips_unregistered(self, tmp_path: Path, registry: EntityRegistry) -> None:
         store = _make_store(tmp_path, [])
@@ -238,12 +239,16 @@ class TestCreateUnlinkedDmd:
         assert len(store._entities) == 1
         assert store._entities.iloc[0]["entity_type"] == "chemical"
 
-    def test_skips_registered(self, tmp_path: Path, registry: EntityRegistry) -> None:
+    def test_creates_seeded_dmd_only(
+        self, tmp_path: Path, registry: EntityRegistry
+    ) -> None:
+        """Seeded DMD molecule not linked in Pass 2 → created here with seeded ID."""
         store = _make_store(tmp_path, [])
         registry.register("dmd", "DMD001", "e50")
         lut = EntityLUT()
         create_unlinked_dmd(_dmd_sources([("DMD001", "chem")]), store, lut, registry)
-        assert len(store._entities) == 0
+        assert len(store._entities) == 1
+        assert store._entities.index[0] == "e50"
 
     def test_deduplicates(self, tmp_path: Path, registry: EntityRegistry) -> None:
         store = _make_store(tmp_path, [])

--- a/backend/kgc/tests/test_resolve_dmd.py
+++ b/backend/kgc/tests/test_resolve_dmd.py
@@ -53,12 +53,20 @@ def _make_store(tmp_path: Path, entities: list[dict]) -> EntityStore:
 
 def _dmd_sources(
     names: list[tuple[str, str]],
+    xrefs: list[dict] | None = None,
 ) -> dict[str, dict[str, pd.DataFrame]]:
     rows = [
         {"native_id": nid, "name": name, "node_type": "molecule", "synonyms": [name]}
         for nid, name in names
     ]
-    return {"dmd": {"nodes": pd.DataFrame(rows)}}
+    result: dict[str, pd.DataFrame] = {"nodes": pd.DataFrame(rows)}
+    if xrefs:
+        result["xrefs"] = pd.DataFrame(xrefs)
+    else:
+        result["xrefs"] = pd.DataFrame(
+            columns=["source_id", "native_id", "target_source", "target_id"]
+        )
+    return {"dmd": result}
 
 
 _CHEBI_ENTITY = {
@@ -67,6 +75,15 @@ _CHEBI_ENTITY = {
     "common_name": "caffeine",
     "synonyms": ["caffeine"],
     "external_ids": {"chebi": [123]},
+    "scientific_name": "",
+}
+
+_PUBCHEM_ENTITY = {
+    "foodatlas_id": "e2",
+    "entity_type": "chemical",
+    "common_name": "glucose",
+    "synonyms": ["glucose"],
+    "external_ids": {"chebi": [456], "pubchem_compound": [5793]},
     "scientific_name": "",
 }
 
@@ -95,7 +112,6 @@ class TestCreateChemicalsFromDmd:
         create_chemicals_from_dmd(
             _dmd_sources([("DMD001", "caffeine")]), store, lut, registry
         )
-        # Should not create — entity exists (enrichment is Pass 2).
         assert len(store._entities) == 1
 
     def test_skips_unregistered(self, tmp_path: Path, registry: EntityRegistry) -> None:
@@ -104,27 +120,112 @@ class TestCreateChemicalsFromDmd:
         create_chemicals_from_dmd(
             _dmd_sources([("DMD999", "new")]), store, lut, registry
         )
-        # No registry entry — creation is Pass 3.
         assert len(store._entities) == 0
 
 
 class TestLinkDmd:
-    """Pass 2: enrich existing entities with DMD external IDs."""
+    """Pass 2: link DMD molecules to existing entities via xrefs."""
 
-    def test_enriches_existing(self, tmp_path: Path, registry: EntityRegistry) -> None:
+    def test_links_via_chebi(self, tmp_path: Path, registry: EntityRegistry) -> None:
         store = _make_store(tmp_path, [_CHEBI_ENTITY])
-        registry.register("dmd", "DMD001", "e1")
-        link_dmd(_dmd_sources([("DMD001", "caffeine")]), store, registry)
+        xrefs = [
+            {
+                "source_id": "dmd",
+                "native_id": "DMD001",
+                "target_source": "chebi",
+                "target_id": "123",
+            }
+        ]
+        link_dmd(_dmd_sources([("DMD001", "caffeine")], xrefs), store, registry)
         ext = store._entities.at["e1", "external_ids"]
         assert "DMD001" in ext["dmd"]
 
-    def test_skips_missing_entity(
+    def test_links_via_pubchem(self, tmp_path: Path, registry: EntityRegistry) -> None:
+        store = _make_store(tmp_path, [_PUBCHEM_ENTITY])
+        xrefs = [
+            {
+                "source_id": "dmd",
+                "native_id": "DMD002",
+                "target_source": "pubchem_cid",
+                "target_id": "5793",
+            }
+        ]
+        link_dmd(_dmd_sources([("DMD002", "glucose")], xrefs), store, registry)
+        ext = store._entities.at["e2", "external_ids"]
+        assert "DMD002" in ext["dmd"]
+
+    def test_chebi_preferred_over_pubchem(
         self, tmp_path: Path, registry: EntityRegistry
     ) -> None:
-        store = _make_store(tmp_path, [])
-        registry.register("dmd", "DMD001", "e99")
-        link_dmd(_dmd_sources([("DMD001", "caffeine")]), store, registry)
-        assert len(store._entities) == 0
+        """If both ChEBI and PubChem match, ChEBI wins."""
+        store = _make_store(tmp_path, [_CHEBI_ENTITY, _PUBCHEM_ENTITY])
+        xrefs = [
+            {
+                "source_id": "dmd",
+                "native_id": "DMD003",
+                "target_source": "chebi",
+                "target_id": "123",
+            },
+            {
+                "source_id": "dmd",
+                "native_id": "DMD003",
+                "target_source": "pubchem_cid",
+                "target_id": "5793",
+            },
+        ]
+        link_dmd(_dmd_sources([("DMD003", "chem")], xrefs), store, registry)
+        # Should link to e1 (ChEBI), not e2 (PubChem).
+        assert "DMD003" in store._entities.at["e1", "external_ids"]["dmd"]
+        assert "dmd" not in store._entities.at["e2", "external_ids"]
+
+    def test_ambiguous_chebi_links_all(
+        self, tmp_path: Path, registry: EntityRegistry
+    ) -> None:
+        """Multiple ChEBI IDs → multiple entities: link to all."""
+        entity_a = {
+            **_CHEBI_ENTITY,
+            "foodatlas_id": "e10",
+            "external_ids": {"chebi": [100]},
+        }
+        entity_b = {
+            **_CHEBI_ENTITY,
+            "foodatlas_id": "e11",
+            "common_name": "caffeine-d",
+            "external_ids": {"chebi": [200]},
+        }
+        store = _make_store(tmp_path, [entity_a, entity_b])
+        xrefs = [
+            {
+                "source_id": "dmd",
+                "native_id": "DMD004",
+                "target_source": "chebi",
+                "target_id": "100",
+            },
+            {
+                "source_id": "dmd",
+                "native_id": "DMD004",
+                "target_source": "chebi",
+                "target_id": "200",
+            },
+        ]
+        link_dmd(_dmd_sources([("DMD004", "chem")], xrefs), store, registry)
+        assert "DMD004" in store._entities.at["e10", "external_ids"]["dmd"]
+        assert "DMD004" in store._entities.at["e11", "external_ids"]["dmd"]
+
+    def test_skips_registered(self, tmp_path: Path, registry: EntityRegistry) -> None:
+        store = _make_store(tmp_path, [_CHEBI_ENTITY])
+        registry.register("dmd", "DMD001", "e1")
+        xrefs = [
+            {
+                "source_id": "dmd",
+                "native_id": "DMD001",
+                "target_source": "chebi",
+                "target_id": "123",
+            }
+        ]
+        link_dmd(_dmd_sources([("DMD001", "caffeine")], xrefs), store, registry)
+        # Already registered — skipped by Pass 2.
+        assert "dmd" not in store._entities.at["e1", "external_ids"]
 
 
 class TestCreateUnlinkedDmd:
@@ -142,7 +243,6 @@ class TestCreateUnlinkedDmd:
         registry.register("dmd", "DMD001", "e50")
         lut = EntityLUT()
         create_unlinked_dmd(_dmd_sources([("DMD001", "chem")]), store, lut, registry)
-        # Has registry entry — handled in Pass 1.
         assert len(store._entities) == 0
 
     def test_deduplicates(self, tmp_path: Path, registry: EntityRegistry) -> None:
@@ -151,3 +251,84 @@ class TestCreateUnlinkedDmd:
         sources = _dmd_sources([("DMD001", "c"), ("DMD001", "c")])
         create_unlinked_dmd(sources, store, lut, registry)
         assert len(store._entities) == 1
+
+    def test_disambiguates_duplicate_names(
+        self, tmp_path: Path, registry: EntityRegistry
+    ) -> None:
+        store = _make_store(tmp_path, [])
+        lut = EntityLUT()
+        xrefs = [
+            {
+                "source_id": "dmd",
+                "native_id": "DMD001",
+                "target_source": "uniprot",
+                "target_id": "P02662",
+            },
+            {
+                "source_id": "dmd",
+                "native_id": "DMD002",
+                "target_source": "uniprot",
+                "target_id": "A0A3Q1NG86",
+            },
+        ]
+        sources = _dmd_sources(
+            [("DMD001", "Alpha-S1-casein"), ("DMD002", "Alpha-S1-casein")],
+            xrefs,
+        )
+        create_unlinked_dmd(sources, store, lut, registry)
+        assert len(store._entities) == 2
+        names = sorted(store._entities["common_name"].tolist())
+        assert names == [
+            "Alpha-S1-casein (UNIPROT:A0A3Q1NG86)",
+            "Alpha-S1-casein (UNIPROT:P02662)",
+        ]
+
+    def test_disambiguates_against_existing_name(
+        self, tmp_path: Path, registry: EntityRegistry
+    ) -> None:
+        existing = {
+            **_CHEBI_ENTITY,
+            "foodatlas_id": "e100",
+            "common_name": "glucose",
+            "external_ids": {"chebi": [999]},
+        }
+        store = _make_store(tmp_path, [existing])
+        lut = EntityLUT()
+        xrefs = [
+            {
+                "source_id": "dmd",
+                "native_id": "DMD005",
+                "target_source": "kegg",
+                "target_id": "C00031",
+            }
+        ]
+        sources = _dmd_sources([("DMD005", "glucose")], xrefs)
+        create_unlinked_dmd(sources, store, lut, registry)
+        new_entity = store._entities.loc[store._entities.index != "e100"].iloc[0]
+        assert new_entity["common_name"] == "glucose (KEGG:C00031)"
+
+    def test_adds_all_xrefs_to_new_entity(
+        self, tmp_path: Path, registry: EntityRegistry
+    ) -> None:
+        store = _make_store(tmp_path, [])
+        lut = EntityLUT()
+        xrefs = [
+            {
+                "source_id": "dmd",
+                "native_id": "DMD010",
+                "target_source": "uniprot",
+                "target_id": "P12345",
+            },
+            {
+                "source_id": "dmd",
+                "native_id": "DMD010",
+                "target_source": "kegg",
+                "target_id": "K00001",
+            },
+        ]
+        sources = _dmd_sources([("DMD010", "someprot")], xrefs)
+        create_unlinked_dmd(sources, store, lut, registry)
+        ext = store._entities.iloc[0]["external_ids"]
+        assert ext["dmd"] == ["DMD010"]
+        assert ext["uniprot"] == ["P12345"]
+        assert ext["kegg"] == ["K00001"]

--- a/frontend/components/entities/CorrelationTable.tsx
+++ b/frontend/components/entities/CorrelationTable.tsx
@@ -67,9 +67,6 @@ const CorrelationTable = ({
     setSelectedEvidenceName(name);
   };
 
-  // calculate the number of empty rows needed
-  const emptyRowsCount = data ? 20 - data?.length : 20;
-
   return (
     <>
       <div>
@@ -103,7 +100,7 @@ const CorrelationTable = ({
             <tbody className="font-light">
               {isLoading ? (
                 // loading skeleton
-                Array.from({ length: 20 }, (_, index) => (
+                Array.from({ length: 10 }, (_, index) => (
                   <tr key={index}>
                     <td className="w-full py-3" colSpan={headers.length}>
                       <div className="h-12 flex items-center">
@@ -196,16 +193,6 @@ const CorrelationTable = ({
                   </td>
                 </tr>
               )}
-              {/* add empty rows to make up for the total of 20 rows */}
-              {numberOfPages > 1 &&
-                !isLoading &&
-                Array.from({ length: emptyRowsCount }, (_, index) => (
-                  <tr key={index}>
-                    <td className="py-3" colSpan={headers.length}>
-                      <div className="h-12" />
-                    </td>
-                  </tr>
-                ))}
             </tbody>
           </table>
         </div>

--- a/frontend/components/entities/food/DmdEvidence.tsx
+++ b/frontend/components/entities/food/DmdEvidence.tsx
@@ -4,13 +4,6 @@ import Card from "@/components/basic/Card";
 import { FoodEvidence } from "@/types/Evidence";
 import { formatConcentrationValueAlt } from "@/utils/utils";
 
-const HEADERS = [
-  { label: "Extracted Food" },
-  { label: "Extracted Chemical" },
-  { label: "Extracted Concentration" },
-  { label: "Converted Concentration" },
-];
-
 type DmdEvidenceProps = {
   evidence: FoodEvidence;
 };
@@ -20,91 +13,73 @@ const DmdEvidence = ({ evidence }: DmdEvidenceProps) => {
     <Card className="bg-light-900">
       {/* source & link */}
       <div className="flex justify-between items-center">
-        {/* source */}
         <Badge
           size="xs"
           color="text-sky-600 border-sky-600 bg-sky-600/10 shadow-sky-700"
         >
           Dairy Molecule Database
         </Badge>
-        {/* link */}
         <Link className="text-xs" href={evidence.reference.url}>
           View Source
         </Link>
       </div>
       {/* extraction table */}
-      <table className="mt-5 text-xs w-full border-collapse table-fixed md:table block">
-        {/* table header */}
-        <thead className="md:table-header-group hidden">
-          <tr>
-            {HEADERS.map((header, index) => (
-              <th
-                key={index}
-                className={`text-light-400 uppercase font-normal text-left pb-2 first:pr-1 last:pl-1 [&:not(:first-child):not(:last-child)]:px-1 border-b border-light-700 leading-tight`}
-              >
-                {header.label}
+      <div className="mt-5 overflow-x-auto">
+        <table className="text-xs w-full table-fixed">
+          <colgroup>
+            <col className="w-[22%]" />
+            <col className="w-[22%]" />
+            <col className="w-[18%]" />
+            <col className="w-[25%]" />
+            <col className="w-[13%]" />
+          </colgroup>
+          <thead>
+            <tr className="border-b border-light-700">
+              <th className="text-light-400 uppercase font-normal text-left pb-2 pr-4">
+                Food
               </th>
-            ))}
-          </tr>
-        </thead>
-        {/* table body */}
-        <tbody className="block md:table-row-group">
-          {evidence.extraction.map((extraction, index) => (
-            <>
-              <tr
-                key={index}
-                className="last:border-b-0 md:border-light-700 md:table-row flex flex-col"
-              >
-                {/* extracted food */}
-                <td className="py-1.5 border-light-600/10 grid grid-cols-[auto,1fr] gap-4 items-center md:pr-1 md:table-cell">
-                  <span className="text-light-400 italic font-mono md:hidden">
-                    Extracted Food
-                  </span>
-                  <span className="text-right md:text-left break-all">
-                    {extraction.extracted_food_name}
-                  </span>
+              <th className="text-light-400 uppercase font-normal text-left pb-2 px-4">
+                Chemical
+              </th>
+              <th className="text-light-400 uppercase font-normal text-right pb-2 px-4">
+                Concentration
+              </th>
+              <th className="text-light-400 uppercase font-normal text-right pb-2 px-4">
+                Converted Concentration
+              </th>
+              <th className="text-light-400 uppercase font-normal text-right pb-2 pl-4">
+                Method
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {evidence.extraction.map((extraction, index) => (
+              <tr key={index}>
+                <td className="py-2 pr-4 break-all">
+                  {extraction.extracted_food_name}
                 </td>
-                {/* extracted chemical */}
-                <td className="py-1.5 border-light-600/10 grid grid-cols-[auto,1fr] gap-4 items-center md:px-1 md:table-cell ">
-                  <span className="text-light-400 italic font-mono md:hidden">
-                    Extracted Chemical
-                  </span>
-                  <span className="text-right md:text-left break-all">
-                    {extraction.extracted_chemical_name}
-                  </span>
+                <td className="py-2 px-4 break-all">
+                  {extraction.extracted_chemical_name}
                 </td>
-                {/* extracted concentration */}
-                <td className="py-1.5 border-light-600/10  grid grid-cols-[auto,1fr] gap-4 items-center md:px-1 md:table-cell">
-                  <span className="text-light-400 italic font-mono md:hidden">
-                    Extracted Concentration
-                  </span>
-                  <span className="text-right md:text-left break-all">
-                    {extraction.extracted_concentration ?? "n/a"}
-                  </span>
+                <td className="py-2 px-4 text-right whitespace-nowrap">
+                  {extraction.extracted_concentration ?? "n/a"}
                 </td>
-                {/* converted concentration */}
-                <td className="py-1.5 border-light-600/10 grid grid-cols-[auto,1fr] gap-4 items-center md:px-1 md:table-cell">
-                  <span className="text-light-400 italic font-mono md:hidden">
-                    Converted Concentration
-                  </span>
-                  <span className="text-right break-all md:text-left">
-                    {extraction.converted_concentration.unit &&
-                    extraction.converted_concentration.value
-                      ? `${formatConcentrationValueAlt(
-                          extraction.converted_concentration.value
-                        )} ${extraction.converted_concentration.unit}`
-                      : "n/a"}
-                  </span>
+                <td className="py-2 px-4 text-right whitespace-nowrap">
+                  {extraction.converted_concentration.unit &&
+                  extraction.converted_concentration.value
+                    ? `${formatConcentrationValueAlt(
+                        extraction.converted_concentration.value
+                      )} ${extraction.converted_concentration.unit}`
+                    : "n/a"}
+                </td>
+                <td className="py-2 pl-4 text-right uppercase whitespace-nowrap">
+                  {extraction.method}
                 </td>
               </tr>
-              {/* divider when smaller than md */}
-              {index < evidence.extraction.length - 1 && (
-                <hr className="my-2 border-light-600 md:hidden" />
-              )}
-            </>
-          ))}
-        </tbody>
-      </table>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </Card>
   );
 };

--- a/frontend/components/entities/food/FdcEvidence.tsx
+++ b/frontend/components/entities/food/FdcEvidence.tsx
@@ -4,14 +4,6 @@ import Card from "@/components/basic/Card";
 import { FoodEvidence } from "@/types/Evidence";
 import { formatConcentrationValueAlt } from "@/utils/utils";
 
-const HEADERS = [
-  { label: "Extracted Food" },
-  { label: "Extracted Chemical" },
-  { label: "Extracted Concentration" },
-  { label: "Converted Concentration" },
-  { label: "Method" },
-];
-
 type FdcEvidenceProps = {
   evidence: FoodEvidence;
 };
@@ -21,100 +13,73 @@ const FdcEvidence = ({ evidence }: FdcEvidenceProps) => {
     <Card className="bg-light-900">
       {/* source & link */}
       <div className="flex justify-between items-center">
-        {/* source */}
         <Badge
           size="xs"
           color="text-sky-600 border-sky-600 bg-sky-600/10 shadow-sky-700"
         >
           FDC Database
         </Badge>
-        {/* link */}
         <Link className="text-xs" href={evidence.reference.url}>
           View Source
         </Link>
       </div>
       {/* extraction table */}
-      <table className="mt-5 text-xs w-full border-collapse table-fixed md:table block">
-        {/* table header */}
-        <thead className="md:table-header-group hidden">
-          <tr>
-            {HEADERS.map((header, index) => (
-              <th
-                key={index}
-                className={`text-light-400 uppercase font-normal text-left pb-2 first:pr-1 last:pl-1 [&:not(:first-child):not(:last-child)]:px-1 border-b border-light-700 leading-tight`}
-              >
-                {header.label}
+      <div className="mt-5 overflow-x-auto">
+        <table className="text-xs w-full table-fixed">
+          <colgroup>
+            <col className="w-[22%]" />
+            <col className="w-[22%]" />
+            <col className="w-[18%]" />
+            <col className="w-[25%]" />
+            <col className="w-[13%]" />
+          </colgroup>
+          <thead>
+            <tr className="border-b border-light-700">
+              <th className="text-light-400 uppercase font-normal text-left pb-2 pr-4">
+                Food
               </th>
-            ))}
-          </tr>
-        </thead>
-        {/* table body */}
-        <tbody className="block md:table-row-group">
-          {evidence.extraction.map((extraction, index) => (
-            <>
-              <tr
-                key={index}
-                className="last:border-b-0 md:border-light-700 md:table-row flex flex-col"
-              >
-                {/* extracted food */}
-                <td className="py-1.5 border-light-600/10 grid grid-cols-[auto,1fr] gap-4 items-center md:pr-1 md:table-cell">
-                  <span className="text-light-400 italic font-mono md:hidden">
-                    Extracted Food
-                  </span>
-                  <span className="text-right md:text-left break-all">
-                    {extraction.extracted_food_name}
-                  </span>
+              <th className="text-light-400 uppercase font-normal text-left pb-2 px-4">
+                Chemical
+              </th>
+              <th className="text-light-400 uppercase font-normal text-right pb-2 px-4">
+                Concentration
+              </th>
+              <th className="text-light-400 uppercase font-normal text-right pb-2 px-4">
+                Converted Concentration
+              </th>
+              <th className="text-light-400 uppercase font-normal text-right pb-2 pl-4">
+                Method
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {evidence.extraction.map((extraction, index) => (
+              <tr key={index}>
+                <td className="py-2 pr-4 break-all">
+                  {extraction.extracted_food_name}
                 </td>
-                {/* extracted chemical */}
-                <td className="py-1.5 border-light-600/10 grid grid-cols-[auto,1fr] gap-4 items-center md:px-1 md:table-cell ">
-                  <span className="text-light-400 italic font-mono md:hidden">
-                    Extracted Chemical
-                  </span>
-                  <span className="text-right md:text-left break-all">
-                    {extraction.extracted_chemical_name}
-                  </span>
+                <td className="py-2 px-4 break-all">
+                  {extraction.extracted_chemical_name}
                 </td>
-                {/* extracted concentration */}
-                <td className="py-1.5 border-light-600/10  grid grid-cols-[auto,1fr] gap-4 items-center md:px-1 md:table-cell">
-                  <span className="text-light-400 italic font-mono md:hidden">
-                    Extracted Concentration
-                  </span>
-                  <span className="text-right md:text-left break-all">
-                    {extraction.extracted_concentration ?? "n/a"}
-                  </span>
+                <td className="py-2 px-4 text-right whitespace-nowrap">
+                  {extraction.extracted_concentration ?? "n/a"}
                 </td>
-                {/* converted concentration */}
-                <td className="py-1.5 border-light-600/10 grid grid-cols-[auto,1fr] gap-4 items-center md:px-1 md:table-cell">
-                  <span className="text-light-400 italic font-mono md:hidden">
-                    Converted Concentration
-                  </span>
-                  <span className="text-right break-all md:text-left">
-                    {extraction.converted_concentration.unit &&
-                    extraction.converted_concentration.value
-                      ? `${formatConcentrationValueAlt(
-                          extraction.converted_concentration.value
-                        )} ${extraction.converted_concentration.unit}`
-                      : "n/a"}
-                  </span>
+                <td className="py-2 px-4 text-right whitespace-nowrap">
+                  {extraction.converted_concentration.unit &&
+                  extraction.converted_concentration.value
+                    ? `${formatConcentrationValueAlt(
+                        extraction.converted_concentration.value
+                      )} ${extraction.converted_concentration.unit}`
+                    : "n/a"}
                 </td>
-                {/* method */}
-                <td className="py-1.5 grid grid-cols-[auto,1fr] gap-4 items-center md:pl-1 md:table-cell ">
-                  <span className="text-light-400 italic font-mono md:hidden">
-                    Method
-                  </span>
-                  <span className="text-right break-all md:text-left">
-                    {extraction.method}
-                  </span>
+                <td className="py-2 pl-4 text-right uppercase whitespace-nowrap">
+                  {extraction.method}
                 </td>
               </tr>
-              {/* divider when smaller than md */}
-              {index < evidence.extraction.length - 1 && (
-                <hr className="my-2 border-light-600 md:hidden" />
-              )}
-            </>
-          ))}
-        </tbody>
-      </table>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </Card>
   );
 };

--- a/frontend/components/entities/food/FoodAtlasEvidence.tsx
+++ b/frontend/components/entities/food/FoodAtlasEvidence.tsx
@@ -4,14 +4,6 @@ import Card from "@/components/basic/Card";
 import { FoodEvidence } from "@/types/Evidence";
 import { formatConcentrationValueAlt } from "@/utils/utils";
 
-const HEADERS = [
-  { label: "Method" },
-  { label: "Extracted Food" },
-  { label: "Extracted Chemical" },
-  { label: "Extracted Concentration" },
-  { label: "Converted Concentration" },
-];
-
 type FoodAtlasEvidenceProps = {
   evidence: FoodEvidence;
 };
@@ -21,9 +13,7 @@ const FoodAtlasEvidence = ({ evidence }: FoodAtlasEvidenceProps) => {
     <Card className="bg-light-900">
       {/* source & link */}
       <div className="flex justify-between items-center">
-        {/* source */}
         <Badge size="xs">FoodAtlas-Extraction</Badge>
-        {/* link */}
         <Link className="text-xs" href={evidence.reference.url}>
           View Paper
         </Link>
@@ -83,85 +73,63 @@ const FoodAtlasEvidence = ({ evidence }: FoodAtlasEvidenceProps) => {
             return part;
           })}
       </p>
-      {/* extraction */}
-      {evidence.extraction.map((extraction, index) => (
-        <div key={index}>
-          <table className="mt-5 text-xs w-full border-collapse table-fixed md:table block">
-            {/* table header */}
-            <thead className="md:table-header-group hidden">
-              {index === 0 && (
-                <tr>
-                  {HEADERS.map((header, index) => (
-                    <th
-                      key={index}
-                      className={`text-light-400 uppercase font-normal text-left pb-2 first:pr-1 last:pl-1 [&:not(:first-child):not(:last-child)]:px-1 border-b border-light-700 leading-tight`}
-                    >
-                      {header.label}
-                    </th>
-                  ))}
-                </tr>
-              )}
-            </thead>
-            {/* table body */}
-            <tbody className="block md:table-row-group">
-              <tr className="last:border-b-0 md:border-light-700 md:table-row flex flex-col">
-                {/* method */}
-                <td className="py-1.5 grid grid-cols-[auto,1fr] gap-4 items-center md:pr-1 md:table-cell text-right md:text-left">
-                  <span className="text-light-400 italic font-mono md:hidden">
-                    Method
-                  </span>
-                  <span className="break-all">{extraction.method}</span>
+      {/* extraction table */}
+      <div className="mt-5 overflow-x-auto">
+        <table className="text-xs w-full table-fixed">
+          <colgroup>
+            <col className="w-[22%]" />
+            <col className="w-[22%]" />
+            <col className="w-[18%]" />
+            <col className="w-[25%]" />
+            <col className="w-[13%]" />
+          </colgroup>
+          <thead>
+            <tr className="border-b border-light-700">
+              <th className="text-light-400 uppercase font-normal text-left pb-2 pr-4">
+                Food
+              </th>
+              <th className="text-light-400 uppercase font-normal text-left pb-2 px-4">
+                Chemical
+              </th>
+              <th className="text-light-400 uppercase font-normal text-right pb-2 px-4">
+                Concentration
+              </th>
+              <th className="text-light-400 uppercase font-normal text-right pb-2 px-4">
+                Converted Concentration
+              </th>
+              <th className="text-light-400 uppercase font-normal text-right pb-2 pl-4">
+                Method
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {evidence.extraction.map((extraction, index) => (
+              <tr key={index}>
+                <td className="py-2 pr-4 break-all">
+                  {extraction.extracted_food_name}
                 </td>
-                {/* extracted food */}
-                <td className="py-1.5 border-light-600/10 grid grid-cols-[auto,1fr] gap-4 items-center md:px-1 md:table-cell text-right md:text-left">
-                  <span className="text-light-400 italic font-mono md:hidden">
-                    Extracted Food
-                  </span>
-                  <span className="break-all">
-                    {extraction.extracted_food_name}
-                  </span>
+                <td className="py-2 px-4 break-all">
+                  {extraction.extracted_chemical_name}
                 </td>
-                {/* extracted chemical */}
-                <td className="py-1.5 border-light-600/10 grid grid-cols-[auto,1fr] gap-4 items-center md:px-1 md:table-cell text-right md:text-left">
-                  <span className="text-light-400 italic font-mono md:hidden">
-                    Extracted Chemical
-                  </span>
-                  <span className="break-all">
-                    {extraction.extracted_chemical_name}
-                  </span>
+                <td className="py-2 px-4 text-right whitespace-nowrap">
+                  {extraction.extracted_concentration ?? "n/a"}
                 </td>
-                {/* extracted concentration */}
-                <td className="py-1.5 border-light-600/10  grid grid-cols-[auto,1fr] gap-4 items-center md:px-1 md:table-cell text-right">
-                  <span className="text-light-400 italic font-mono md:hidden">
-                    Extracted Concentration
-                  </span>
-                  <span className="break-all">
-                    {extraction.extracted_concentration ?? "n/a"}
-                  </span>
+                <td className="py-2 px-4 text-right whitespace-nowrap">
+                  {extraction.converted_concentration.unit &&
+                  extraction.converted_concentration.value
+                    ? `${formatConcentrationValueAlt(
+                        extraction.converted_concentration.value
+                      )} ${extraction.converted_concentration.unit}`
+                    : "n/a"}
                 </td>
-                {/* converted concentration */}
-                <td className="py-1.5 border-light-600/10 grid grid-cols-[auto,1fr] gap-4 items-center md:pl-1 md:table-cell text-right">
-                  <span className="text-light-400 italic font-mono md:hidden">
-                    Converted Concentration
-                  </span>
-                  <span className="break-all">
-                    {extraction.converted_concentration.unit &&
-                    extraction.converted_concentration.value
-                      ? `${formatConcentrationValueAlt(
-                          extraction.converted_concentration.value
-                        )} ${extraction.converted_concentration.unit}`
-                      : "n/a"}
-                  </span>
+                <td className="py-2 pl-4 text-right uppercase whitespace-nowrap">
+                  {extraction.method}
                 </td>
               </tr>
-            </tbody>
-          </table>
-          {/* add divider after each extraction except the last one */}
-          {index < evidence.extraction.length - 1 && (
-            <hr className="my-2 border-light-600 md:hidden" />
-          )}
-        </div>
-      ))}
+            ))}
+          </tbody>
+        </table>
+      </div>
     </Card>
   );
 };

--- a/frontend/components/entities/food/FoodCompositionSection.tsx
+++ b/frontend/components/entities/food/FoodCompositionSection.tsx
@@ -38,16 +38,20 @@ const TABLE_HEADERS = [
   {
     label: "Chemical",
     sortName: "common_name",
+    align: "left" as const,
   },
   {
     label: "Nutrient Classification",
+    align: "left" as const,
   },
   {
     label: "Median Concentration (mg/100g)",
     sortName: "median_concentration",
+    align: "right" as const,
   },
   {
     label: "Evidence",
+    align: "right" as const,
   },
 ];
 
@@ -323,7 +327,13 @@ const FoodCompositionSection = ({
           </div>
           {/* table */}
           <div className="mt-3 overflow-x-auto">
-            <table className="w-full md:table-fixed">
+            <table className="w-full table-fixed">
+              <colgroup>
+                <col className="w-[30%]" />
+                <col className="w-[25%]" />
+                <col className="w-[25%]" />
+                <col className="w-[20%]" />
+              </colgroup>
               <thead className="text-light-400 text-left">
                 <tr>
                   {/* table headers */}
@@ -336,14 +346,14 @@ const FoodCompositionSection = ({
                           : index === TABLE_HEADERS.length - 1
                           ? "pl-4"
                           : "px-4"
-                      }`}
+                      } ${header.align === "right" ? "text-right" : "text-left"}`}
                     >
                       <div
-                        className={`group flex justify-between gap-1 items-center flex-nowrap w-full ${
+                        className={`group flex gap-1 items-center flex-nowrap w-full ${
                           header.sortName
                             ? "cursor-pointer"
                             : "pointer-events-none"
-                        }`}
+                        } ${header.align === "right" ? "justify-end" : "justify-between"}`}
                         onClick={() =>
                           header.sortName && handleSortClick(header.sortName)
                         }

--- a/frontend/context/paginationsContext.tsx
+++ b/frontend/context/paginationsContext.tsx
@@ -34,7 +34,7 @@ export const PaginationsProvider: React.FC<PaginationsProviderProps> = ({
   const setTablePaginations = (
     tableId: string,
     currentPage: number,
-    rowsPerPage: number = 20
+    rowsPerPage: number = 10
   ) => {
     setPaginations((prevState) => ({
       ...prevState,
@@ -43,7 +43,7 @@ export const PaginationsProvider: React.FC<PaginationsProviderProps> = ({
   };
 
   const getTablePaginations = (tableId: string): PaginationssSettings => {
-    return paginations[tableId] || { currentPage: 1, rowsPerPage: 20 };
+    return paginations[tableId] || { currentPage: 1, rowsPerPage: 10 };
   };
 
   return (

--- a/frontend/middleware.ts
+++ b/frontend/middleware.ts
@@ -1,0 +1,57 @@
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Detect entity ID slugs (e.g. /food/e2908) and redirect to the
+ * name-based URL (e.g. /food/cow--milk) by resolving via the API.
+ *
+ * Entity IDs match the pattern: "e" followed by one or more digits.
+ */
+
+const ENTITY_ID_RE = /^e\d+$/;
+const ENTITY_ROUTES = new Set(["food", "chemical", "disease"]);
+
+function encodeSpace(phrase: string) {
+  return phrase.replace(/ /g, "--");
+}
+
+export async function middleware(request: NextRequest) {
+  const segments = request.nextUrl.pathname.split("/").filter(Boolean);
+
+  // Only intercept /{entityType}/{slug} routes
+  if (segments.length !== 2) return NextResponse.next();
+
+  const [entityType, slug] = segments;
+  if (!ENTITY_ROUTES.has(entityType)) return NextResponse.next();
+  if (!ENTITY_ID_RE.test(slug)) return NextResponse.next();
+
+  // Resolve entity ID → common_name via API
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  const apiKey = process.env.NEXT_PUBLIC_API_KEY;
+  if (!apiUrl) return NextResponse.next();
+
+  try {
+    const res = await fetch(
+      `${apiUrl}/resolve?entity_id=${encodeURIComponent(slug)}`,
+      {
+        headers: apiKey ? { Authorization: `Bearer ${apiKey}` } : {},
+      }
+    );
+
+    if (!res.ok) return NextResponse.next();
+
+    const { entity_type, common_name } = await res.json();
+    const encodedName = encodeURIComponent(encodeSpace(common_name));
+    const redirectUrl = new URL(
+      `/${entity_type}/${encodedName}`,
+      request.url
+    );
+
+    return NextResponse.redirect(redirectUrl);
+  } catch {
+    return NextResponse.next();
+  }
+}
+
+export const config = {
+  matcher: ["/(food|chemical|disease)/:slug*"],
+};


### PR DESCRIPTION
## Summary

- **DMD entity deduplication**: Rewrite DMD entity resolution with 3-tier linking (ChEBI → PubChem → new entity). 790 DMD molecules now link to existing ChEBI/PubChem entities instead of creating duplicates. Remaining entities get disambiguated names with xref suffixes (e.g. `Alpha-S1-casein (UNIPROT:P02662)`). Fixes duplicate composition rows like three identical "cow milk × Alpha-S1-casein" entries.
- **Concentration converter**: Add `convert_conc()` to parse and standardize lit2kg raw concentrations (mg/kg, µg/g, etc.) to mg/100g. 4478 of 10212 lit2kg extractions now have converted values. Unconvertible units (%, molar) are logged to `diagnostics/ie_conc_unconverted.tsv`.
- **Materializer performance**: Vectorize food-chemical composition materializer — replace `iterrows()` over 500K triplets with `explode` + `merge` + `groupby`. Add tqdm progress bars to composition and correlation steps.
- **Concentration sorting**: Fix JSONB median_concentration sorting from string comparison to numeric cast (`(median_concentration->>'value')::NUMERIC`).
- **Pagination**: Remove empty row padding in correlation tables, reduce skeleton to 10 rows, align frontend `rowsPerPage` default with backend.
- **Evidence modal UI**: Unify column order across FDC/FoodAtlas/DMD evidence cards (Food, Chemical, Concentration, Converted Concentration, Method). Fix column alignment with `table-fixed` + explicit `colgroup` widths. Show resolved entity names instead of raw IDs for FDC/DMD. Include raw unit in concentration display.
- **Entity ID redirect**: Add `/resolve` API endpoint and Next.js middleware to redirect entity ID URLs (e.g. `/food/e2908`) to SEO-friendly name-based URLs.
- **Search index**: Filter synonyms longer than 200 chars from GIN index to avoid btree page-size limit errors from protein sequences.

## Test plan

- [x] Verify Alpha-S1-casein shows three disambiguated entries (not three identical ones)
- [x] Verify concentration column sorts numerically on food composition page
- [x] Verify correlation table adapts height to actual row count (no empty padding)
- [x] Verify evidence modal columns align across FDC and FoodAtlas data points
- [x] Verify `/food/e2908` redirects to `/food/cow--milk`
- [x] Verify lit2kg concentrations show converted values where applicable
- [x] Run full pipeline: `entities` → `triplets` → `ie` → `load`