### PR TITLE
feat: fix disease table PMIDs, descendant aggregation, and source chemical column

### DIFF
--- a/backend/api/src/repositories/chemical.py
+++ b/backend/api/src/repositories/chemical.py
@@ -83,10 +83,11 @@ async def get_correlation(
     result = await session.execute(
         text("""
             SELECT disease_foodatlas_id AS id, disease_name AS name,
-                   sources, evidences
+                   source_chemical_name, source_chemical_foodatlas_id,
+                   sources, evidences, evidence_count
             FROM mv_chemical_disease_correlation
             WHERE chemical_name = :name AND relationship_id = :rel
-            ORDER BY jsonb_array_length(evidences) DESC
+            ORDER BY evidence_count DESC
             OFFSET :offset ROWS FETCH FIRST :limit ROWS ONLY
         """),
         {

--- a/backend/api/src/repositories/disease.py
+++ b/backend/api/src/repositories/disease.py
@@ -42,10 +42,10 @@ async def get_correlation(
     result = await session.execute(
         text("""
             SELECT chemical_foodatlas_id AS id, chemical_name AS name,
-                   sources, evidences
+                   sources, evidences, evidence_count
             FROM mv_chemical_disease_correlation
             WHERE disease_name = :name AND relationship_id = :rel
-            ORDER BY jsonb_array_length(evidences) DESC
+            ORDER BY evidence_count DESC
             OFFSET :offset ROWS FETCH FIRST :limit ROWS ONLY
         """),
         {

--- a/backend/db/main.py
+++ b/backend/db/main.py
@@ -23,7 +23,8 @@ def cli() -> None:
 @click.option(
     "--parquet-dir",
     type=click.Path(exists=True, path_type=Path),
-    required=True,
+    default=Path(__file__).resolve().parent.parent / "kgc" / "outputs" / "kg",
+    show_default=True,
     help="Path to KGC output directory containing parquet files.",
 )
 def load(parquet_dir: Path) -> None:

--- a/backend/db/migrations/versions/001_initial_schema.py
+++ b/backend/db/migrations/versions/001_initial_schema.py
@@ -197,8 +197,11 @@ def upgrade() -> None:
         sa.Column("relationship_id", sa.String(10), nullable=False),
         sa.Column("disease_name", sa.Text, nullable=False),
         sa.Column("disease_foodatlas_id", sa.String(20), nullable=False),
+        sa.Column("source_chemical_name", sa.Text, server_default=""),
+        sa.Column("source_chemical_foodatlas_id", sa.String(20), server_default=""),
         sa.Column("sources", postgresql.ARRAY(sa.Text), server_default="{}"),
         sa.Column("evidences", postgresql.JSONB, server_default="[]"),
+        sa.Column("evidence_count", sa.Integer, server_default="0"),
     )
     op.create_index(
         "ix_mv_cdc_chem_rel",

--- a/backend/db/src/etl/materializer.py
+++ b/backend/db/src/etl/materializer.py
@@ -49,7 +49,12 @@ def _materialize_entity_views(conn: Connection) -> None:
     )
     _insert_mv_entities(conn, "mv_food_entities", foods, ["food_classification"])
 
-    chem_ids = set(r1["tail_id"])
+    # Include chemicals from food composition (r1), disease correlations (r3/r4),
+    # and their IS_A ancestors (so ancestor pages have metadata).
+    r2 = triplets[triplets["relationship_id"] == "r2"]
+    disease_chem_ids = set(r3r4["head_id"])
+    ancestor_ids = _collect_ancestors(r2, disease_chem_ids, entities)
+    chem_ids = set(r1["tail_id"]) | disease_chem_ids | ancestor_ids
     chemicals = entities[
         (entities["entity_type"] == "chemical")
         & (entities["foodatlas_id"].isin(chem_ids))
@@ -67,8 +72,7 @@ def _materialize_entity_views(conn: Connection) -> None:
         ["chemical_classification", "flavor_descriptors"],
     )
 
-    disease_chem_ids = set(r3r4["head_id"]) & chem_ids
-    relevant_disease_ids = set(r3r4[r3r4["head_id"].isin(disease_chem_ids)]["tail_id"])
+    relevant_disease_ids = set(r3r4["tail_id"])
     diseases = entities[
         (entities["entity_type"] == "disease")
         & (entities["foodatlas_id"].isin(relevant_disease_ids))
@@ -81,6 +85,27 @@ def _materialize_entity_views(conn: Connection) -> None:
         len(chemicals),
         len(diseases),
     )
+
+
+def _collect_ancestors(
+    r2: pd.DataFrame, seed_ids: set[str], entities: pd.DataFrame
+) -> set[str]:
+    """Return all chemical ancestors of seed_ids via IS_A (r2) triplets."""
+    chem_ids_all = set(entities[entities["entity_type"] == "chemical"]["foodatlas_id"])
+    chem_r2 = r2[r2["head_id"].isin(chem_ids_all) & r2["tail_id"].isin(chem_ids_all)]
+    parents_of: dict[str, set[str]] = {}
+    for _, row in chem_r2.iterrows():
+        parents_of.setdefault(row["head_id"], set()).add(row["tail_id"])
+
+    ancestors: set[str] = set()
+    for node in seed_ids:
+        stack = list(parents_of.get(node, set()))
+        while stack:
+            parent = stack.pop()
+            if parent not in ancestors:
+                ancestors.add(parent)
+                stack.extend(parents_of.get(parent, set()))
+    return ancestors
 
 
 def _insert_mv_entities(

--- a/backend/db/src/etl/materializer_correlation.py
+++ b/backend/db/src/etl/materializer_correlation.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+from collections import defaultdict
 
 import pandas as pd
 from sqlalchemy import text
@@ -12,9 +13,20 @@ from .bulk_insert import bulk_copy
 
 logger = logging.getLogger(__name__)
 
+_PUBMED_URL = "https://pubmed.ncbi.nlm.nih.gov/"
+_PMC_URL = "https://www.ncbi.nlm.nih.gov/pmc/?term="
+
 
 def materialize_chemical_disease_correlation(conn: Connection) -> None:
-    """Build mv_chemical_disease_correlation from r3/r4 triplets."""
+    """Build mv_chemical_disease_correlation from r3/r4 triplets.
+
+    For each chemical, includes disease correlations from itself and all
+    descendant chemicals (via IS_A hierarchy) so that parent categories
+    like "Vitamin" surface their children's connections.
+
+    Each (chemical, source_chemical, disease, rel) gets its own row so
+    the frontend can show which descendant contributes the connection.
+    """
     r3r4 = pd.read_sql(
         text("SELECT * FROM base_triplets WHERE relationship_id IN ('r3', 'r4')"),
         conn,
@@ -22,36 +34,59 @@ def materialize_chemical_disease_correlation(conn: Connection) -> None:
     attestations = pd.read_sql(text("SELECT * FROM base_attestations"), conn)
     evidence = pd.read_sql(text("SELECT * FROM base_evidence"), conn)
     entities = pd.read_sql(
-        text("SELECT foodatlas_id, common_name FROM base_entities"), conn
+        text("SELECT foodatlas_id, common_name, entity_type FROM base_entities"),
+        conn,
     )
 
     name_map = entities.set_index("foodatlas_id")["common_name"].to_dict()
+    etype_map = entities.set_index("foodatlas_id")["entity_type"].to_dict()
     att_map = attestations.set_index("attestation_id")
     ev_map = evidence.set_index("evidence_id")
 
-    rows = []
+    ancestors_of = _build_ancestors(conn, etype_map)
+
+    # Keyed by (chemical_id, source_chemical_id, disease_id, rel_id)
+    agg: dict[tuple, dict] = {}
+
     for _, triplet in tqdm(
         r3r4.iterrows(), total=len(r3r4), desc="correlation", leave=True
     ):
         chem_id = triplet["head_id"]
         disease_id = triplet["tail_id"]
+        rel_id = triplet["relationship_id"]
         att_ids = triplet["attestation_ids"] or []
 
         sources, evidences = _get_correlation_evidence(att_ids, att_map, ev_map)
+
+        # Direct row: source_chemical = chemical itself
+        _merge_into(agg, chem_id, chem_id, disease_id, rel_id, sources, evidences)
+
+        # Inherited rows: source_chemical = the actual descendant (chem_id)
+        for ancestor_id in ancestors_of.get(chem_id, set()):
+            _merge_into(
+                agg, ancestor_id, chem_id, disease_id, rel_id, sources, evidences
+            )
+
+    if not agg:
+        return
+
+    rows = []
+    for (chem_id, src_chem_id, disease_id, rel_id), data in agg.items():
+        deduped = _deduplicate_evidences(data["evidences"])
         rows.append(
             {
                 "chemical_name": name_map.get(chem_id, ""),
                 "chemical_foodatlas_id": chem_id,
-                "relationship_id": triplet["relationship_id"],
+                "relationship_id": rel_id,
                 "disease_name": name_map.get(disease_id, ""),
                 "disease_foodatlas_id": disease_id,
-                "sources": sources,
-                "evidences": json.dumps(evidences),
+                "source_chemical_name": name_map.get(src_chem_id, ""),
+                "source_chemical_foodatlas_id": src_chem_id,
+                "sources": list(data["sources"]),
+                "evidences": json.dumps(deduped),
+                "evidence_count": len(deduped),
             }
         )
-
-    if not rows:
-        return
 
     result = pd.DataFrame(rows)
     columns = [
@@ -60,11 +95,83 @@ def materialize_chemical_disease_correlation(conn: Connection) -> None:
         "relationship_id",
         "disease_name",
         "disease_foodatlas_id",
+        "source_chemical_name",
+        "source_chemical_foodatlas_id",
         "sources",
         "evidences",
+        "evidence_count",
     ]
     bulk_copy(conn, "mv_chemical_disease_correlation", result, columns)
     logger.info("Chemical-disease correlations: %d rows", len(result))
+
+
+def _merge_into(
+    agg: dict[tuple, dict],
+    chem_id: str,
+    src_chem_id: str,
+    disease_id: str,
+    rel_id: str,
+    sources: list[str],
+    evidences: list[dict],
+) -> None:
+    """Merge evidence into aggregated row."""
+    key = (chem_id, src_chem_id, disease_id, rel_id)
+    if key not in agg:
+        agg[key] = {"sources": set(), "evidences": []}
+    agg[key]["sources"].update(sources)
+    agg[key]["evidences"].extend(evidences)
+
+
+def _deduplicate_evidences(evidences: list[dict]) -> list[dict]:
+    """Remove duplicate evidence entries by PMID/PMCID."""
+    seen: set[str] = set()
+    result: list[dict] = []
+    for ev in evidences:
+        eid = ev.get("pmid", {}).get("id") or ev.get("pmcid", {}).get("id") or ""
+        key = str(eid)
+        if key and key not in seen:
+            seen.add(key)
+            result.append(ev)
+    return result
+
+
+def _build_ancestors(
+    conn: Connection, etype_map: dict[str, str]
+) -> dict[str, set[str]]:
+    """Build child -> all ancestors map from chemical IS_A triplets."""
+    r2 = pd.read_sql(
+        text("SELECT head_id, tail_id FROM base_triplets WHERE relationship_id = 'r2'"),
+        conn,
+    )
+    # Filter to chemical-chemical IS_A only
+    r2 = r2[
+        r2["head_id"].map(lambda x: etype_map.get(x) == "chemical")
+        & r2["tail_id"].map(lambda x: etype_map.get(x) == "chemical")
+    ]
+
+    parents_of: dict[str, set[str]] = defaultdict(set)
+    for _, row in r2.iterrows():
+        parents_of[row["head_id"]].add(row["tail_id"])
+
+    cache: dict[str, set[str]] = {}
+
+    def _ancestors(node: str) -> set[str]:
+        if node in cache:
+            return cache[node]
+        result: set[str] = set()
+        stack = list(parents_of.get(node, set()))
+        while stack:
+            parent = stack.pop()
+            if parent not in result:
+                result.add(parent)
+                stack.extend(parents_of.get(parent, set()))
+        cache[node] = result
+        return result
+
+    for node in parents_of:
+        _ancestors(node)
+
+    return cache
 
 
 def _get_correlation_evidence(
@@ -92,12 +199,12 @@ def _get_correlation_evidence(
         if "pmcid" in ref:
             ev_dict["pmcid"] = {
                 "id": ref["pmcid"],
-                "url": f"https://www.ncbi.nlm.nih.gov/pmc/?term={ref['pmcid']}",
+                "url": f"{_PMC_URL}{ref['pmcid']}",
             }
         if "pmid" in ref:
             ev_dict["pmid"] = {
-                "id": ref["pmid"],
-                "url": f"https://pubmed.ncbi.nlm.nih.gov/{ref['pmid']}",
+                "id": str(ref["pmid"]),
+                "url": f"{_PUBMED_URL}{ref['pmid']}",
             }
         if ev_dict:
             evidences.append(ev_dict)

--- a/backend/db/src/models/views.py
+++ b/backend/db/src/models/views.py
@@ -96,7 +96,9 @@ class MVFoodChemicalComposition(Base):
 class MVChemicalDiseaseCorrelation(Base):
     """Denormalized chemical-disease correlations with evidence.
 
-    One row per chemical-disease-relationship triplet (r3/r4).
+    One row per (chemical, source_chemical, disease, relationship).
+    For direct connections source_chemical = chemical itself.
+    For inherited connections source_chemical = the descendant chemical.
     """
 
     __tablename__ = "mv_chemical_disease_correlation"
@@ -107,8 +109,13 @@ class MVChemicalDiseaseCorrelation(Base):
     relationship_id: Mapped[str] = mapped_column(String(10), nullable=False)
     disease_name: Mapped[str] = mapped_column(Text, nullable=False)
     disease_foodatlas_id: Mapped[str] = mapped_column(String(20), nullable=False)
+    source_chemical_name: Mapped[str] = mapped_column(Text, server_default="")
+    source_chemical_foodatlas_id: Mapped[str] = mapped_column(
+        String(20), server_default=""
+    )
     sources: Mapped[list[str]] = mapped_column(ARRAY(Text), server_default="{}")
     evidences: Mapped[list] = mapped_column(JSONB, server_default="[]")
+    evidence_count: Mapped[int] = mapped_column(Integer, server_default="0")
 
     __table_args__ = (
         Index("ix_mv_cdc_chem_rel", "chemical_name", "relationship_id"),

--- a/backend/db/tests/test_correlation_helpers.py
+++ b/backend/db/tests/test_correlation_helpers.py
@@ -3,50 +3,58 @@
 import json
 
 import pandas as pd
-from src.etl.materializer_correlation import _get_correlation_evidence
+from src.etl.materializer_correlation import (
+    _deduplicate_evidences,
+    _get_correlation_evidence,
+    _merge_into,
+)
 
 
 class TestGetCorrelationEvidence:
     def test_extracts_pmcid_and_pmid(self):
         att_map = pd.DataFrame(
-            {
-                "evidence_id": ["ev1"],
-                "source": ["ctd"],
-            },
+            {"evidence_id": ["ev1"], "source": ["ctd"]},
             index=["at1"],
         )
         ev_map = pd.DataFrame(
-            {
-                "reference": [{"pmcid": "PMC123", "pmid": "456"}],
-            },
+            {"reference": [{"pmcid": "PMC123", "pmid": "456"}]},
             index=["ev1"],
         )
         sources, evidences = _get_correlation_evidence(["at1"], att_map, ev_map)
         assert "ctd" in sources
         assert len(evidences) == 1
-        assert "pmcid" in evidences[0]
-        assert "pmid" in evidences[0]
         assert evidences[0]["pmcid"]["id"] == "PMC123"
         assert evidences[0]["pmid"]["id"] == "456"
 
     def test_handles_pmcid_only(self):
         att_map = pd.DataFrame(
-            {
-                "evidence_id": ["ev1"],
-                "source": ["ctd"],
-            },
+            {"evidence_id": ["ev1"], "source": ["ctd"]},
             index=["at1"],
         )
         ev_map = pd.DataFrame(
-            {
-                "reference": [{"pmcid": "PMC999"}],
-            },
+            {"reference": [{"pmcid": "PMC999"}]},
             index=["ev1"],
         )
         _sources, evidences = _get_correlation_evidence(["at1"], att_map, ev_map)
         assert len(evidences) == 1
         assert "pmcid" in evidences[0]
         assert "pmid" not in evidences[0]
+
+    def test_handles_scalar_pmid(self):
+        """CTD evidence has one pmid per evidence record after explode."""
+        att_map = pd.DataFrame(
+            {"evidence_id": ["ev1"], "source": ["ctd"]},
+            index=["at1"],
+        )
+        ev_map = pd.DataFrame(
+            {"reference": [{"ctd_direct_evidence": "therapeutic", "pmid": "123"}]},
+            index=["ev1"],
+        )
+        sources, evidences = _get_correlation_evidence(["at1"], att_map, ev_map)
+        assert "ctd" in sources
+        assert len(evidences) == 1
+        assert evidences[0]["pmid"]["id"] == "123"
+        assert "pubmed.ncbi" in evidences[0]["pmid"]["url"]
 
     def test_skips_missing_attestation(self):
         att_map = pd.DataFrame(columns=["evidence_id", "source"])
@@ -57,10 +65,7 @@ class TestGetCorrelationEvidence:
 
     def test_skips_missing_evidence(self):
         att_map = pd.DataFrame(
-            {
-                "evidence_id": ["missing_ev"],
-                "source": ["ctd"],
-            },
+            {"evidence_id": ["missing_ev"], "source": ["ctd"]},
             index=["at1"],
         )
         ev_map = pd.DataFrame(columns=["reference"])
@@ -70,16 +75,11 @@ class TestGetCorrelationEvidence:
 
     def test_handles_string_reference(self):
         att_map = pd.DataFrame(
-            {
-                "evidence_id": ["ev1"],
-                "source": ["ctd"],
-            },
+            {"evidence_id": ["ev1"], "source": ["ctd"]},
             index=["at1"],
         )
         ev_map = pd.DataFrame(
-            {
-                "reference": [json.dumps({"pmid": "789"})],
-            },
+            {"reference": [json.dumps({"pmid": "789"})]},
             index=["ev1"],
         )
         _sources, evidences = _get_correlation_evidence(["at1"], att_map, ev_map)
@@ -88,16 +88,11 @@ class TestGetCorrelationEvidence:
 
     def test_skips_evidence_without_pmid_or_pmcid(self):
         att_map = pd.DataFrame(
-            {
-                "evidence_id": ["ev1"],
-                "source": ["ctd"],
-            },
+            {"evidence_id": ["ev1"], "source": ["ctd"]},
             index=["at1"],
         )
         ev_map = pd.DataFrame(
-            {
-                "reference": [{"other_field": "value"}],
-            },
+            {"reference": [{"other_field": "value"}]},
             index=["ev1"],
         )
         sources, evidences = _get_correlation_evidence(["at1"], att_map, ev_map)
@@ -106,18 +101,77 @@ class TestGetCorrelationEvidence:
 
     def test_multiple_attestations(self):
         att_map = pd.DataFrame(
-            {
-                "evidence_id": ["ev1", "ev2"],
-                "source": ["ctd", "mesh"],
-            },
+            {"evidence_id": ["ev1", "ev2"], "source": ["ctd", "mesh"]},
             index=["at1", "at2"],
         )
         ev_map = pd.DataFrame(
-            {
-                "reference": [{"pmid": "1"}, {"pmcid": "PMC2"}],
-            },
+            {"reference": [{"pmid": "1"}, {"pmcid": "PMC2"}]},
             index=["ev1", "ev2"],
         )
         sources, evidences = _get_correlation_evidence(["at1", "at2"], att_map, ev_map)
         assert set(sources) == {"ctd", "mesh"}
         assert len(evidences) == 2
+
+    def test_pmid_coerced_to_string(self):
+        """Numeric pmid values should be coerced to strings."""
+        att_map = pd.DataFrame(
+            {"evidence_id": ["ev1"], "source": ["ctd"]},
+            index=["at1"],
+        )
+        ev_map = pd.DataFrame(
+            {"reference": [{"pmid": 12345}]},
+            index=["ev1"],
+        )
+        _sources, evidences = _get_correlation_evidence(["at1"], att_map, ev_map)
+        assert len(evidences) == 1
+        assert evidences[0]["pmid"]["id"] == "12345"
+
+
+class TestMergeInto:
+    def test_creates_new_entry(self):
+        agg: dict = {}
+        _merge_into(agg, "c1", "c1", "d1", "r3", ["ctd"], [{"pmid": {"id": "1"}}])
+        assert ("c1", "c1", "d1", "r3") in agg
+        assert "ctd" in agg[("c1", "c1", "d1", "r3")]["sources"]
+        assert len(agg[("c1", "c1", "d1", "r3")]["evidences"]) == 1
+
+    def test_merges_into_existing(self):
+        agg: dict = {}
+        _merge_into(agg, "c1", "c1", "d1", "r3", ["ctd"], [{"pmid": {"id": "1"}}])
+        _merge_into(agg, "c1", "c1", "d1", "r3", ["mesh"], [{"pmid": {"id": "2"}}])
+        assert agg[("c1", "c1", "d1", "r3")]["sources"] == {"ctd", "mesh"}
+        assert len(agg[("c1", "c1", "d1", "r3")]["evidences"]) == 2
+
+    def test_different_source_chemicals_separate(self):
+        agg: dict = {}
+        _merge_into(
+            agg, "parent", "child1", "d1", "r3", ["ctd"], [{"pmid": {"id": "1"}}]
+        )
+        _merge_into(
+            agg, "parent", "child2", "d1", "r3", ["ctd"], [{"pmid": {"id": "2"}}]
+        )
+        assert len(agg) == 2
+        assert ("parent", "child1", "d1", "r3") in agg
+        assert ("parent", "child2", "d1", "r3") in agg
+
+
+class TestDeduplicateEvidences:
+    def test_removes_duplicate_pmids(self):
+        evidences = [
+            {"pmid": {"id": "123", "url": "u1"}},
+            {"pmid": {"id": "123", "url": "u1"}},
+            {"pmid": {"id": "456", "url": "u2"}},
+        ]
+        result = _deduplicate_evidences(evidences)
+        assert len(result) == 2
+
+    def test_keeps_different_types(self):
+        evidences = [
+            {"pmid": {"id": "123", "url": "u1"}},
+            {"pmcid": {"id": "PMC456", "url": "u2"}},
+        ]
+        result = _deduplicate_evidences(evidences)
+        assert len(result) == 2
+
+    def test_empty_list(self):
+        assert _deduplicate_evidences([]) == []

--- a/backend/db/tests/test_materializer.py
+++ b/backend/db/tests/test_materializer.py
@@ -3,7 +3,7 @@
 from unittest.mock import MagicMock
 
 import pandas as pd
-from src.etl.materializer import _insert_mv_entities
+from src.etl.materializer import _collect_ancestors, _insert_mv_entities
 from src.etl.materializer_composition import (
     _add_foodatlas_evidence,
     _compute_median,
@@ -165,3 +165,62 @@ class TestInsertMvEntities:
             cols = mock_copy.call_args[0][3]
             assert len(cols) == 6
             assert "external_ids" in cols
+
+
+class TestCollectAncestors:
+    """Test _collect_ancestors IS_A hierarchy traversal."""
+
+    def _make_entities(self, ids_and_types):
+        return pd.DataFrame(
+            [
+                {"foodatlas_id": fid, "entity_type": etype}
+                for fid, etype in ids_and_types
+            ]
+        )
+
+    def test_direct_parent(self):
+        r2 = pd.DataFrame([{"head_id": "c1", "tail_id": "p1"}])
+        entities = self._make_entities([("c1", "chemical"), ("p1", "chemical")])
+        result = _collect_ancestors(r2, {"c1"}, entities)
+        assert result == {"p1"}
+
+    def test_transitive_ancestors(self):
+        r2 = pd.DataFrame(
+            [
+                {"head_id": "c1", "tail_id": "p1"},
+                {"head_id": "p1", "tail_id": "gp1"},
+            ]
+        )
+        entities = self._make_entities(
+            [
+                ("c1", "chemical"),
+                ("p1", "chemical"),
+                ("gp1", "chemical"),
+            ]
+        )
+        result = _collect_ancestors(r2, {"c1"}, entities)
+        assert result == {"p1", "gp1"}
+
+    def test_ignores_non_chemical(self):
+        r2 = pd.DataFrame([{"head_id": "c1", "tail_id": "d1"}])
+        entities = self._make_entities([("c1", "chemical"), ("d1", "disease")])
+        result = _collect_ancestors(r2, {"c1"}, entities)
+        assert result == set()
+
+    def test_no_parents(self):
+        r2 = pd.DataFrame(columns=["head_id", "tail_id"])
+        entities = self._make_entities([("c1", "chemical")])
+        result = _collect_ancestors(r2, {"c1"}, entities)
+        assert result == set()
+
+    def test_seed_not_in_hierarchy(self):
+        r2 = pd.DataFrame([{"head_id": "c2", "tail_id": "p1"}])
+        entities = self._make_entities(
+            [
+                ("c1", "chemical"),
+                ("c2", "chemical"),
+                ("p1", "chemical"),
+            ]
+        )
+        result = _collect_ancestors(r2, {"c1"}, entities)
+        assert result == set()

--- a/backend/kgc/src/pipeline/ingest/adapters/ctd.py
+++ b/backend/kgc/src/pipeline/ingest/adapters/ctd.py
@@ -162,7 +162,11 @@ def _build_chemdis_edges(chemdis: pd.DataFrame) -> pd.DataFrame:
         }
     )
     de = chemdis["DirectEvidence"].fillna("")
-    result["raw_attrs"] = de.apply(lambda x: {"direct_evidence": x})
+    pmids = chemdis["PubMedIDs"]
+    result["raw_attrs"] = [
+        {"direct_evidence": d, "PubMedIDs": p if isinstance(p, list) else []}
+        for d, p in zip(de, pmids, strict=False)
+    ]
     return result
 
 

--- a/backend/kgc/src/pipeline/triplets/chemical_disease/ctd.py
+++ b/backend/kgc/src/pipeline/triplets/chemical_disease/ctd.py
@@ -83,25 +83,32 @@ def merge_ctd_triplets(
         logger.info("No CTD data to merge after resolution.")
         return
 
-    # Build evidence references.
-    df["source_type"] = "ctd"
-    df["reference"] = df["raw_attrs"].apply(
-        lambda x: json.dumps(
-            {
-                "ctd_direct_evidence": x.get("direct_evidence", ""),
-                "pubmed": x.get("PubMedIDs", []),
-            }
-        )
+    # Explode PubMedIDs so each PMID is its own evidence record.
+    df["_pmids"] = df["raw_attrs"].apply(lambda x: x.get("PubMedIDs", []))
+    df["_de"] = df["raw_attrs"].apply(lambda x: x.get("direct_evidence", ""))
+    exploded = df.explode("_pmids", ignore_index=True)
+    exploded = exploded[exploded["_pmids"].notna() & (exploded["_pmids"] != "")]
+
+    if exploded.empty:
+        logger.info("No CTD edges with PubMed IDs after explode.")
+        return
+
+    exploded["source_type"] = "ctd"
+    exploded["reference"] = exploded.apply(
+        lambda r: json.dumps(
+            {"ctd_direct_evidence": r["_de"], "pmid": str(r["_pmids"])}
+        ),
+        axis=1,
     )
-    df["source"] = "ctd"
-    df["head_name_raw"] = df["head_native_id"].astype(str)
-    df["tail_name_raw"] = df["tail_native_id"].astype(str)
+    exploded["source"] = "ctd"
+    exploded["head_name_raw"] = exploded["head_native_id"].astype(str)
+    exploded["tail_name_raw"] = exploded["tail_native_id"].astype(str)
 
-    ev_result = kg.evidence.create(df[["source_type", "reference"]])
-    df["evidence_id"] = ev_result.index
-    attestations = kg.attestations.create(df)
+    ev_result = kg.evidence.create(exploded[["source_type", "reference"]])
+    exploded["evidence_id"] = ev_result.index
+    attestations = kg.attestations.create(exploded)
 
-    triplet_input = df[["_head_id", "_tail_id", "_rel_id"]].copy()
+    triplet_input = exploded[["_head_id", "_tail_id", "_rel_id"]].copy()
     triplet_input.columns = pd.Index(["head_id", "tail_id", "relationship_id"])
     triplet_input.index = attestations.index
     triplets = kg.triplets.create(triplet_input)

--- a/backend/kgc/tests/test_chemical_disease.py
+++ b/backend/kgc/tests/test_chemical_disease.py
@@ -73,7 +73,10 @@ class TestMergeCtdTriplets:
                             "head_native_id": "D001241",
                             "tail_native_id": "MESH:D001249",
                             "edge_type": "chemical_disease_association",
-                            "raw_attrs": {"direct_evidence": "therapeutic"},
+                            "raw_attrs": {
+                                "direct_evidence": "therapeutic",
+                                "PubMedIDs": [12345],
+                            },
                         },
                     ]
                 ),
@@ -105,7 +108,10 @@ class TestMergeCtdTriplets:
                             "head_native_id": "D001241",
                             "tail_native_id": "MESH:D999999",
                             "edge_type": "chemical_disease_association",
-                            "raw_attrs": {"direct_evidence": "therapeutic"},
+                            "raw_attrs": {
+                                "direct_evidence": "therapeutic",
+                                "PubMedIDs": [99999],
+                            },
                         },
                     ]
                 ),

--- a/frontend/components/entities/CorrelationTable.tsx
+++ b/frontend/components/entities/CorrelationTable.tsx
@@ -33,7 +33,7 @@ const CorrelationTable = ({
   const [numberOfPages, setNumberOfPages] = useState(1);
   const { getTablePaginations } = usePaginations();
   const { currentPage } = getTablePaginations(tableId);
-  const [selectedEvidenceName, setSelectedEvidenceName] = useState("");
+  const [selectedRowIdx, setSelectedRowIdx] = useState(-1);
 
   // fetch data
   useEffect(() => {
@@ -63,8 +63,8 @@ const CorrelationTable = ({
   }, [tableLocation, correlationType, currentPage, commonName]);
 
   // handle evidence show more click
-  const handleEvidenceShowMoreClick = (name: string) => {
-    setSelectedEvidenceName(name);
+  const handleEvidenceShowMoreClick = (idx: number) => {
+    setSelectedRowIdx(idx);
   };
 
   return (
@@ -121,19 +121,44 @@ const CorrelationTable = ({
                 </tr>
               ) : data.length > 0 ? (
                 // data rows
-                data.map((row) => (
-                  <tr key={row.id}>
+                data.map((row, rowIdx) => (
+                  <tr key={`${row.id}-${rowIdx}`}>
+                    {/* source chemical (chemical page only) */}
+                    {tableLocation === "chemical" && (
+                      <td className="py-3 pr-4">
+                        <div className="flex gap-2.5 min-h-12 capitalize items-center">
+                          {correlationType === "negative" ? (
+                            <div className="w-[1.2rem] h-[1.2rem] flex justify-center items-center rounded-full border-[1.5px] border-red-600 text-red-600 bg-red-600/10 shadow-red-800/50 shadow-[inset_0_2px_8px_rgba(0,0,0,0.4)] md:shadow-inset_0_2px_8px_rgba(0,0,0,0.6) font-bold">
+                              <MdRemove />
+                            </div>
+                          ) : (
+                            <div className="w-[1.2rem] h-[1.2rem] flex justify-center items-center rounded-full border-[1.5px] border-lime-600 text-lime-600 bg-lime-600/10 shadow-lime-800/50 shadow-[inset_0_2px_8px_rgba(0,0,0,0.4)] md:shadow-inset_0_2px_8px_rgba(0,0,0,0.6) font-bold">
+                              <MdAdd />
+                            </div>
+                          )}
+                          <Link
+                            className="capitalize"
+                            href={`/chemical/${encodeURIComponent(encodeSpace(row.source_chemical_name ?? commonName))}`}
+                            isExternal={false}
+                          >
+                            {row.source_chemical_name ?? commonName}
+                          </Link>
+                        </div>
+                      </td>
+                    )}
                     {/* entity name */}
                     <td className="py-3 pr-4">
                       <div className="flex gap-2.5 min-h-12 capitalize items-center">
-                        {correlationType === "negative" ? (
-                          <div className="w-[1.2rem] h-[1.2rem] flex justify-center items-center rounded-full border-[1.5px] border-red-600 text-red-600 bg-red-600/10 shadow-red-800/50 shadow-[inset_0_2px_8px_rgba(0,0,0,0.4)] md:shadow-inset_0_2px_8px_rgba(0,0,0,0.6) font-bold">
-                            <MdRemove />
-                          </div>
-                        ) : (
-                          <div className="w-[1.2rem] h-[1.2rem] flex justify-center items-center rounded-full border-[1.5px] border-lime-600 text-lime-600 bg-lime-600/10 shadow-lime-800/50 shadow-[inset_0_2px_8px_rgba(0,0,0,0.4)] md:shadow-inset_0_2px_8px_rgba(0,0,0,0.6) font-bold">
-                            <MdAdd />
-                          </div>
+                        {tableLocation !== "chemical" && (
+                          correlationType === "negative" ? (
+                            <div className="w-[1.2rem] h-[1.2rem] flex justify-center items-center rounded-full border-[1.5px] border-red-600 text-red-600 bg-red-600/10 shadow-red-800/50 shadow-[inset_0_2px_8px_rgba(0,0,0,0.4)] md:shadow-inset_0_2px_8px_rgba(0,0,0,0.6) font-bold">
+                              <MdRemove />
+                            </div>
+                          ) : (
+                            <div className="w-[1.2rem] h-[1.2rem] flex justify-center items-center rounded-full border-[1.5px] border-lime-600 text-lime-600 bg-lime-600/10 shadow-lime-800/50 shadow-[inset_0_2px_8px_rgba(0,0,0,0.4)] md:shadow-inset_0_2px_8px_rgba(0,0,0,0.6) font-bold">
+                              <MdAdd />
+                            </div>
+                          )
                         )}
                         <Link
                           className="capitalize"
@@ -152,7 +177,7 @@ const CorrelationTable = ({
                     <td className="py-3 pl-4">
                       {
                         <div className="flex min-h-12 capitalize items-center justify-end">
-                          <div className="flex gap-2 justify-end items-center flex-wrap">
+                          <div className="flex gap-2 justify-end items-center flex-nowrap">
                             {row.evidences.slice(0, 3).map((evidence) => (
                               <Link
                                 className="whitespace-nowrap"
@@ -170,7 +195,7 @@ const CorrelationTable = ({
                                   variant="outlined"
                                   size="sm"
                                   onClick={() =>
-                                    handleEvidenceShowMoreClick(row.name)
+                                    handleEvidenceShowMoreClick(rowIdx)
                                   }
                                 >
                                   {`${row.evidences.length - 3} more`}...
@@ -212,20 +237,20 @@ const CorrelationTable = ({
         entityType={tableLocation as "chemical" | "disease"}
         correlationType={correlationType}
         chemicalName={
-          tableLocation === "chemical" ? commonName : selectedEvidenceName
+          tableLocation === "chemical"
+            ? (data[selectedRowIdx]?.source_chemical_name ?? commonName)
+            : (data[selectedRowIdx]?.name ?? "")
         }
         diseaseName={
-          tableLocation === "chemical" ? selectedEvidenceName : commonName
+          tableLocation === "chemical"
+            ? (data[selectedRowIdx]?.name ?? "")
+            : commonName
         }
         evidences={
-          selectedEvidenceName === ""
-            ? undefined
-            : data?.filter((row) => {
-                return row.name === selectedEvidenceName;
-              })[0].evidences
+          selectedRowIdx < 0 ? undefined : data[selectedRowIdx]?.evidences
         }
-        isOpen={selectedEvidenceName !== ""}
-        onClose={() => setSelectedEvidenceName("")}
+        isOpen={selectedRowIdx >= 0}
+        onClose={() => setSelectedRowIdx(-1)}
       />
     </>
   );

--- a/frontend/components/entities/HeaderSection.tsx
+++ b/frontend/components/entities/HeaderSection.tsx
@@ -42,7 +42,7 @@ const HeaderSection = async ({
         </Badge>
         <div className="border-l h-6 border-light-500" />
         <span className="font-mono font-medium italic text-sm text-light-300">
-          FoodAtlas {data.id}
+          FoodAtlas {data?.id ?? "—"}
         </span>
       </div>
       {/* name */}

--- a/frontend/components/entities/MetainformationSection.tsx
+++ b/frontend/components/entities/MetainformationSection.tsx
@@ -159,7 +159,7 @@ const MetainformationSection = async ({
                 {/* foodatlas id */}
                 <tr className="border-b border-light-50/[0.05]">
                   <td className="py-2 pr-4 whitespace-nowrap">FoodAtlas</td>
-                  <td className="py-2 break-all">{data.id}</td>
+                  <td className="py-2 break-all">{data?.id ?? "—"}</td>
                 </tr>
                 {/* external ids */}
                 {data?.external_ids &&

--- a/frontend/components/entities/chemical/ChemicalCompositionSection.tsx
+++ b/frontend/components/entities/chemical/ChemicalCompositionSection.tsx
@@ -17,7 +17,7 @@ const ChemicalCompositionSection = async ({
   return (
     <div className="flex flex-col gap-7">
       <Heading type="h2" variant="boxed">
-        {`Foods containing ${capitalizeFirstLetter(metaData?.common_name)}`}
+        {`Foods containing ${capitalizeFirstLetter(metaData?.common_name ?? "")}`}
       </Heading>
       <div className="flex flex-col gap-7">
         {/* with concentration section */}

--- a/frontend/components/entities/chemical/ChemicalCorrelationSection.tsx
+++ b/frontend/components/entities/chemical/ChemicalCorrelationSection.tsx
@@ -54,7 +54,7 @@ const ChemicalCorrelationSection = ({
             <CorrelationTable
               commonName={commonName}
               tableLocation={"chemical"}
-              headers={[{ label: "Disease" }, { label: "Publication (PMID)" }]}
+              headers={[{ label: "Chemical" }, { label: "Disease" }, { label: "Publication (PMID)" }]}
               correlationType={"positive"}
             />
           </Card>
@@ -77,7 +77,7 @@ const ChemicalCorrelationSection = ({
             <CorrelationTable
               commonName={commonName}
               tableLocation={"chemical"}
-              headers={[{ label: "Disease" }, { label: "Publication (PMID)" }]}
+              headers={[{ label: "Chemical" }, { label: "Disease" }, { label: "Publication (PMID)" }]}
               correlationType={"negative"}
             />
           </Card>

--- a/frontend/types/ChemicalCorrelation.ts
+++ b/frontend/types/ChemicalCorrelation.ts
@@ -3,6 +3,8 @@ import { Evidence } from "@/types";
 export type ChemicalCorrelation = {
   id: string;
   name: string;
+  source_chemical_name?: string;
+  source_chemical_foodatlas_id?: string;
   sources: string[];
   evidences: Evidence[];
 };


### PR DESCRIPTION
## Summary

- **Fix CTD PubMed IDs not showing**: The CTD ingest adapter was discarding `PubMedIDs` from `raw_attrs`, and the triplet builder bundled them as a list instead of individual evidence records. Now each PMID is exploded into its own evidence → attestation chain, so PMIDs flow correctly through to the frontend.
- **Descendant chemical aggregation**: The correlation materializer now traverses the chemical IS_A hierarchy (r2 triplets) so parent chemicals like "Vitamin" surface disease connections from their descendants. Each (ancestor, source_chemical, disease) gets its own row with clear provenance.
- **Source chemical column**: The chemical page disease table now shows a "Chemical" column identifying which descendant (or itself) has the connection. The MV table adds `source_chemical_name` and `source_chemical_foodatlas_id` columns.
- **Ranking by evidence count**: Added `evidence_count` column to `mv_chemical_disease_correlation` for efficient `ORDER BY` instead of `jsonb_array_length(evidences)`.
- **Entity view expansion**: `mv_chemical_entities` now includes r3/r4 chemicals and their IS_A ancestors, so navigating to ancestor chemical pages no longer crashes.
- **Null guards**: `HeaderSection`, `MetainformationSection`, and `ChemicalCompositionSection` handle missing metadata gracefully.
- **ETL default path**: `backend/db/main.py load` defaults `--parquet-dir` to `../kgc/outputs/kg`.

## Files changed

**KGC pipeline** (ingest + triplet builder):
- `backend/kgc/src/pipeline/ingest/adapters/ctd.py` — include PubMedIDs in raw_attrs
- `backend/kgc/src/pipeline/triplets/chemical_disease/ctd.py` — explode PubMedIDs into individual evidence records

**DB ETL** (materializer + schema):
- `backend/db/src/etl/materializer_correlation.py` — IS_A ancestor traversal, per-source-chemical rows, evidence dedup
- `backend/db/src/etl/materializer.py` — include r3/r4 chemicals + ancestors in mv_chemical_entities
- `backend/db/src/models/views.py` — add source_chemical and evidence_count columns
- `backend/db/migrations/versions/001_initial_schema.py` — schema update

**API**:
- `backend/api/src/repositories/chemical.py` — return source_chemical fields, order by evidence_count
- `backend/api/src/repositories/disease.py` — order by evidence_count

**Frontend**:
- `frontend/components/entities/CorrelationTable.tsx` — Chemical column, row-index-based modal
- `frontend/components/entities/chemical/ChemicalCorrelationSection.tsx` — 3-column headers
- `frontend/types/ChemicalCorrelation.ts` — source_chemical fields
- Null guards in HeaderSection, MetainformationSection, ChemicalCompositionSection

## Test plan

- [x] All 462 KGC tests pass
- [x] All 212 DB tests pass (80.63% coverage)
- [x] All 57 API tests pass
- [ ] Re-run KGC pipeline (`uv run main.py run`) then ETL load (`cd backend/db && uv run main.py load`)
- [ ] Verify PMIDs show on chemical/disease pages
- [ ] Verify ancestor chemicals show descendant disease connections
- [ ] Verify Chemical column links work on chemical page disease table