### PR TITLE
feat: FoodOn-based food classification with 13 curated categories

### DIFF
--- a/backend/db/src/etl/materializer.py
+++ b/backend/db/src/etl/materializer.py
@@ -38,22 +38,14 @@ def _materialize_entity_views(conn: Connection) -> None:
     triplets = pd.read_sql(text("SELECT * FROM base_triplets"), conn)
 
     r1 = triplets[triplets["relationship_id"] == "r1"]
-    r2 = triplets[triplets["relationship_id"] == "r2"]
     r3r4 = triplets[triplets["relationship_id"].isin(["r3", "r4"])]
-
-    entity_map = entities.set_index("foodatlas_id")
-    name_map = entity_map["common_name"].to_dict()
-
-    foodon_cls = _build_classification_map(r2, name_map, "foodon")
 
     food_ids = set(r1["head_id"])
     foods = entities[
         (entities["entity_type"] == "food") & (entities["foodatlas_id"].isin(food_ids))
     ].copy()
-    foods["food_classification"] = (
-        foods["foodatlas_id"]
-        .map(foodon_cls)
-        .apply(lambda x: x if isinstance(x, list) else [])
+    foods["food_classification"] = foods["attributes"].apply(
+        lambda a: a.get("food_groups", []) if isinstance(a, dict) else []
     )
     _insert_mv_entities(conn, "mv_food_entities", foods, ["food_classification"])
 
@@ -89,22 +81,6 @@ def _materialize_entity_views(conn: Connection) -> None:
         len(chemicals),
         len(diseases),
     )
-
-
-def _build_classification_map(
-    r2_triplets: pd.DataFrame,
-    name_map: dict[str, str],
-    source_prefix: str,
-) -> dict[str, list[str]]:
-    """Pre-build {entity_id: [classification names]} from IS_A triplets."""
-    filtered = r2_triplets[
-        r2_triplets["source"].str.contains(source_prefix, case=False, na=False)
-    ]
-    result: dict[str, list[str]] = {}
-    for head_id, group in filtered.groupby("head_id"):
-        names = [name_map[tid] for tid in group["tail_id"] if tid in name_map]
-        result[str(head_id)] = names
-    return result
 
 
 def _insert_mv_entities(

--- a/backend/db/tests/test_materializer.py
+++ b/backend/db/tests/test_materializer.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock
 
 import pandas as pd
-from src.etl.materializer import _build_classification_map, _insert_mv_entities
+from src.etl.materializer import _insert_mv_entities
 from src.etl.materializer_composition import (
     _add_foodatlas_evidence,
     _compute_median,
@@ -165,44 +165,3 @@ class TestInsertMvEntities:
             cols = mock_copy.call_args[0][3]
             assert len(cols) == 6
             assert "external_ids" in cols
-
-
-class TestBuildClassificationMap:
-    """Test _build_classification_map with mock DataFrames."""
-
-    def test_finds_matching_classifications(self):
-        r2 = pd.DataFrame(
-            [
-                {"head_id": "c001", "tail_id": "class1", "source": "chebi_ontology"},
-                {"head_id": "c001", "tail_id": "class2", "source": "chebi_other"},
-                {"head_id": "c002", "tail_id": "class3", "source": "chebi_ontology"},
-            ]
-        )
-        name_map = {"class1": "ClassA", "class2": "ClassB", "class3": "ClassC"}
-        result = _build_classification_map(r2, name_map, "chebi")
-        assert result["c001"] == ["ClassA", "ClassB"]
-
-    def test_no_matching_source(self):
-        r2 = pd.DataFrame(
-            [
-                {"head_id": "c001", "tail_id": "class1", "source": "foodon_ontology"},
-            ]
-        )
-        name_map = {"class1": "X"}
-        result = _build_classification_map(r2, name_map, "chebi")
-        assert "c001" not in result
-
-    def test_empty_r2(self):
-        r2 = pd.DataFrame(columns=["head_id", "tail_id", "source"])
-        result = _build_classification_map(r2, {}, "chebi")
-        assert result == {}
-
-    def test_missing_tail_in_name_map(self):
-        r2 = pd.DataFrame(
-            [
-                {"head_id": "c001", "tail_id": "missing", "source": "chebi_x"},
-            ]
-        )
-        name_map = {"other": "A"}
-        result = _build_classification_map(r2, name_map, "chebi")
-        assert result.get("c001") == []

--- a/backend/db/tests/test_materializer_helpers.py
+++ b/backend/db/tests/test_materializer_helpers.py
@@ -3,51 +3,12 @@
 from unittest.mock import MagicMock, patch
 
 import pandas as pd
-from src.etl.materializer import _build_classification_map
 from src.etl.materializer_composition import (
     _add_foodatlas_evidence,
     _build_evidence_json,
     _compute_median,
     materialize_food_chemical_composition,
 )
-
-
-class TestBuildClassificationMap:
-    def test_returns_matching_labels(self):
-        r2 = pd.DataFrame(
-            {
-                "head_id": ["e1", "e1", "e2"],
-                "tail_id": ["e10", "e11", "e10"],
-                "source": ["foodon", "foodon", "chebi"],
-            }
-        )
-        name_map = {"e10": "fruit", "e11": "vegetable", "e12": "organic"}
-        result = _build_classification_map(r2, name_map, "foodon")
-        assert result["e1"] == ["fruit", "vegetable"]
-
-    def test_returns_empty_for_no_match(self):
-        r2 = pd.DataFrame(
-            {
-                "head_id": ["e2"],
-                "tail_id": ["e10"],
-                "source": ["chebi"],
-            }
-        )
-        name_map = {"e10": "x"}
-        result = _build_classification_map(r2, name_map, "foodon")
-        assert "e1" not in result
-
-    def test_skips_missing_tail_ids(self):
-        r2 = pd.DataFrame(
-            {
-                "head_id": ["e1"],
-                "tail_id": ["e999"],
-                "source": ["foodon"],
-            }
-        )
-        name_map = {"e10": "x"}
-        result = _build_classification_map(r2, name_map, "foodon")
-        assert result.get("e1") == []
 
 
 class TestComputeMedian:

--- a/backend/kgc/src/pipeline/enrichment/food_classification.py
+++ b/backend/kgc/src/pipeline/enrichment/food_classification.py
@@ -1,0 +1,132 @@
+"""Food classification via FoodOn IS_A hierarchy traversal.
+
+Assigns each food entity to one or more categories by checking
+whether it is a descendant of curated FoodOn anchor nodes.  Multi-label:
+a single food can belong to multiple categories (e.g. a fruit juice is
+both "botanical fruit food product" and "plant derived beverage").
+
+Note: FoodOn IS_A direction is head=child, tail=parent — the inverse of
+the chemical (ChEBI) convention.  ``_build_parent_child_map`` accounts
+for this by mapping tail -> head.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from ...models.attributes import FoodAttributes
+from .utils import read_attributes, write_attributes
+
+if TYPE_CHECKING:
+    import pandas as pd
+
+    from ...stores.entity_store import EntityStore
+    from ...stores.triplet_store import TripletStore
+
+logger = logging.getLogger(__name__)
+
+# Each entry maps a human-readable category name (the FoodOn entity's
+# ``common_name``) to the ``foodatlas_id`` of its anchor entity in the
+# KG.  Every descendant of that anchor (via IS_A edges) inherits the
+# category label.
+#
+# Broad categories (level 1 — children of root "food product by organism"):
+#   Every food reachable in the IS_A tree gets at least one of these.
+# Specific categories (level 2/3 under plant / animal):
+#   Finer-grained labels that coexist with the broad label.
+FOOD_CATEGORIES: dict[str, str] = {
+    # Broad
+    "plant food product": "e19",
+    "animal food product": "e2032",
+    "fungus food product": "e135",
+    "algal food product": "e170",
+    # Specific — plant (level 2)
+    "plant fruit food product": "e59",
+    "plant seed or nut food product": "e10145",
+    "spice or herb": "e217",
+    # Specific — animal (level 3, children of "vertebrate animal food product")
+    "dairy food product": "e231",
+    "mammalian meat food product": "e10",
+    "fish food product": "e223",
+    "avian food product": "e226",
+    "egg food product": "e246",
+    # Specific — animal (level 2)
+    "animal seafood product": "e49",
+}
+
+_IS_A_RELATIONSHIP = "r2"
+
+
+def classify_foods(
+    entity_store: EntityStore,
+    triplet_store: TripletStore,
+) -> None:
+    """Assign ``food_groups`` in entity attributes.
+
+    Writes into the ``attributes`` column via :class:`FoodAttributes`.
+    An empty list means the food could not be classified.
+    """
+    entities = entity_store._entities
+    food_mask = entities["entity_type"] == "food"
+    food_ids = set(entities.index[food_mask])
+
+    parent_to_children = _build_parent_child_map(triplet_store._triplets, food_ids)
+
+    category_members: dict[str, set[str]] = {}
+    for cat_name, anchor_eid in FOOD_CATEGORIES.items():
+        descendants = _get_all_descendants(anchor_eid, parent_to_children)
+        descendants.add(anchor_eid)
+        category_members[cat_name] = descendants & food_ids
+
+    classified = 0
+    for eid in food_ids:
+        matched = sorted(
+            cat for cat, members in category_members.items() if eid in members
+        )
+        attrs = read_attributes(entities, eid, FoodAttributes)
+        attrs.food_groups = matched
+        write_attributes(entities, eid, attrs)
+        if matched:
+            classified += 1
+
+    logger.info(
+        "Classified %d / %d foods across %d categories.",
+        classified,
+        len(food_ids),
+        len(FOOD_CATEGORIES),
+    )
+
+
+def _build_parent_child_map(
+    triplets: pd.DataFrame,
+    food_ids: set[str],
+) -> dict[str, set[str]]:
+    """Build parent -> children mapping from IS_A triplets.
+
+    In the KG, food IS_A triplets are stored as ``head=child,
+    tail=parent`` (the inverse of the chemical convention).
+    """
+    is_a = triplets[triplets["relationship_id"] == _IS_A_RELATIONSHIP]
+    is_a_ff = is_a[is_a["head_id"].isin(food_ids) & is_a["tail_id"].isin(food_ids)]
+
+    parent_to_children: dict[str, set[str]] = {}
+    for _, row in is_a_ff.iterrows():
+        parent_to_children.setdefault(row["tail_id"], set()).add(row["head_id"])
+    return parent_to_children
+
+
+def _get_all_descendants(
+    node: str,
+    children_map: dict[str, set[str]],
+) -> set[str]:
+    """Iterative DFS to collect all descendants of *node*."""
+    result: set[str] = set()
+    stack = [node]
+    while stack:
+        current = stack.pop()
+        for child in children_map.get(current, ()):
+            if child not in result:
+                result.add(child)
+                stack.append(child)
+    return result

--- a/backend/kgc/src/pipeline/runner.py
+++ b/backend/kgc/src/pipeline/runner.py
@@ -10,6 +10,7 @@ from ..utils.timing import log_duration
 from .checkpoint import load_checkpoint
 from .enrichment.classification import classify_chemicals
 from .enrichment.flavor import apply_flavor_descriptions
+from .enrichment.food_classification import classify_foods
 from .entities.runner import EntityRunner
 from .ie.runner import IERunner
 from .ingest.runner import IngestRunner
@@ -82,6 +83,7 @@ class PipelineRunner:
         sources = load_sources(self._settings)
         kg = KnowledgeGraph(self._settings)
         classify_chemicals(kg.entities, kg.triplets)
+        classify_foods(kg.entities, kg.triplets)
         apply_flavor_descriptions(kg, sources)
         kg.save()
 

--- a/backend/kgc/tests/test_food_classification.py
+++ b/backend/kgc/tests/test_food_classification.py
@@ -1,0 +1,322 @@
+"""Tests for FoodOn-based food classification."""
+
+import pandas as pd
+import pytest
+from src.models.attributes import FoodAttributes
+from src.pipeline.enrichment.food_classification import (
+    FOOD_CATEGORIES,
+    _build_parent_child_map,
+    _get_all_descendants,
+    classify_foods,
+)
+from src.stores.schema import INDEX_COL
+
+IC = INDEX_COL
+
+
+def _get_groups(entities: pd.DataFrame, eid: str) -> list[str]:
+    """Extract food_groups from the attributes dict."""
+    raw = entities.at[eid, "attributes"]
+    result: list[str] = FoodAttributes.model_validate(raw).food_groups
+    return result
+
+
+# -- hierarchy helpers --------------------------------------------------
+
+
+class TestBuildParentChildMap:
+    def test_builds_map_food_direction(self) -> None:
+        """Food IS_A: head=child, tail=parent -> parent maps to child."""
+        triplets = pd.DataFrame(
+            [
+                {
+                    IC: "t0",
+                    "head_id": "child",
+                    "tail_id": "parent",
+                    "relationship_id": "r2",
+                },
+            ]
+        ).set_index(IC)
+        result = _build_parent_child_map(triplets, {"child", "parent"})
+        assert result == {"parent": {"child"}}
+
+    def test_filters_to_food_ids(self) -> None:
+        triplets = pd.DataFrame(
+            [
+                {
+                    IC: "t0",
+                    "head_id": "food1",
+                    "tail_id": "chem1",
+                    "relationship_id": "r2",
+                },
+            ]
+        ).set_index(IC)
+        result = _build_parent_child_map(triplets, {"food1"})
+        assert result == {}
+
+    def test_ignores_non_is_a(self) -> None:
+        triplets = pd.DataFrame(
+            [
+                {
+                    IC: "t0",
+                    "head_id": "child",
+                    "tail_id": "parent",
+                    "relationship_id": "r1",
+                },
+            ]
+        ).set_index(IC)
+        result = _build_parent_child_map(triplets, {"child", "parent"})
+        assert result == {}
+
+
+class TestGetAllDescendants:
+    def test_linear_chain(self) -> None:
+        children = {"a": {"b"}, "b": {"c"}}
+        assert _get_all_descendants("a", children) == {"b", "c"}
+
+    def test_branching(self) -> None:
+        children = {"a": {"b", "c"}, "b": {"d"}}
+        assert _get_all_descendants("a", children) == {"b", "c", "d"}
+
+    def test_no_children(self) -> None:
+        assert _get_all_descendants("a", {}) == set()
+
+    def test_cycle_safe(self) -> None:
+        children = {"a": {"b"}, "b": {"a"}}
+        result = _get_all_descendants("a", children)
+        assert result == {"a", "b"}
+
+
+# -- classification -----------------------------------------------------
+
+
+class _FakeEntityStore:
+    _entities: pd.DataFrame
+
+
+class _FakeTripletStore:
+    _triplets: pd.DataFrame
+
+
+def _make_stores(
+    entities: pd.DataFrame, triplets: pd.DataFrame
+) -> tuple[_FakeEntityStore, _FakeTripletStore]:
+    es = _FakeEntityStore()
+    es._entities = entities
+    ts = _FakeTripletStore()
+    ts._triplets = triplets
+    return es, ts
+
+
+class TestClassifyFoods:
+    @pytest.fixture()
+    def stores(self) -> tuple:
+        """Minimal food hierarchy:
+
+        e19 (plant food product)
+          <- e234 (vegetable food product)
+              <- leaf1 (carrot)
+        e2032 (animal food product)
+          <- leaf2 (beef)
+        lone (tofu) — no IS_A edges
+        chem1 (chemical, should be untouched)
+        """
+        entities = pd.DataFrame(
+            [
+                {
+                    IC: "e19",
+                    "entity_type": "food",
+                    "common_name": "plant food product",
+                    "attributes": {},
+                },
+                {
+                    IC: "e234",
+                    "entity_type": "food",
+                    "common_name": "vegetable food product",
+                    "attributes": {},
+                },
+                {
+                    IC: "leaf1",
+                    "entity_type": "food",
+                    "common_name": "carrot",
+                    "attributes": {},
+                },
+                {
+                    IC: "e2032",
+                    "entity_type": "food",
+                    "common_name": "animal food product",
+                    "attributes": {},
+                },
+                {
+                    IC: "leaf2",
+                    "entity_type": "food",
+                    "common_name": "beef",
+                    "attributes": {},
+                },
+                {
+                    IC: "lone",
+                    "entity_type": "food",
+                    "common_name": "tofu",
+                    "attributes": {},
+                },
+                {
+                    IC: "chem1",
+                    "entity_type": "chemical",
+                    "common_name": "water",
+                    "attributes": {},
+                },
+            ]
+        ).set_index(IC)
+
+        # Food IS_A: head=child, tail=parent
+        triplets = pd.DataFrame(
+            [
+                {
+                    IC: "t0",
+                    "head_id": "e234",
+                    "tail_id": "e19",
+                    "relationship_id": "r2",
+                },
+                {
+                    IC: "t1",
+                    "head_id": "leaf1",
+                    "tail_id": "e234",
+                    "relationship_id": "r2",
+                },
+                {
+                    IC: "t2",
+                    "head_id": "leaf2",
+                    "tail_id": "e2032",
+                    "relationship_id": "r2",
+                },
+            ]
+        ).set_index(IC)
+
+        return _make_stores(entities, triplets)
+
+    def test_classifies_anchor(self, stores: tuple) -> None:
+        es, ts = stores
+        classify_foods(es, ts)
+        groups = _get_groups(es._entities, "e19")
+        assert "plant food product" in groups
+
+    def test_classifies_descendant_gets_broad_label(self, stores: tuple) -> None:
+        es, ts = stores
+        classify_foods(es, ts)
+        groups = _get_groups(es._entities, "leaf1")
+        assert "plant food product" in groups
+
+    def test_animal_descendant(self, stores: tuple) -> None:
+        es, ts = stores
+        classify_foods(es, ts)
+        groups = _get_groups(es._entities, "leaf2")
+        assert "animal food product" in groups
+
+    def test_unclassified_empty_list(self, stores: tuple) -> None:
+        es, ts = stores
+        classify_foods(es, ts)
+        assert _get_groups(es._entities, "lone") == []
+
+    def test_chemical_untouched(self, stores: tuple) -> None:
+        es, ts = stores
+        classify_foods(es, ts)
+        assert es._entities.at["chem1", "attributes"] == {}
+
+    def test_multi_label(self) -> None:
+        """A food that is a descendant of two specific anchors."""
+        entities = pd.DataFrame(
+            [
+                {
+                    IC: "e19",
+                    "entity_type": "food",
+                    "common_name": "plant food product",
+                    "attributes": {},
+                },
+                {
+                    IC: "e59",
+                    "entity_type": "food",
+                    "common_name": "plant fruit food product",
+                    "attributes": {},
+                },
+                {
+                    IC: "e10145",
+                    "entity_type": "food",
+                    "common_name": "plant seed or nut food product",
+                    "attributes": {},
+                },
+                {
+                    IC: "leaf",
+                    "entity_type": "food",
+                    "common_name": "tomato seed",
+                    "attributes": {},
+                },
+            ]
+        ).set_index(IC)
+
+        triplets = pd.DataFrame(
+            [
+                {
+                    IC: "t0",
+                    "head_id": "e59",
+                    "tail_id": "e19",
+                    "relationship_id": "r2",
+                },
+                {
+                    IC: "t1",
+                    "head_id": "e10145",
+                    "tail_id": "e19",
+                    "relationship_id": "r2",
+                },
+                {
+                    IC: "t2",
+                    "head_id": "leaf",
+                    "tail_id": "e59",
+                    "relationship_id": "r2",
+                },
+                {
+                    IC: "t3",
+                    "head_id": "leaf",
+                    "tail_id": "e10145",
+                    "relationship_id": "r2",
+                },
+            ]
+        ).set_index(IC)
+
+        es, ts = _make_stores(entities, triplets)
+        classify_foods(es, ts)
+
+        groups = _get_groups(es._entities, "leaf")
+        assert "plant food product" in groups
+        assert "plant fruit food product" in groups
+        assert "plant seed or nut food product" in groups
+
+    def test_preserves_existing_attributes(self) -> None:
+        entities = pd.DataFrame(
+            [
+                {
+                    IC: "e19",
+                    "entity_type": "food",
+                    "common_name": "plant food product",
+                    "attributes": {"food_groups": ["stale"]},
+                },
+            ]
+        ).set_index(IC)
+
+        triplets = pd.DataFrame(
+            [{IC: "t0", "head_id": "x", "tail_id": "y", "relationship_id": "r2"}]
+        ).set_index(IC)
+
+        es, ts = _make_stores(entities, triplets)
+        classify_foods(es, ts)
+
+        attrs = FoodAttributes.model_validate(es._entities.at["e19", "attributes"])
+        assert "plant food product" in attrs.food_groups
+
+
+class TestFoodCategoryConstants:
+    def test_no_duplicate_eids(self) -> None:
+        eids = list(FOOD_CATEGORIES.values())
+        assert len(eids) == len(set(eids))
+
+    def test_thirteen_categories(self) -> None:
+        assert len(FOOD_CATEGORIES) == 13

--- a/frontend/components/entities/MetainformationSection.tsx
+++ b/frontend/components/entities/MetainformationSection.tsx
@@ -80,7 +80,11 @@ const MetainformationSection = async ({
                     Classification
                   </Heading>
                   <div className="mt-3 capitalize break-all">
-                    <p>{data.food_classification}</p>
+                    <p>
+                      {data.food_classification.length > 0
+                        ? data.food_classification.join(", ")
+                        : "—"}
+                    </p>
                   </div>
                 </Card>
               )}


### PR DESCRIPTION
## Summary

- Add `classify_foods()` to the KGC enrichment pipeline, mirroring the `classify_chemicals` pattern: curated FoodOn entity anchors, IS_A descendant set traversal, multi-label assignment into `FoodAttributes.food_groups`
- 13 categories: 4 broad (plant, animal, fungus, algal) + 9 specific (fruit, seed/nut, spice/herb, dairy, meat, fish, avian, egg, seafood) — covers 99.7% of 10,270 food entities
- Update ETL materializer to source `food_classification` from `attributes.food_groups` (matching the chemical pattern) instead of raw IS_A triplets
- Fix frontend `MetainformationSection` to render food classification array with `.join(", ")` instead of raw concatenation

## Design decisions

- **Categories are real FoodOn entities** (not aliases), so classification labels will be consistent with the FoodOn IS_A tree path when taxonomical navigation is added (see #61)
- **Multi-label**: a food can belong to multiple categories (e.g. apple gets both "plant food product" and "plant fruit food product")
- **Dropped `vegetable food product`** as a category — FoodOn defines it so broadly that fruits are a subclass of vegetable, which is confusing for users
- **Reversed IS_A direction** vs chemicals: food IS_A triplets use head=child, tail=parent (opposite of ChEBI convention)
- **Removed `_build_classification_map`** from the ETL materializer — food classification now flows through entity attributes like chemicals do

## Related issues

Partially addresses #67 (food classification backend + display) and is designed to be compatible with #61 (taxonomical tree/path).

## Test plan

- [x] 16 unit tests covering hierarchy helpers, classification logic, multi-label, edge cases, constants
- [x] All pre-existing tests pass (KGC, DB, API, frontend)
- [x] Verified against real KG data: 99.7% coverage (10,240/10,270 foods)
- [x] Enrichment pipeline + ETL load tested end-to-end