### PR TITLE
fix: distinguish IE methods in attestation source and tighten evidence table (#71)

### DIFF
--- a/backend/kgc/src/config/defaults.json
+++ b/backend/kgc/src/config/defaults.json
@@ -15,10 +15,10 @@
       },
       "metadata_processing": {},
       "triplet_expansion": {
-        "ie_raw_paths": [
-          "data/Lit2KG/2024_12_31/text_parser_predicted_2024_02_25.parquet",
-          "data/Lit2KG/2024_12_31/text_parser_predicted_gpt3.tsv"
-        ]
+        "ie_raw_paths": {
+          "gpt-4": "data/Lit2KG/2024_12_31/text_parser_predicted_2024_02_25.parquet",
+          "gpt-3.5-finetuned": "data/Lit2KG/2024_12_31/text_parser_predicted_gpt3.tsv"
+        }
       },
       "enrichment": {}
     }

--- a/backend/kgc/src/config/defaults.json
+++ b/backend/kgc/src/config/defaults.json
@@ -16,8 +16,8 @@
       "metadata_processing": {},
       "triplet_expansion": {
         "ie_raw_paths": {
-          "gpt-4": "data/Lit2KG/2024_12_31/text_parser_predicted_2024_02_25.parquet",
-          "gpt-3.5-finetuned": "data/Lit2KG/2024_12_31/text_parser_predicted_gpt3.tsv"
+          "gpt-4": "data/Lit2KG/text_parser_predicted_2024_02_25_gpt-4.parquet",
+          "gpt-3.5-finetuned": "data/Lit2KG/text_parser_predicted_2024_07_11_gpt-3.5-ft.tsv"
         }
       },
       "enrichment": {}

--- a/backend/kgc/src/models/settings.py
+++ b/backend/kgc/src/models/settings.py
@@ -35,7 +35,7 @@ class MetadataProcessingStageConfig(BaseModel):
 
 
 class TripletExpansionStageConfig(BaseModel):
-    ie_raw_paths: list[str] = Field(default_factory=list)
+    ie_raw_paths: dict[str, str] = Field(default_factory=dict)
     ie_prob_threshold: float = 0.95
 
 

--- a/backend/kgc/src/pipeline/ie/loader.py
+++ b/backend/kgc/src/pipeline/ie/loader.py
@@ -74,6 +74,8 @@ def _process_line(
     rows: list[dict],
     parse_errors: list[dict],
     conc_errors: list[dict],
+    *,
+    method: str,
 ) -> None:
     """Parse one response line into a row dict, or log an error."""
     parsed = _parse_tuple(line)
@@ -92,7 +94,7 @@ def _process_line(
         {
             "source_type": "pubmed",
             "reference": ref,
-            "source": "lit2kg",
+            "source": f"lit2kg:{method}",
             "head_name_raw": standardize_name(food),
             "tail_name_raw": standardize_name(chemical),
             "conc_value": conc_value_converted,
@@ -145,8 +147,13 @@ def _convert_quantity(
     return None, ""
 
 
-def load_ie_raw(path: Path, output_dir: Path) -> pd.DataFrame:
+def load_ie_raw(path: Path, output_dir: Path, *, method: str) -> pd.DataFrame:
     """Parse raw IE file (TSV or pkl) into a MetadataContains-compatible DataFrame.
+
+    Args:
+        path: Path to the raw IE file.
+        output_dir: Directory for diagnostics output.
+        method: IE method name (e.g. "gpt-4"), used in the attestation source field.
 
     Returns:
         DataFrame with evidence + extraction columns.
@@ -173,7 +180,7 @@ def load_ie_raw(path: Path, output_dir: Path) -> pd.DataFrame:
             )
             continue
         for line in response.split("\n"):
-            _process_line(line, rec, rows, parse_errors, conc_errors)
+            _process_line(line, rec, rows, parse_errors, conc_errors, method=method)
 
     if parse_errors:
         errors_path = output_dir / FILE_IE_PARSE_ERRORS

--- a/backend/kgc/src/pipeline/ie/runner.py
+++ b/backend/kgc/src/pipeline/ie/runner.py
@@ -60,15 +60,15 @@ class IERunner:
             logger.info("No IE raw paths configured — skipping expansion.")
             return
 
-        for raw_path in ie_config.ie_raw_paths:
+        for method, raw_path in ie_config.ie_raw_paths.items():
             path = Path(raw_path)
             if not path.exists():
                 logger.warning("IE raw file not found at %s — skipping.", path)
                 continue
 
-            logger.info("Processing IE file: %s", path)
+            logger.info("Processing IE file: %s (method=%s)", path, method)
             with log_duration(f"Load IE raw: {path.name}", logger):
-                metadata = load_ie_raw(path, kg_dir)
+                metadata = load_ie_raw(path, kg_dir, method=method)
             if metadata.empty:
                 logger.info("IE loader produced no rows — skipping.")
                 continue

--- a/backend/kgc/tests/test_ie_loader.py
+++ b/backend/kgc/tests/test_ie_loader.py
@@ -102,26 +102,30 @@ class TestLoadIeRaw:
         return path
 
     def test_greek_normalized(self, ie_tsv: Path) -> None:
-        df = load_ie_raw(ie_tsv, ie_tsv.parent)
+        df = load_ie_raw(ie_tsv, ie_tsv.parent, method="gpt-4")
         assert "beta-carotene" in df["_chemical_name"].values
 
     def test_multi_tuple_response(self, ie_tsv: Path) -> None:
-        df = load_ie_raw(ie_tsv, ie_tsv.parent)
+        df = load_ie_raw(ie_tsv, ie_tsv.parent, method="gpt-4")
         berry_rows = df[df["_food_name"] == "berry"]
         assert len(berry_rows) == 2
 
-    def test_source_and_reference(self, ie_tsv: Path) -> None:
-        df = load_ie_raw(ie_tsv, ie_tsv.parent)
+    def test_source_includes_method(self, ie_tsv: Path) -> None:
+        df = load_ie_raw(ie_tsv, ie_tsv.parent, method="gpt-4")
         row = df[df["_food_name"] == "apple"].iloc[0]
-        assert row["source"] == "lit2kg"
+        assert row["source"] == "lit2kg:gpt-4"
         assert row["source_type"] == "pubmed"
         assert "111" in row["reference"]
+
+    def test_source_different_method(self, ie_tsv: Path) -> None:
+        df = load_ie_raw(ie_tsv, ie_tsv.parent, method="gpt-3.5-finetuned")
+        assert (df["source"] == "lit2kg:gpt-3.5-finetuned").all()
 
     def test_missing_column_raises(self, tmp_path: Path) -> None:
         path = tmp_path / "bad.tsv"
         path.write_text("col_a\tcol_b\n1\t2\n")
         with pytest.raises(ValueError, match="missing columns"):
-            load_ie_raw(path, tmp_path)
+            load_ie_raw(path, tmp_path, method="gpt-4")
 
     def test_quantity_parsed_into_raw_fields(self, tmp_path: Path) -> None:
         path = tmp_path / "conc.tsv"
@@ -136,7 +140,7 @@ class TestLoadIeRaw:
             },
         ]
         pd.DataFrame(rows).to_csv(path, sep="\t", index=False)
-        df = load_ie_raw(path, tmp_path)
+        df = load_ie_raw(path, tmp_path, method="gpt-4")
         row = df.iloc[0]
         assert row["conc_value_raw"] == "1.5"
         assert row["conc_unit_raw"] == "mg/g"
@@ -154,7 +158,7 @@ class TestLoadIeRaw:
             },
         ]
         pd.DataFrame(rows).to_csv(path, sep="\t", index=False)
-        df = load_ie_raw(path, tmp_path)
+        df = load_ie_raw(path, tmp_path, method="gpt-4")
         # Row is still created, with empty raw fields.
         assert len(df) == 1
         assert df.iloc[0]["conc_value_raw"] == ""
@@ -166,7 +170,7 @@ class TestLoadIeRaw:
         assert (errors["reason"] == "bad_conc").any()
 
     def test_empty_quantity_no_error(self, ie_tsv: Path) -> None:
-        df = load_ie_raw(ie_tsv, ie_tsv.parent)
+        df = load_ie_raw(ie_tsv, ie_tsv.parent, method="gpt-4")
         # All fixtures have empty quantities — should not produce bad_conc errors.
         assert (df["conc_value_raw"] == "").all()
         assert (df["conc_unit_raw"] == "").all()
@@ -178,5 +182,5 @@ class TestLoadIeRaw:
             "111\tINTRO\tapple\tSentence.\t0.99\t",
         ]
         path.write_text("\n".join(lines))
-        df = load_ie_raw(path, tmp_path)
+        df = load_ie_raw(path, tmp_path, method="gpt-4")
         assert df.empty

--- a/backend/kgc/tests/test_ie_runner.py
+++ b/backend/kgc/tests/test_ie_runner.py
@@ -20,7 +20,7 @@ def settings(tmp_path: Path) -> KGCSettings:
         output_dir=str(tmp_path / "out"),
         cache_dir=str(tmp_path / "cache"),
     )
-    s.pipeline.stages.triplet_expansion.ie_raw_paths = []
+    s.pipeline.stages.triplet_expansion.ie_raw_paths = {}
     return s
 
 
@@ -60,7 +60,7 @@ def test_ie_expansion_calls_resolver(
         cache_dir=str(tmp_path / "cache"),
     )
     (tmp_path / "kg").mkdir()
-    settings.pipeline.stages.triplet_expansion.ie_raw_paths = [str(ie_path)]
+    settings.pipeline.stages.triplet_expansion.ie_raw_paths = {"gpt-4": str(ie_path)}
 
     kg = MagicMock()
     mock_kg_cls.return_value = kg

--- a/frontend/components/entities/food/DmdEvidence.tsx
+++ b/frontend/components/entities/food/DmdEvidence.tsx
@@ -27,27 +27,27 @@ const DmdEvidence = ({ evidence }: DmdEvidenceProps) => {
       <div className="mt-5 overflow-x-auto">
         <table className="text-xs w-full table-fixed">
           <colgroup>
-            <col className="w-[22%]" />
-            <col className="w-[22%]" />
-            <col className="w-[18%]" />
-            <col className="w-[25%]" />
-            <col className="w-[13%]" />
+            <col className="w-[20%]" />
+            <col className="w-[20%]" />
+            <col className="w-[16%]" />
+            <col className="w-[24%]" />
+            <col className="w-[20%]" />
           </colgroup>
           <thead>
             <tr className="border-b border-light-700">
-              <th className="text-light-400 uppercase font-normal text-left pb-2 pr-4">
+              <th className="text-light-400 uppercase font-normal text-left pb-2 pr-2">
                 Food
               </th>
-              <th className="text-light-400 uppercase font-normal text-left pb-2 px-4">
+              <th className="text-light-400 uppercase font-normal text-left pb-2 px-2">
                 Chemical
               </th>
-              <th className="text-light-400 uppercase font-normal text-right pb-2 px-4">
+              <th className="text-light-400 uppercase font-normal text-right pb-2 px-2">
                 Concentration
               </th>
-              <th className="text-light-400 uppercase font-normal text-right pb-2 px-4">
+              <th className="text-light-400 uppercase font-normal text-right pb-2 px-2">
                 Converted Concentration
               </th>
-              <th className="text-light-400 uppercase font-normal text-right pb-2 pl-4">
+              <th className="text-light-400 uppercase font-normal text-right pb-2 pl-2">
                 Method
               </th>
             </tr>
@@ -55,16 +55,16 @@ const DmdEvidence = ({ evidence }: DmdEvidenceProps) => {
           <tbody>
             {evidence.extraction.map((extraction, index) => (
               <tr key={index}>
-                <td className="py-2 pr-4 break-all">
+                <td className="py-2 pr-2 break-all">
                   {extraction.extracted_food_name}
                 </td>
-                <td className="py-2 px-4 break-all">
+                <td className="py-2 px-2 break-all">
                   {extraction.extracted_chemical_name}
                 </td>
-                <td className="py-2 px-4 text-right whitespace-nowrap">
+                <td className="py-2 px-2 text-right whitespace-nowrap">
                   {extraction.extracted_concentration ?? "-"}
                 </td>
-                <td className="py-2 px-4 text-right whitespace-nowrap">
+                <td className="py-2 px-2 text-right whitespace-nowrap">
                   {extraction.converted_concentration.unit &&
                   extraction.converted_concentration.value
                     ? `${formatConcentrationValueAlt(
@@ -72,7 +72,7 @@ const DmdEvidence = ({ evidence }: DmdEvidenceProps) => {
                       )} ${extraction.converted_concentration.unit}`
                     : "-"}
                 </td>
-                <td className="py-2 pl-4 text-right uppercase whitespace-nowrap">
+                <td className="py-2 pl-2 text-right uppercase break-words">
                   {extraction.method}
                 </td>
               </tr>

--- a/frontend/components/entities/food/FdcEvidence.tsx
+++ b/frontend/components/entities/food/FdcEvidence.tsx
@@ -27,27 +27,27 @@ const FdcEvidence = ({ evidence }: FdcEvidenceProps) => {
       <div className="mt-5 overflow-x-auto">
         <table className="text-xs w-full table-fixed">
           <colgroup>
-            <col className="w-[22%]" />
-            <col className="w-[22%]" />
-            <col className="w-[18%]" />
-            <col className="w-[25%]" />
-            <col className="w-[13%]" />
+            <col className="w-[20%]" />
+            <col className="w-[20%]" />
+            <col className="w-[16%]" />
+            <col className="w-[24%]" />
+            <col className="w-[20%]" />
           </colgroup>
           <thead>
             <tr className="border-b border-light-700">
-              <th className="text-light-400 uppercase font-normal text-left pb-2 pr-4">
+              <th className="text-light-400 uppercase font-normal text-left pb-2 pr-2">
                 Food
               </th>
-              <th className="text-light-400 uppercase font-normal text-left pb-2 px-4">
+              <th className="text-light-400 uppercase font-normal text-left pb-2 px-2">
                 Chemical
               </th>
-              <th className="text-light-400 uppercase font-normal text-right pb-2 px-4">
+              <th className="text-light-400 uppercase font-normal text-right pb-2 px-2">
                 Concentration
               </th>
-              <th className="text-light-400 uppercase font-normal text-right pb-2 px-4">
+              <th className="text-light-400 uppercase font-normal text-right pb-2 px-2">
                 Converted Concentration
               </th>
-              <th className="text-light-400 uppercase font-normal text-right pb-2 pl-4">
+              <th className="text-light-400 uppercase font-normal text-right pb-2 pl-2">
                 Method
               </th>
             </tr>
@@ -55,16 +55,16 @@ const FdcEvidence = ({ evidence }: FdcEvidenceProps) => {
           <tbody>
             {evidence.extraction.map((extraction, index) => (
               <tr key={index}>
-                <td className="py-2 pr-4 break-all">
+                <td className="py-2 pr-2 break-all">
                   {extraction.extracted_food_name}
                 </td>
-                <td className="py-2 px-4 break-all">
+                <td className="py-2 px-2 break-all">
                   {extraction.extracted_chemical_name}
                 </td>
-                <td className="py-2 px-4 text-right whitespace-nowrap">
+                <td className="py-2 px-2 text-right whitespace-nowrap">
                   {extraction.extracted_concentration ?? "—"}
                 </td>
-                <td className="py-2 px-4 text-right whitespace-nowrap">
+                <td className="py-2 px-2 text-right whitespace-nowrap">
                   {extraction.converted_concentration.unit &&
                   extraction.converted_concentration.value
                     ? `${formatConcentrationValueAlt(
@@ -72,7 +72,7 @@ const FdcEvidence = ({ evidence }: FdcEvidenceProps) => {
                       )} ${extraction.converted_concentration.unit}`
                     : "—"}
                 </td>
-                <td className="py-2 pl-4 text-right uppercase whitespace-nowrap">
+                <td className="py-2 pl-2 text-right uppercase break-words">
                   {extraction.method}
                 </td>
               </tr>

--- a/frontend/components/entities/food/FoodAtlasEvidence.tsx
+++ b/frontend/components/entities/food/FoodAtlasEvidence.tsx
@@ -77,27 +77,27 @@ const FoodAtlasEvidence = ({ evidence }: FoodAtlasEvidenceProps) => {
       <div className="mt-5 overflow-x-auto">
         <table className="text-xs w-full table-fixed">
           <colgroup>
-            <col className="w-[22%]" />
-            <col className="w-[22%]" />
-            <col className="w-[18%]" />
-            <col className="w-[25%]" />
-            <col className="w-[13%]" />
+            <col className="w-[20%]" />
+            <col className="w-[20%]" />
+            <col className="w-[16%]" />
+            <col className="w-[24%]" />
+            <col className="w-[20%]" />
           </colgroup>
           <thead>
             <tr className="border-b border-light-700">
-              <th className="text-light-400 uppercase font-normal text-left pb-2 pr-4">
+              <th className="text-light-400 uppercase font-normal text-left pb-2 pr-2">
                 Food
               </th>
-              <th className="text-light-400 uppercase font-normal text-left pb-2 px-4">
+              <th className="text-light-400 uppercase font-normal text-left pb-2 px-2">
                 Chemical
               </th>
-              <th className="text-light-400 uppercase font-normal text-right pb-2 px-4">
+              <th className="text-light-400 uppercase font-normal text-right pb-2 px-2">
                 Concentration
               </th>
-              <th className="text-light-400 uppercase font-normal text-right pb-2 px-4">
+              <th className="text-light-400 uppercase font-normal text-right pb-2 px-2">
                 Converted Concentration
               </th>
-              <th className="text-light-400 uppercase font-normal text-right pb-2 pl-4">
+              <th className="text-light-400 uppercase font-normal text-right pb-2 pl-2">
                 Method
               </th>
             </tr>
@@ -105,16 +105,16 @@ const FoodAtlasEvidence = ({ evidence }: FoodAtlasEvidenceProps) => {
           <tbody>
             {evidence.extraction.map((extraction, index) => (
               <tr key={index}>
-                <td className="py-2 pr-4 break-all">
+                <td className="py-2 pr-2 break-all">
                   {extraction.extracted_food_name}
                 </td>
-                <td className="py-2 px-4 break-all">
+                <td className="py-2 px-2 break-all">
                   {extraction.extracted_chemical_name}
                 </td>
-                <td className="py-2 px-4 text-right whitespace-nowrap">
+                <td className="py-2 px-2 text-right whitespace-nowrap">
                   {extraction.extracted_concentration ?? "-"}
                 </td>
-                <td className="py-2 px-4 text-right whitespace-nowrap">
+                <td className="py-2 px-2 text-right whitespace-nowrap">
                   {extraction.converted_concentration.unit &&
                   extraction.converted_concentration.value
                     ? `${formatConcentrationValueAlt(
@@ -122,7 +122,7 @@ const FoodAtlasEvidence = ({ evidence }: FoodAtlasEvidenceProps) => {
                       )} ${extraction.converted_concentration.unit}`
                     : "-"}
                 </td>
-                <td className="py-2 pl-4 text-right uppercase whitespace-nowrap">
+                <td className="py-2 pl-2 text-right uppercase break-words">
                   {extraction.method}
                 </td>
               </tr>


### PR DESCRIPTION
## Summary

- **IE attestation source field**: Changed `ie_raw_paths` config from `list[str]` to `dict[str, str]` mapping method name to file path. The loader now tags each attestation with `lit2kg:<method>` (e.g. `lit2kg:gpt-4`, `lit2kg:gpt-3.5-finetuned`) instead of a generic `lit2kg`, so extractions from different LLM models produce distinct attestation IDs and all show up in the UI.
- **IE raw paths**: Updated file paths to match actual data locations.
- **Evidence table spacing**: Reduced column padding and widened the Method column across all three evidence components (FoodAtlas, FDC, DMD) so long method names like `lit2kg:gpt-3.5-finetuned` fit without horizontal scrolling.

## Changed files

- `backend/kgc/src/models/settings.py` — `ie_raw_paths: dict[str, str]`
- `backend/kgc/src/config/defaults.json` — method→path mapping
- `backend/kgc/src/pipeline/ie/loader.py` — `method` kwarg, `source=f"lit2kg:{method}"`
- `backend/kgc/src/pipeline/ie/runner.py` — iterate dict items
- `backend/kgc/tests/test_ie_loader.py` — updated for new signature + method test
- `backend/kgc/tests/test_ie_runner.py` — updated for dict config
- `frontend/components/entities/food/{FoodAtlasEvidence,FdcEvidence,DmdEvidence}.tsx` — tighter padding, wider Method column

Closes #71