### PR TITLE
fix: frontend batch — classification filter, identifiers, highlights, scrollbar (#55 #59 #66 #69 #74)

### DIFF
--- a/backend/api/src/repositories/food.py
+++ b/backend/api/src/repositories/food.py
@@ -214,10 +214,10 @@ def _build_query_parts(
         has_named = [c for c in classifications if c != "n/a"]
         has_unclassified = "n/a" in classifications
         cls_parts: list[str] = []
-        if has_named:
-            cls_parts.append("chemical_classification && CAST(:cls_arr AS TEXT[])")
-            quoted = ",".join(f'"{c}"' for c in has_named)
-            params["cls_arr"] = "{" + quoted + "}"
+        for i, cls in enumerate(has_named):
+            key = f"cls_{i}"
+            cls_parts.append(f":{key} = ANY(chemical_classification)")
+            params[key] = cls
         if has_unclassified:
             cls_parts.append("chemical_classification = '{}'")
         conditions.append("(" + " OR ".join(cls_parts) + ")")

--- a/backend/api/src/repositories/formatting.py
+++ b/backend/api/src/repositories/formatting.py
@@ -4,10 +4,7 @@ _SOURCE_CONFIG: dict[str, tuple[str, str]] = {
     "foodon": ("FoodOn", ""),
     "chebi": ("ChEBI", "https://www.ebi.ac.uk/chebi/searchId.do?chebiId=CHEBI:{}"),
     "fdc": ("FDC", "https://fdc.nal.usda.gov/fdc-app.html#/food-details/{}"),
-    "fdc_nutrient": (
-        "FDC Nutrient",
-        "https://fdc.nal.usda.gov/fdc-app.html#/food-details/{}",
-    ),
+    "fdc_nutrient": ("FDC Nutrient", ""),
     "cdno": ("CDNO", ""),
     "ctd": ("CTD", "https://ctdbase.org/detail.go?type=disease&acc={}"),
     "dmd": ("DMD", ""),

--- a/frontend/components/basic/Modal.tsx
+++ b/frontend/components/basic/Modal.tsx
@@ -1,11 +1,10 @@
 // modal wrapper for headless ui dialog
 
-import { Dialog, DialogBackdrop, DialogPanel, Portal } from "@headlessui/react";
+import { Dialog, DialogPanel } from "@headlessui/react";
 import { MdClose } from "react-icons/md";
 
 import Heading from "@/components/basic/Heading";
 import Button from "@/components/basic/Button";
-import { useEffect } from "react";
 
 interface ModalProps {
   children: React.ReactNode;
@@ -22,21 +21,9 @@ const Modal = ({
   title,
   description,
 }: ModalProps) => {
-  // add useEffect to handle body scroll
-  useEffect(() => {
-    if (isOpen) {
-      // prevent scrolling on body when modal is open
-      document.body.style.overflow = "hidden";
-    } else {
-      // restore scrolling when modal is closed
-      document.body.style.overflow = "unset";
-    }
-
-    // cleanup on unmount
-    return () => {
-      document.body.style.overflow = "unset";
-    };
-  }, [isOpen]);
+  // Headless UI Dialog handles scroll locking internally.
+  // scrollbar-gutter: stable on <html> (globals.css) reserves scrollbar
+  // space, preventing layout shift when the scrollbar is hidden.
 
   return (
     <Dialog

--- a/frontend/components/entities/MetainformationSection.tsx
+++ b/frontend/components/entities/MetainformationSection.tsx
@@ -139,51 +139,53 @@ const MetainformationSection = async ({
           >
             Identifiers
           </Heading>
-          <div
-            className="grid gap-3"
-            style={{
-              gridTemplateColumns: "repeat(auto-fit, minmax(200px, 1fr))",
-            }}
-          >
-            {/* foodatlas id */}
-            <Card>
-              <Heading
-                type="h4"
-                className="font-mono italic text-light-400 text-xs"
-              >
-                FoodAtlas
-              </Heading>
-              <div className="mt-3">{data.id}</div>
-            </Card>
-            {/* external ids */}
-            {data?.external_ids &&
-              // create a card for each source
-              Object.values(data.external_ids).map((reference) => (
-                <Card key={reference.display_name}>
-                  <Heading
-                    type="h4"
-                    className="font-mono italic text-light-400 text-xs"
-                  >
-                    {reference.display_name}
-                  </Heading>
-                  <div className="mt-3 flex flex-wrap gap-3">
-                    {reference.ids.map((id) => {
-                      return id.url ? (
-                        <Link
-                          key={id.url}
-                          href={id.url}
-                          className="whitespace-nowrap"
-                        >
-                          {id.id}
-                        </Link>
-                      ) : (
-                        <p>{id.id}</p>
-                      );
-                    })}
-                  </div>
-                </Card>
-              ))}
-          </div>
+          <Card>
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-light-50/10">
+                  <th className="py-2 pr-4 text-left font-mono text-xs font-medium italic text-light-400">
+                    Source
+                  </th>
+                  <th className="py-2 text-left font-mono text-xs font-medium italic text-light-400">
+                    Identifier
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {/* foodatlas id */}
+                <tr className="border-b border-light-50/[0.05]">
+                  <td className="py-2 pr-4 whitespace-nowrap">FoodAtlas</td>
+                  <td className="py-2 break-all">{data.id}</td>
+                </tr>
+                {/* external ids */}
+                {data?.external_ids &&
+                  Object.values(data.external_ids).map((reference) =>
+                    reference.ids.map((id, idx) => (
+                      <tr
+                        key={`${reference.display_name}-${id.id}`}
+                        className="border-b border-light-50/[0.05]"
+                      >
+                        {idx === 0 && (
+                          <td
+                            className="py-2 pr-4 align-top whitespace-nowrap"
+                            rowSpan={reference.ids.length}
+                          >
+                            {reference.display_name}
+                          </td>
+                        )}
+                        <td className="py-2 break-all">
+                          {id.url ? (
+                            <Link href={id.url}>{id.id}</Link>
+                          ) : (
+                            id.id
+                          )}
+                        </td>
+                      </tr>
+                    )),
+                  )}
+              </tbody>
+            </table>
+          </Card>
         </div>
       </div>
     </div>

--- a/frontend/components/entities/MetainformationSection.tsx
+++ b/frontend/components/entities/MetainformationSection.tsx
@@ -140,7 +140,11 @@ const MetainformationSection = async ({
             Identifiers
           </Heading>
           <Card>
-            <table className="w-full text-sm">
+            <table className="w-full table-fixed text-sm">
+              <colgroup>
+                <col className="w-[30%]" />
+                <col className="w-[70%]" />
+              </colgroup>
               <thead>
                 <tr className="border-b border-light-50/10">
                   <th className="py-2 pr-4 text-left font-mono text-xs font-medium italic text-light-400">
@@ -159,30 +163,28 @@ const MetainformationSection = async ({
                 </tr>
                 {/* external ids */}
                 {data?.external_ids &&
-                  Object.values(data.external_ids).map((reference) =>
-                    reference.ids.map((id, idx) => (
-                      <tr
-                        key={`${reference.display_name}-${id.id}`}
-                        className="border-b border-light-50/[0.05]"
-                      >
-                        {idx === 0 && (
-                          <td
-                            className="py-2 pr-4 align-top whitespace-nowrap"
-                            rowSpan={reference.ids.length}
-                          >
-                            {reference.display_name}
-                          </td>
-                        )}
-                        <td className="py-2 break-all">
-                          {id.url ? (
-                            <Link href={id.url}>{id.id}</Link>
-                          ) : (
-                            id.id
-                          )}
-                        </td>
-                      </tr>
-                    )),
-                  )}
+                  Object.values(data.external_ids).map((reference) => (
+                    <tr
+                      key={reference.display_name}
+                      className="border-b border-light-50/[0.05]"
+                    >
+                      <td className="py-2 pr-4 align-top whitespace-nowrap">
+                        {reference.display_name}
+                      </td>
+                      <td className="py-2 break-all">
+                        {reference.ids.map((id, idx) => (
+                          <span key={id.id}>
+                            {idx > 0 && ", "}
+                            {id.url ? (
+                              <Link href={id.url}>{id.id}</Link>
+                            ) : (
+                              id.id
+                            )}
+                          </span>
+                        ))}
+                      </td>
+                    </tr>
+                  ))}
               </tbody>
             </table>
           </Card>

--- a/frontend/components/entities/food/FoodAtlasEvidence.tsx
+++ b/frontend/components/entities/food/FoodAtlasEvidence.tsx
@@ -3,6 +3,7 @@ import Badge from "@/components/basic/Badge";
 import Card from "@/components/basic/Card";
 import { FoodEvidence } from "@/types/Evidence";
 import { formatConcentrationValueAlt } from "@/utils/utils";
+import { greekVariants, matchesWithGreek } from "@/utils/greekLetters";
 
 type FoodAtlasEvidenceProps = {
   evidence: FoodEvidence;
@@ -25,9 +26,12 @@ const FoodAtlasEvidence = ({ evidence }: FoodAtlasEvidenceProps) => {
           .split(
             new RegExp(
               `(${evidence.extraction
-                .map(
-                  (e) =>
-                    `${e.extracted_chemical_name}|${e.extracted_food_name}|${e.extracted_concentration}`
+                .flatMap((e) =>
+                  [
+                    e.extracted_chemical_name,
+                    e.extracted_food_name,
+                    e.extracted_concentration,
+                  ].flatMap((name) => greekVariants(name))
                 )
                 .join("|")})`,
               "gi"
@@ -36,24 +40,19 @@ const FoodAtlasEvidence = ({ evidence }: FoodAtlasEvidenceProps) => {
           .map((part, index) => {
             const matchingExtraction = evidence.extraction.find(
               (e) =>
-                part?.toLowerCase() === e.extracted_food_name?.toLowerCase() ||
-                part?.toLowerCase() ===
-                  e.extracted_chemical_name?.toLowerCase() ||
-                part?.toLowerCase() === e.extracted_concentration?.toLowerCase()
+                matchesWithGreek(part, e.extracted_food_name) ||
+                matchesWithGreek(part, e.extracted_chemical_name) ||
+                matchesWithGreek(part, e.extracted_concentration)
             );
 
-            if (
-              matchingExtraction?.extracted_food_name?.toLowerCase() ===
-              part?.toLowerCase()
-            ) {
+            if (matchesWithGreek(part, matchingExtraction?.extracted_food_name)) {
               return (
                 <span key={index} className="text-amber-600 bg-amber-600/10">
                   {part}
                 </span>
               );
             } else if (
-              matchingExtraction?.extracted_chemical_name?.toLowerCase() ===
-              part?.toLowerCase()
+              matchesWithGreek(part, matchingExtraction?.extracted_chemical_name)
             ) {
               return (
                 <span key={index} className="text-cyan-600 bg-cyan-600/10">
@@ -61,8 +60,10 @@ const FoodAtlasEvidence = ({ evidence }: FoodAtlasEvidenceProps) => {
                 </span>
               );
             } else if (
-              matchingExtraction?.extracted_concentration?.toLowerCase() ===
-              part?.toLowerCase()
+              matchesWithGreek(
+                part,
+                matchingExtraction?.extracted_concentration
+              )
             ) {
               return (
                 <span key={index} className="text-teal-600 bg-teal-600/10">

--- a/frontend/components/entities/food/FoodCompositionSection.tsx
+++ b/frontend/components/entities/food/FoodCompositionSection.tsx
@@ -6,6 +6,9 @@ import {
   ListboxButton,
   ListboxOption,
   ListboxOptions,
+  Popover,
+  PopoverButton,
+  PopoverPanel,
   Portal,
   Switch,
 } from "@headlessui/react";
@@ -100,7 +103,7 @@ const FoodCompositionSection = ({
   const [sourceCounts, setSourceCounts] = useState<Record<string, number>>({});
   const [classificationFilter, setClassificationFilter] = useState<
     string[]
-  >([]);
+  >([...CLASSIFICATION_OPTIONS]);
   const [classificationCounts, setClassificationCounts] = useState<
     Record<string, number>
   >({});
@@ -112,6 +115,12 @@ const FoodCompositionSection = ({
         const counts = await getFoodCompositionCounts(commonName);
         setSourceCounts(counts.source_counts);
         setClassificationCounts(counts.classification_counts);
+        // Initialize filter to only classes that have results
+        setClassificationFilter(
+          CLASSIFICATION_OPTIONS.filter(
+            (cls) => (counts.classification_counts[cls] ?? 0) > 0
+          )
+        );
       } catch {
         setSourceCounts({});
         setClassificationCounts({});
@@ -135,6 +144,13 @@ const FoodCompositionSection = ({
       try {
         setIsError(false);
         setIsLoading(true);
+        const visibleCount = CLASSIFICATION_OPTIONS.filter(
+          (cls) => (classificationCounts[cls] ?? 0) > 0
+        ).length;
+        const activeClsFilter =
+          classificationFilter.length >= visibleCount
+            ? []
+            : classificationFilter;
         const result = await getFoodCompositionData(
           commonName,
           currentPage,
@@ -142,7 +158,7 @@ const FoodCompositionSection = ({
           searchTerm,
           sort,
           showAllConcentrations,
-          classificationFilter
+          activeClsFilter
         );
         // client-side filter: only keep rows with evidence from selected sources
         const filteredData = (
@@ -176,6 +192,7 @@ const FoodCompositionSection = ({
     sort,
     showAllConcentrations,
     classificationFilter,
+    classificationCounts,
   ]);
 
   // handle source filter change
@@ -355,64 +372,113 @@ const FoodCompositionSection = ({
                       } ${header.align === "right" ? "text-right" : "text-left"}`}
                     >
                       {header.filterable ? (
-                        <Listbox
-                          value={classificationFilter}
-                          onChange={(val: string[]) => {
-                            setTablePaginations(
-                              "food-composition-table",
-                              1,
-                              20
-                            );
-                            setClassificationFilter(val);
-                          }}
-                          multiple
-                        >
-                          <ListboxButton className="group flex gap-1 items-center cursor-pointer focus:outline-none">
-                            <span
-                              className={`select-none uppercase text-xs font-medium transition duration-300 ease-in-out ${
-                                classificationFilter.length > 0
-                                  ? "text-accent-600"
-                                  : "text-light-400 group-hover:text-light-100"
-                              }`}
-                            >
-                              {header.label}
-                              {classificationFilter.length > 0 &&
-                                ` (${classificationFilter.length})`}
-                            </span>
-                            <MdKeyboardArrowDown
-                              className={`transition duration-300 ease-in-out flex-shrink-0 ${
-                                classificationFilter.length > 0
-                                  ? "text-accent-600"
-                                  : "text-light-400 group-hover:text-light-100"
-                              }`}
-                            />
-                          </ListboxButton>
-                          <ListboxOptions
-                            anchor="bottom start"
-                            className={twMerge(
-                              "w-52 rounded-xl border border-white/5 bg-white/5 backdrop-blur-lg p-1 [--anchor-gap:var(--spacing-1)] focus:outline-none z-50",
-                              "transition duration-100 ease-in data-[leave]:data-[closed]:opacity-0"
-                            )}
-                          >
-                            {CLASSIFICATION_OPTIONS.map((cls) => (
-                              <ListboxOption
-                                key={cls}
-                                value={cls}
-                                className="group flex cursor-default items-center gap-2 rounded-lg py-1.5 px-4 select-none data-[focus]:bg-white/10 capitalize"
-                              >
-                                <MdCheck className="invisible size-4 fill-white group-data-[selected]:visible flex-shrink-0" />
-                                <span className="flex-1">
-                                  {cls === "n/a" ? "—" : cls}
-                                </span>
-                                {classificationCounts[cls] != null && (
-                                  <span className="text-xs text-light-400">
-                                    {classificationCounts[cls]}
+                        <Popover className="relative">
+                          <PopoverButton className="group flex gap-1 items-center cursor-pointer focus:outline-none">
+                            {(() => {
+                              const visibleCls = CLASSIFICATION_OPTIONS.filter(
+                                (cls) => (classificationCounts[cls] ?? 0) > 0
+                              );
+                              const isFiltered =
+                                classificationFilter.length < visibleCls.length;
+                              return (
+                                <>
+                                  <span
+                                    className={`select-none uppercase text-xs font-medium transition duration-300 ease-in-out ${
+                                      isFiltered
+                                        ? "text-accent-600"
+                                        : "text-light-400 group-hover:text-light-100"
+                                    }`}
+                                  >
+                                    {header.label}
+                                    {isFiltered &&
+                                      ` (${classificationFilter.length})`}
                                   </span>
-                                )}
-                              </ListboxOption>
+                                  <MdKeyboardArrowDown
+                                    className={`transition duration-300 ease-in-out flex-shrink-0 ${
+                                      isFiltered
+                                        ? "text-accent-600"
+                                        : "text-light-400 group-hover:text-light-100"
+                                    }`}
+                                  />
+                                </>
+                              );
+                            })()}
+                          </PopoverButton>
+                          <PopoverPanel
+                            anchor="bottom start"
+                            className="w-56 rounded-xl border border-white/5 bg-neutral-900 backdrop-blur-lg p-1 z-50 shadow-lg"
+                          >
+                            {/* select all / deselect all */}
+                            {(() => {
+                              const visibleOpts =
+                                CLASSIFICATION_OPTIONS.filter(
+                                  (cls) =>
+                                    (classificationCounts[cls] ?? 0) > 0
+                                );
+                              const allChecked =
+                                classificationFilter.length >=
+                                visibleOpts.length;
+                              return (
+                                <button
+                                  type="button"
+                                  className="w-full text-left text-xs text-light-400 hover:text-light-100 px-4 py-1.5"
+                                  onClick={() => {
+                                    setTablePaginations(
+                                      "food-composition-table",
+                                      1,
+                                      20
+                                    );
+                                    setClassificationFilter(
+                                      allChecked ? [] : [...visibleOpts]
+                                    );
+                                  }}
+                                >
+                                  {allChecked
+                                    ? "Deselect all"
+                                    : "Select all"}
+                                </button>
+                              );
+                            })()}
+                            <div className="border-b border-white/5 my-1" />
+                            {CLASSIFICATION_OPTIONS.filter(
+                              (cls) =>
+                                (classificationCounts[cls] ?? 0) > 0
+                            ).map((cls) => (
+                              <label
+                                key={cls}
+                                className="flex cursor-pointer items-center gap-2 rounded-lg py-1.5 px-4 hover:bg-white/10 capitalize"
+                              >
+                                <input
+                                  type="checkbox"
+                                  className="size-4 rounded border-white/20 bg-transparent accent-accent-600"
+                                  checked={classificationFilter.includes(
+                                    cls
+                                  )}
+                                  onChange={() => {
+                                    setTablePaginations(
+                                      "food-composition-table",
+                                      1,
+                                      20
+                                    );
+                                    setClassificationFilter((prev) =>
+                                      prev.includes(cls)
+                                        ? prev.filter((c) => c !== cls)
+                                        : [...prev, cls]
+                                    );
+                                  }}
+                                />
+                                <span className="flex-1 text-sm">
+                                  {cls === "n/a"
+                                    ? "Unclassified"
+                                    : cls}
+                                </span>
+                                <span className="text-xs text-light-400">
+                                  {classificationCounts[cls]}
+                                </span>
+                              </label>
                             ))}
-                          </ListboxOptions>
-                        </Listbox>
+                          </PopoverPanel>
+                        </Popover>
                       ) : (
                       <div
                         className={`group flex gap-1 items-center flex-nowrap w-full ${

--- a/frontend/components/entities/food/MacrosAndMicrosSection.tsx
+++ b/frontend/components/entities/food/MacrosAndMicrosSection.tsx
@@ -7,10 +7,9 @@ import { useEffect, useState } from "react";
 import Button from "@/components/basic/Button";
 import Card from "@/components/basic/Card";
 import Heading from "@/components/basic/Heading";
-import Link from "@/components/basic/Link";
 import Modal from "@/components/basic/Modal";
 import { getFoodMacroAndMicroData } from "@/utils/fetching";
-import { encodeSpace, formatConcentrationValueAlt } from "@/utils/utils";
+import { formatConcentrationValueAlt } from "@/utils/utils";
 import { MacroAndMicroData } from "@/types";
 
 const VALUES_CUTOFF = 5;
@@ -87,15 +86,9 @@ const MacrosAndMicrosSection = ({
                           key={concentration.name + "_" + index}
                           className="flex items-baseline w-full gap-2.5"
                         >
-                          <Link
-                            href={`/chemical/${encodeURIComponent(
-                              encodeSpace(concentration.name)
-                            )}`}
-                            className="capitalize"
-                            isExternal={false}
-                          >
+                          <span className="capitalize">
                             {concentration.name}
-                          </Link>
+                          </span>
                           <span className="flex-grow border-b-2 border-dotted border-light-700" />
                           <span className="text-right">
                             {concentration.median_concentration?.value
@@ -124,15 +117,9 @@ const MacrosAndMicrosSection = ({
                 key={concentration.name + "_" + index}
                 className="flex items-baseline w-full gap-2.5"
               >
-                <Link
-                  href={`/chemical/${encodeURIComponent(
-                    encodeSpace(concentration.name)
-                  )}`}
-                  className="capitalize"
-                  isExternal={false}
-                >
+                <span className="capitalize">
                   {concentration.name}
-                </Link>
+                </span>
                 <span className="flex-grow border-b-2 border-dotted border-light-700" />
                 <span className="text-right">
                   {concentration.median_concentration?.value

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -14,7 +14,7 @@ html {
   background-color: #0a0a09;
   color: #fff;
   padding: 0 !important;
-  scrollbar-gutter: stable;
+  overflow-y: scroll !important;
 }
 
 a {

--- a/frontend/utils/__tests__/greekLetters.test.ts
+++ b/frontend/utils/__tests__/greekLetters.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from "vitest";
+
+import { greekVariants, matchesWithGreek } from "@/utils/greekLetters";
+
+describe("greekVariants", () => {
+  it("returns empty array for null/undefined/empty input", () => {
+    expect(greekVariants(null)).toEqual([]);
+    expect(greekVariants(undefined)).toEqual([]);
+    expect(greekVariants("")).toEqual([]);
+  });
+
+  it("returns escaped original for names without Greek letters", () => {
+    expect(greekVariants("tocopherol")).toEqual(["tocopherol"]);
+  });
+
+  it("generates Greek variant for Latin name", () => {
+    const variants = greekVariants("alpha-tocopherol");
+    expect(variants).toContain("alpha-tocopherol");
+    expect(variants).toContain("\u03b1-tocopherol");
+  });
+
+  it("generates Latin variant for Greek name", () => {
+    const variants = greekVariants("\u03b1-tocopherol");
+    expect(variants).toContain("\u03b1-tocopherol");
+    expect(variants).toContain("alpha-tocopherol");
+  });
+
+  it("handles beta mapping", () => {
+    const variants = greekVariants("beta-carotene");
+    expect(variants).toContain("beta-carotene");
+    expect(variants).toContain("\u03b2-carotene");
+  });
+
+  it("handles case-insensitive Latin replacement", () => {
+    const variants = greekVariants("Alpha-tocopherol");
+    expect(variants).toContain("Alpha-tocopherol");
+    expect(variants).toContain("\u03b1-tocopherol");
+  });
+
+  it("escapes regex special characters", () => {
+    const variants = greekVariants("alpha (test)");
+    expect(variants).toContain("alpha \\(test\\)");
+    expect(variants).toContain("\u03b1 \\(test\\)");
+  });
+});
+
+describe("matchesWithGreek", () => {
+  it("returns false for null/undefined inputs", () => {
+    expect(matchesWithGreek(null, "alpha")).toBe(false);
+    expect(matchesWithGreek("alpha", null)).toBe(false);
+    expect(matchesWithGreek(undefined, undefined)).toBe(false);
+  });
+
+  it("matches exact same string", () => {
+    expect(matchesWithGreek("tocopherol", "tocopherol")).toBe(true);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(matchesWithGreek("Alpha", "alpha")).toBe(true);
+  });
+
+  it("matches Greek character against Latin name", () => {
+    expect(
+      matchesWithGreek("\u03b1-tocopherol", "alpha-tocopherol")
+    ).toBe(true);
+  });
+
+  it("matches Latin name against Greek character", () => {
+    expect(
+      matchesWithGreek("alpha-tocopherol", "\u03b1-tocopherol")
+    ).toBe(true);
+  });
+
+  it("matches beta variants", () => {
+    expect(matchesWithGreek("\u03b2-carotene", "beta-carotene")).toBe(true);
+    expect(matchesWithGreek("beta-carotene", "\u03b2-carotene")).toBe(true);
+  });
+
+  it("returns false for non-matching strings", () => {
+    expect(matchesWithGreek("gamma-linolenic", "alpha-tocopherol")).toBe(
+      false
+    );
+  });
+});

--- a/frontend/utils/fetching.ts
+++ b/frontend/utils/fetching.ts
@@ -65,7 +65,7 @@ export async function getFoodCompositionData(
 ) {
   const clsParam =
     classificationFilters.length > 0
-      ? `&filter_classification=${classificationFilters.join("+")}`
+      ? `&filter_classification=${classificationFilters.map(encodeURIComponent).join("%2B")}`
       : "";
   const response = await fetch(
     `${
@@ -73,7 +73,7 @@ export async function getFoodCompositionData(
     }/food/composition?common_name=${encodeURIComponent(
       commonName
     )}&page=${currentPage}&filter_source=${sourceFilters.join(
-      "+"
+      "%2B"
     )}&search=${encodeURIComponent(searchTerm)}&sort_by=${
       sort.column
     }&sort_dir=${sort.direction}&show_all_rows=${showAllConcentrations}${clsParam}`,

--- a/frontend/utils/greekLetters.ts
+++ b/frontend/utils/greekLetters.ts
@@ -1,0 +1,89 @@
+/**
+ * Greek-letter ↔ Latin-name mapping for highlight matching.
+ *
+ * The KGC pipeline standardizes Greek letters to their Latin names
+ * (e.g. α → alpha) in attestation chemical names. The original
+ * evidence sentences still use Unicode Greek characters, so we need
+ * to generate alternate name variants for regex matching.
+ */
+
+const GREEK_LETTER_MAP: readonly [string, string][] = [
+  ["alpha", "α"],
+  ["beta", "β"],
+  ["gamma", "γ"],
+  ["delta", "δ"],
+  ["epsilon", "ε"],
+  ["omega", "ω"],
+];
+
+/**
+ * Escape special regex characters in a string.
+ */
+function escapeRegex(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Return all Greek-letter variants of a name.
+ *
+ * For a name like "alpha-tocopherol", this returns
+ * ["alpha\\-tocopherol", "α\\-tocopherol"]. All returned strings
+ * are regex-escaped so they can be safely interpolated into a
+ * RegExp pattern.
+ *
+ * Returns an empty array for null/undefined/empty input.
+ */
+export function greekVariants(name: string | null | undefined): string[] {
+  if (!name) return [];
+
+  const escaped = escapeRegex(name);
+  const variants = new Set<string>([escaped]);
+
+  for (const [latin, greek] of GREEK_LETTER_MAP) {
+    // Latin → Greek variant (case-insensitive replacement)
+    const latinPattern = new RegExp(escapeRegex(latin), "gi");
+    if (latinPattern.test(name)) {
+      const greekName = name.replace(latinPattern, greek);
+      variants.add(escapeRegex(greekName));
+    }
+
+    // Greek → Latin variant
+    const greekPattern = new RegExp(escapeRegex(greek), "g");
+    if (greekPattern.test(name)) {
+      const latinName = name.replace(greekPattern, latin);
+      variants.add(escapeRegex(latinName));
+    }
+  }
+
+  return Array.from(variants);
+}
+
+/**
+ * Check whether a sentence part matches an extraction name,
+ * accounting for Greek-letter variants.
+ *
+ * Returns true if `part` case-insensitively equals `name` or any
+ * of its Greek/Latin variants.
+ */
+export function matchesWithGreek(
+  part: string | null | undefined,
+  name: string | null | undefined
+): boolean {
+  if (!part || !name) return false;
+
+  const lower = part.toLowerCase();
+  if (lower === name.toLowerCase()) return true;
+
+  for (const [latin, greek] of GREEK_LETTER_MAP) {
+    const latinPattern = new RegExp(escapeRegex(latin), "gi");
+    const greekPattern = new RegExp(escapeRegex(greek), "g");
+
+    const withGreek = name.replace(latinPattern, greek).toLowerCase();
+    if (lower === withGreek) return true;
+
+    const withLatin = name.replace(greekPattern, latin).toLowerCase();
+    if (lower === withLatin) return true;
+  }
+
+  return false;
+}


### PR DESCRIPTION
## Summary

Batch of frontend fixes and one backend fix:

- **Classification filter UX (#74)**: Replaced Headless UI Listbox with actual checkboxes. All classes checked by default, select all/deselect all toggle, hide 0-count classes. Fixed OR filter bug where URL `+` separator was decoded as space — now uses `%2B` encoding and per-value `ANY()` SQL instead of array overlap.
- **FDC Nutrient links (#66)**: Removed broken hyperlinks for FDC Nutrient identifiers (no dedicated page exists). Applies in both the identifiers table and macro/micro section.
- **Evidence highlight (#55)**: Added `greekVariants()` utility so sentence highlighting matches both Unicode Greek (α, β) and Latin equivalents (alpha, beta). 14 unit tests.
- **Identifiers table (#59)**: Refactored external IDs from card grid to a two-column table (Source | Identifier) with fixed column widths and comma-separated multi-IDs per source.
- **Scrollbar (#69)**: Replaced `scrollbar-gutter: stable` with `overflow-y: scroll \!important` on `<html>` to keep the scrollbar visible when modals are open, preventing layout shift.

## Files changed

**Backend:**
- `backend/api/src/repositories/food.py` — classification filter uses per-value `ANY()` for correct OR semantics
- `backend/api/src/repositories/formatting.py` — removed broken FDC Nutrient URL template

**Frontend:**
- `frontend/components/entities/food/FoodCompositionSection.tsx` — checkbox-based classification filter with select all/deselect all
- `frontend/components/entities/MetainformationSection.tsx` — identifiers as table
- `frontend/components/entities/food/FoodAtlasEvidence.tsx` — Greek letter highlight support
- `frontend/utils/greekLetters.ts` — new utility + tests
- `frontend/utils/fetching.ts` — `%2B` encoding for filter params
- `frontend/styles/globals.css` — scrollbar fix
- `frontend/components/basic/Modal.tsx` — removed redundant overflow toggle
- `frontend/components/entities/food/MacrosAndMicrosSection.tsx` — nutrient names as plain text

Closes #55, #59, #66, #69, #74