### PR TITLE
fix: concentration display, collapsible unknowns, and chemical deep-links (#60)

### DIFF
--- a/backend/api/src/repositories/chemical.py
+++ b/backend/api/src/repositories/chemical.py
@@ -27,18 +27,28 @@ async def get_metadata(session: AsyncSession, common_name: str) -> dict[str, obj
 
 async def get_composition(session: AsyncSession, common_name: str) -> dict[str, object]:
     """Get foods containing this chemical, split by concentration."""
-    base = """
-        SELECT food_foodatlas_id AS id, food_name AS name,
-               median_concentration
-        FROM mv_food_chemical_composition
-        WHERE chemical_name = :name
-    """
     with_conc = await session.execute(
-        text(f"{base} AND median_concentration IS NOT NULL"),
+        text("""
+            SELECT food_foodatlas_id AS id, food_name AS name,
+                   median_concentration
+            FROM mv_food_chemical_composition
+            WHERE chemical_name = :name AND median_concentration IS NOT NULL
+        """),
         {"name": common_name},
     )
     without_conc = await session.execute(
-        text(f"{base} AND median_concentration IS NULL"),
+        text("""
+            SELECT food_foodatlas_id AS id, food_name AS name,
+                   COALESCE(jsonb_array_length(fdc_evidences), 0)
+                   + COALESCE(jsonb_array_length(foodatlas_evidences), 0)
+                   + COALESCE(jsonb_array_length(dmd_evidences), 0)
+                   AS evidence_count
+            FROM mv_food_chemical_composition
+            WHERE chemical_name = :name AND median_concentration IS NULL
+            ORDER BY COALESCE(jsonb_array_length(fdc_evidences), 0)
+                   + COALESCE(jsonb_array_length(foodatlas_evidences), 0)
+                   + COALESCE(jsonb_array_length(dmd_evidences), 0) DESC
+        """),
         {"name": common_name},
     )
     with_data = [dict(r._mapping) for r in with_conc]

--- a/backend/api/src/repositories/food.py
+++ b/backend/api/src/repositories/food.py
@@ -204,8 +204,12 @@ def _build_query_parts(
         conditions.append(valid[0] + "_evidences IS NOT NULL")
 
     if search_term:
-        conditions.append("chemical_name ILIKE :search")
-        params["search"] = "%" + search_term + "%"
+        if search_term.startswith("e") and search_term[1:].isdigit():
+            conditions.append("chemical_foodatlas_id = :search")
+            params["search"] = search_term
+        else:
+            conditions.append("chemical_name ILIKE :search")
+            params["search"] = "%" + search_term + "%"
 
     if not show_all_rows:
         conditions.append("median_concentration IS NOT NULL")

--- a/backend/api/tests/test_repo_other.py
+++ b/backend/api/tests/test_repo_other.py
@@ -49,7 +49,7 @@ class TestChemicalGetComposition:
     @pytest.mark.asyncio
     async def test_splits_by_concentration(self) -> None:
         with_row = _make_row(id="FA:F001", name="apple", median_concentration=5.0)
-        without_row = _make_row(id="FA:F002", name="banana", median_concentration=None)
+        without_row = _make_row(id="FA:F002", name="banana", evidence_count=3)
         session = AsyncMock()
         r_with = MagicMock()
         r_with.__iter__ = lambda self: iter([with_row])

--- a/backend/db/src/etl/materializer_composition.py
+++ b/backend/db/src/etl/materializer_composition.py
@@ -249,5 +249,4 @@ def _compute_median(evidences: list) -> dict | None:
     if not values:
         return None
     median = float(np.median(values))
-    formatted = f"{median:.6f}".rstrip("0").rstrip(".")
-    return {"unit": "mg/100g", "value": formatted}
+    return {"unit": "mg/100g", "value": median}

--- a/backend/db/tests/test_materializer.py
+++ b/backend/db/tests/test_materializer.py
@@ -24,7 +24,7 @@ class TestComputeMedian:
         result = _compute_median(evidences)
         assert result is not None
         assert result["unit"] == "mg/100g"
-        assert result["value"] == "10"
+        assert result["value"] == 10.0
 
     def test_multiple_values_median(self):
         evidences = [
@@ -37,7 +37,7 @@ class TestComputeMedian:
         ]
         result = _compute_median(evidences)
         assert result is not None
-        assert result["value"] == "5"
+        assert result["value"] == 5.0
 
     def test_skips_zero_values(self):
         evidences = [
@@ -50,7 +50,7 @@ class TestComputeMedian:
         ]
         result = _compute_median(evidences)
         assert result is not None
-        assert result["value"] == "6"
+        assert result["value"] == 6.0
 
     def test_skips_non_mg_units(self):
         evidences = [
@@ -95,7 +95,7 @@ class TestComputeMedian:
         ]
         result = _compute_median(evidences)
         assert result is not None
-        assert result["value"] == "2.5"
+        assert result["value"] == 2.5
 
 
 class TestAddFoodatlasEvidence:

--- a/backend/db/tests/test_materializer_helpers.py
+++ b/backend/db/tests/test_materializer_helpers.py
@@ -22,7 +22,7 @@ class TestComputeMedian:
             },
         ]
         result = _compute_median(evidences)
-        assert result == {"unit": "mg/100g", "value": "15"}
+        assert result == {"unit": "mg/100g", "value": 15.0}
 
     def test_returns_none_for_empty(self):
         assert _compute_median([]) is None
@@ -38,7 +38,7 @@ class TestComputeMedian:
         ]
         result = _compute_median(evidences)
         assert result is not None
-        assert result["value"] == "5"
+        assert result["value"] == 5.0
 
     def test_skips_non_mg100g_units(self):
         evidences = [

--- a/frontend/components/entities/chemical/ChemicalCompositionSection.tsx
+++ b/frontend/components/entities/chemical/ChemicalCompositionSection.tsx
@@ -35,6 +35,7 @@ const ChemicalCompositionSection = async ({
           </div>
           <ConcentrationCompositionPlot
             data={compositionData?.with_concentrations}
+            chemicalName={metaData?.id}
           />
         </div>
         {/* without concentration section */}
@@ -52,6 +53,7 @@ const ChemicalCompositionSection = async ({
           </div>
           <NoConcentrationComposition
             data={compositionData?.without_concentrations}
+            chemicalName={metaData?.id}
           />
         </div>
       </div>

--- a/frontend/components/entities/chemical/ConcentrationCompositionPlot.tsx
+++ b/frontend/components/entities/chemical/ConcentrationCompositionPlot.tsx
@@ -26,7 +26,6 @@ import {
   ValueType,
   NameType,
 } from "recharts/types/component/DefaultTooltipContent";
-
 import Card from "@/components/basic/Card";
 import { encodeSpace, formatConcentrationValueAlt } from "@/utils/utils";
 
@@ -50,19 +49,29 @@ const ConcentrationCompositionPlot = ({ data }: DotPlotProps) => {
   const [sortedData, setSortedData] = useState<SortedData[]>([]);
   const [sortOrder, setSortOrder] = useState("desc");
 
+  // whether values span enough orders of magnitude to warrant log scale
+  const useLogScale = useMemo(() => {
+    if (!data || data.length < 2) return false;
+    const values = data
+      .map((r) => r.median_concentration?.value ?? 0)
+      .filter((v) => v > 0);
+    if (values.length < 2) return false;
+    const min = Math.min(...values);
+    const max = Math.max(...values);
+    return max / min > 100;
+  }, [data]);
+
   // sort data
   useEffect(() => {
     if (!data) return;
 
-    const d = Array.from(
-      data.map((row) => {
-        return {
-          food: row.name,
-          value: row.median_concentration?.value ?? 0,
-          id: row.id,
-        };
-      })
-    );
+    const d = data
+      .filter((row) => !useLogScale || (row.median_concentration?.value ?? 0) > 0)
+      .map((row) => ({
+        food: row.name,
+        value: row.median_concentration?.value ?? 0,
+        id: row.id,
+      }));
 
     const sortedData = [...d].sort((a, b) => {
       if (a.value === undefined) return 1;
@@ -72,7 +81,7 @@ const ConcentrationCompositionPlot = ({ data }: DotPlotProps) => {
     });
 
     setSortedData(sortedData);
-  }, [data, sortOrder]);
+  }, [data, sortOrder, useLogScale]);
 
   // custom bar
   const CustomBar = (props: BarProps) => {
@@ -170,9 +179,12 @@ const ConcentrationCompositionPlot = ({ data }: DotPlotProps) => {
             name="concentration (mg/100g)"
             orientation="top"
             fontSize={10}
-            tickCount={10}
+            tickCount={useLogScale ? 5 : 10}
             axisLine={false}
             label={{ angle: -90, offset: 10 }}
+            scale={useLogScale ? "log" : "auto"}
+            domain={useLogScale ? ["auto", "auto"] : undefined}
+            tickFormatter={(v: number) => formatConcentrationValueAlt(v)}
           />
           <YAxis
             type="category"
@@ -200,23 +212,12 @@ const ConcentrationCompositionPlot = ({ data }: DotPlotProps) => {
         </BarChart>
       </ResponsiveContainer>
     );
-  }, [chartHeight, sortedData, router]);
+  }, [chartHeight, sortedData, router, useLogScale]);
 
   return (
     <Card>
       {data && data.length > 0 ? (
         <div className="flex flex-col gap-5">
-          {/* info & sort container */}
-          {/* search */}
-          {/* <div className="relative flex items-center">
-          <MdSearch className="absolute left-2.5 w-5 h-5 text-light-400" />
-          <input
-            className="pl-9 w-60 h-9 text-sm rounded-lg border border-light-50/5 bg-light-800 focus:bg-light-400/20 hover:bg-light-400/20 text-light-100 placeholder-light-400 transition duration-100 ease-in-out outline-light-50/60"
-            type="text"
-            placeholder="Search foods"
-            onChange={handleSearchChange}
-          />
-        </ */}
           {/* label & sort container */}
           <div className="flex justify-between items-center">
             <span className="text-light-400">Found {data.length} foods</span>
@@ -265,9 +266,17 @@ const ConcentrationCompositionPlot = ({ data }: DotPlotProps) => {
           {/* graph container */}
           <div className="mt-2 min-h-16 max-h-80 overflow-y-auto">{graph}</div>
           {/* concentration unit info */}
-          <div className="flex items-center gap-1.5 text-sm text-light-400">
-            <MdInfo />
-            All concentrations shown are measured in mg / 100g
+          <div className="flex flex-col gap-1 text-sm text-light-400">
+            <div className="flex items-center gap-1.5">
+              <MdInfo className="flex-shrink-0" />
+              All concentrations shown are measured in mg / 100g
+            </div>
+            {useLogScale && (
+              <div className="flex items-center gap-1.5">
+                <MdInfo className="flex-shrink-0" />
+                Logarithmic scale applied due to wide range of values
+              </div>
+            )}
           </div>
         </div>
       ) : (

--- a/frontend/components/entities/chemical/ConcentrationCompositionPlot.tsx
+++ b/frontend/components/entities/chemical/ConcentrationCompositionPlot.tsx
@@ -49,24 +49,13 @@ const ConcentrationCompositionPlot = ({ data }: DotPlotProps) => {
   const [sortedData, setSortedData] = useState<SortedData[]>([]);
   const [sortOrder, setSortOrder] = useState("desc");
 
-  // whether values span enough orders of magnitude to warrant log scale
-  const useLogScale = useMemo(() => {
-    if (!data || data.length < 2) return false;
-    const values = data
-      .map((r) => r.median_concentration?.value ?? 0)
-      .filter((v) => v > 0);
-    if (values.length < 2) return false;
-    const min = Math.min(...values);
-    const max = Math.max(...values);
-    return max / min > 100;
-  }, [data]);
 
   // sort data
   useEffect(() => {
     if (!data) return;
 
     const d = data
-      .filter((row) => !useLogScale || (row.median_concentration?.value ?? 0) > 0)
+      .filter((row) => (row.median_concentration?.value ?? 0) >= 0)
       .map((row) => ({
         food: row.name,
         value: row.median_concentration?.value ?? 0,
@@ -81,7 +70,7 @@ const ConcentrationCompositionPlot = ({ data }: DotPlotProps) => {
     });
 
     setSortedData(sortedData);
-  }, [data, sortOrder, useLogScale]);
+  }, [data, sortOrder]);
 
   // custom bar
   const CustomBar = (props: BarProps) => {
@@ -179,12 +168,11 @@ const ConcentrationCompositionPlot = ({ data }: DotPlotProps) => {
             name="concentration (mg/100g)"
             orientation="top"
             fontSize={10}
-            tickCount={useLogScale ? 5 : 10}
             axisLine={false}
             label={{ angle: -90, offset: 10 }}
-            scale={useLogScale ? "log" : "auto"}
-            domain={useLogScale ? ["auto", "auto"] : undefined}
-            tickFormatter={(v: number) => formatConcentrationValueAlt(v)}
+            domain={[0, "dataMax"]}
+            allowDecimals={false}
+            allowDataOverflow={false}
           />
           <YAxis
             type="category"
@@ -212,7 +200,7 @@ const ConcentrationCompositionPlot = ({ data }: DotPlotProps) => {
         </BarChart>
       </ResponsiveContainer>
     );
-  }, [chartHeight, sortedData, router, useLogScale]);
+  }, [chartHeight, sortedData, router]);
 
   return (
     <Card>
@@ -271,12 +259,6 @@ const ConcentrationCompositionPlot = ({ data }: DotPlotProps) => {
               <MdInfo className="flex-shrink-0" />
               All concentrations shown are measured in mg / 100g
             </div>
-            {useLogScale && (
-              <div className="flex items-center gap-1.5">
-                <MdInfo className="flex-shrink-0" />
-                Logarithmic scale applied due to wide range of values
-              </div>
-            )}
           </div>
         </div>
       ) : (

--- a/frontend/components/entities/chemical/ConcentrationCompositionPlot.tsx
+++ b/frontend/components/entities/chemical/ConcentrationCompositionPlot.tsx
@@ -40,11 +40,12 @@ interface DotPlotProps {
       }[]
     | undefined
     | null;
+  chemicalName?: string;
 }
 
 type SortedData = { food: string; value: any; id: string };
 
-const ConcentrationCompositionPlot = ({ data }: DotPlotProps) => {
+const ConcentrationCompositionPlot = ({ data, chemicalName }: DotPlotProps) => {
   const router = useRouter();
   const [sortedData, setSortedData] = useState<SortedData[]>([]);
   const [sortOrder, setSortOrder] = useState("desc");
@@ -147,7 +148,12 @@ const ConcentrationCompositionPlot = ({ data }: DotPlotProps) => {
   const graph = useMemo(() => {
     // handle bar click
     const handleClick = (commonName: string) => {
-      router.push(`/food/${encodeURIComponent(encodeSpace(commonName))}`);
+      const search = chemicalName
+        ? `?search=${encodeURIComponent(chemicalName)}#composition`
+        : "";
+      router.push(
+        `/food/${encodeURIComponent(encodeSpace(commonName))}${search}`
+      );
     };
 
     return (
@@ -200,7 +206,7 @@ const ConcentrationCompositionPlot = ({ data }: DotPlotProps) => {
         </BarChart>
       </ResponsiveContainer>
     );
-  }, [chartHeight, sortedData, router]);
+  }, [chartHeight, sortedData, router, chemicalName]);
 
   return (
     <Card>

--- a/frontend/components/entities/chemical/NoConcentrationComposition.tsx
+++ b/frontend/components/entities/chemical/NoConcentrationComposition.tsx
@@ -1,42 +1,67 @@
 "use client";
 
-import { MdInfoOutline } from "react-icons/md";
+import { useState } from "react";
+import { MdInfoOutline, MdKeyboardArrowDown } from "react-icons/md";
 
 import Link from "@/components/basic/Link";
 import Card from "@/components/basic/Card";
 import { encodeSpace } from "@/utils/utils";
 
+interface NoConcentrationRow {
+  id: string;
+  name: string;
+  evidence_count: number;
+}
+
 interface NoConcentrationCompositionProps {
-  data: any | undefined | null;
+  data: NoConcentrationRow[] | undefined | null;
 }
 
 const NoConcentrationComposition = ({
   data,
 }: NoConcentrationCompositionProps) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+
   return (
     <Card>
-      {/* <div className="relative flex items-center">
-        <MdSearch className="absolute left-2.5 w-5 h-5 text-light-400" />
-        <input
-          className="pl-9 w-60 h-9 text-sm rounded-lg border border-light-50/5 bg-light-800 focus:bg-light-400/20 hover:bg-light-400/20 text-light-100 placeholder-light-400 transition duration-100 ease-in-out outline-light-50/60"
-          type="text"
-          placeholder="Search foods"
-          onChange={handleSearchChange}
-        />
-      </div> */}
-      {data?.length > 0 ? (
-        <div className="flex gap-2 flex-wrap font-light">
-          {/* @ts-ignore */}
-          {data.map((row) => (
-            <Link
-              key={row.id}
-              className="capitalize"
-              href={`/food/${encodeURIComponent(encodeSpace(row.name))}`}
-              isExternal={false}
-            >
-              {row.name}
-            </Link>
-          ))}
+      {data && data.length > 0 ? (
+        <div className="flex flex-col gap-3">
+          {/* collapsible header */}
+          <button
+            className="flex items-center gap-2 text-light-300 hover:text-light-100 transition duration-200 cursor-pointer"
+            onClick={() => setIsExpanded((prev) => !prev)}
+          >
+            <MdKeyboardArrowDown
+              className={`size-5 transition-transform duration-200 ${
+                isExpanded ? "rotate-0" : "-rotate-90"
+              }`}
+            />
+            <span className="text-sm">
+              {data.length} food{data.length === 1 ? "" : "s"} with
+              unknown concentration
+            </span>
+          </button>
+          {/* expanded content */}
+          {isExpanded && (
+            <div className="flex gap-2 flex-wrap font-light">
+              {data.map((row) => (
+                <span key={row.id} className="flex items-baseline gap-1">
+                  <Link
+                    className="capitalize"
+                    href={`/food/${encodeURIComponent(encodeSpace(row.name))}`}
+                    isExternal={false}
+                  >
+                    {row.name}
+                  </Link>
+                  {row.evidence_count > 0 && (
+                    <span className="text-xs text-light-500">
+                      ({row.evidence_count})
+                    </span>
+                  )}
+                </span>
+              ))}
+            </div>
+          )}
         </div>
       ) : (
         <div className="h-16 flex items-center justify-center text-light-300 gap-2">

--- a/frontend/components/entities/chemical/NoConcentrationComposition.tsx
+++ b/frontend/components/entities/chemical/NoConcentrationComposition.tsx
@@ -15,10 +15,12 @@ interface NoConcentrationRow {
 
 interface NoConcentrationCompositionProps {
   data: NoConcentrationRow[] | undefined | null;
+  chemicalName?: string;
 }
 
 const NoConcentrationComposition = ({
   data,
+  chemicalName,
 }: NoConcentrationCompositionProps) => {
   const [isExpanded, setIsExpanded] = useState(false);
 
@@ -43,12 +45,17 @@ const NoConcentrationComposition = ({
           </button>
           {/* expanded content */}
           {isExpanded && (
+            <div className="flex flex-col gap-3">
+            <p className="text-xs text-light-500">
+              Number in parentheses indicates the number of evidence
+              sources supporting this food-chemical relationship.
+            </p>
             <div className="flex gap-2 flex-wrap font-light">
               {data.map((row) => (
                 <span key={row.id} className="flex items-baseline gap-1">
                   <Link
                     className="capitalize"
-                    href={`/food/${encodeURIComponent(encodeSpace(row.name))}`}
+                    href={`/food/${encodeURIComponent(encodeSpace(row.name))}${chemicalName ? `?search=${encodeURIComponent(chemicalName)}#composition` : ""}`}
                     isExternal={false}
                   >
                     {row.name}
@@ -60,6 +67,7 @@ const NoConcentrationComposition = ({
                   )}
                 </span>
               ))}
+            </div>
             </div>
           )}
         </div>

--- a/frontend/components/entities/food/FoodCompositionSection.tsx
+++ b/frontend/components/entities/food/FoodCompositionSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
 import {
   Listbox,
   ListboxButton,
@@ -81,6 +82,7 @@ interface FoodCompositionSectionProps {
 const FoodCompositionSection = ({
   commonName,
 }: FoodCompositionSectionProps) => {
+  const searchParams = useSearchParams();
   const [data, setData] = useState<FoodCompositionData[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [isError, setIsError] = useState(false);
@@ -88,7 +90,9 @@ const FoodCompositionSection = ({
   const { currentPage } = getTablePaginations("food-composition-table");
   const [numberOfPages, setNumberOfPages] = useState(-1);
   const [numberOfRows, setNumberOfRows] = useState(-1);
-  const [searchTerm, setSearchTerm] = useState("");
+  const [searchTerm, setSearchTerm] = useState(
+    searchParams.get("search") ?? ""
+  );
   const [sourceFilters, setSourceFilters] = useState<string[]>([
     "fdc",
     "foodatlas",
@@ -247,7 +251,7 @@ const FoodCompositionSection = ({
 
   return (
     <>
-      <div className="flex flex-col gap-7">
+      <div id="composition" className="flex flex-col gap-7 scroll-mt-8">
         <Heading type="h2" variant="boxed">
           Full Chemical Composition
         </Heading>
@@ -261,6 +265,7 @@ const FoodCompositionSection = ({
                 className="pl-9 w-full lg:w-72 h-9 text-sm rounded-lg border border-light-50/5 bg-light-900 focus:bg-light-400/20 hover:bg-light-400/20 text-light-100 placeholder-light-400 transition duration-100 ease-in-out outline-light-50/60"
                 type="text"
                 placeholder="Search for a chemical"
+                value={searchTerm}
                 onChange={handleSearch}
               />
             </div>


### PR DESCRIPTION
## Summary

- **Median concentration stored as number**: `_compute_median` was formatting the value as a string, causing Recharts to compare lexicographically (e.g. `"7400" > "10800"`). Now stores a proper float in JSONB. Requires ETL reload.
- **Collapsible unknown concentration section**: Collapsed by default showing count. Expanded view shows foods sorted by evidence count with explanation text.
- **Deep-link from chemical → food page**: Clicking a food on a chemical page navigates to `/food/<name>?search=<entityId>#composition`, scrolling to the composition table with the search box pre-filled.
- **Search by entity ID**: Search terms matching `e<digits>` pattern do exact match on `chemical_foodatlas_id` instead of ILIKE on name, enabling precise filtering from chemical page links.

## Files changed

**Backend:**
- `backend/api/src/repositories/food.py` — entity ID search support, classification filter fix
- `backend/db/src/etl/materializer_composition.py` — numeric median value
- `backend/db/tests/test_materializer.py` — updated assertions
- `backend/db/tests/test_materializer_helpers.py` — updated assertions

**Frontend:**
- `frontend/components/entities/chemical/ConcentrationCompositionPlot.tsx` — removed log scale, fixed axis domain, deep-link on bar click
- `frontend/components/entities/chemical/NoConcentrationComposition.tsx` — collapsible section, evidence count, deep-link, explanation text
- `frontend/components/entities/chemical/ChemicalCompositionSection.tsx` — passes entity ID to child components
- `frontend/components/entities/food/FoodCompositionSection.tsx` — reads `?search` param, controlled search input, `#composition` scroll target

Closes #60