### PR TITLE
feat: show taxonomical tree/path on entity detail pages (#61)

### DIFF
--- a/backend/api/src/repositories/taxonomy.py
+++ b/backend/api/src/repositories/taxonomy.py
@@ -1,0 +1,145 @@
+"""Taxonomy ancestry via IS_A (r2) hierarchy traversal."""
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# IS_A direction per entity type: (child_column, parent_column).
+# Food & Disease: head=child, tail=parent.
+# Chemical: head=parent, tail=child.
+_DIRECTION: dict[str, tuple[str, str]] = {
+    "food": ("head_id", "tail_id"),
+    "chemical": ("tail_id", "head_id"),
+    "disease": ("head_id", "tail_id"),
+}
+
+_MV_TABLE: dict[str, str] = {
+    "food": "mv_food_entities",
+    "chemical": "mv_chemical_entities",
+    "disease": "mv_disease_entities",
+}
+
+_MAX_DEPTH = 20
+
+
+async def get_taxonomy(
+    session: AsyncSession,
+    common_name: str,
+    entity_type: str,
+) -> dict[str, object]:
+    """Return the IS_A ancestor tree for an entity.
+
+    Walks upward from the entity through r2 triplets, returning all
+    ancestor nodes and parent-child edges.
+    """
+    entity_id = await _resolve_entity_id(session, common_name, entity_type)
+    if entity_id is None:
+        return {"data": {"entity_id": None, "nodes": [], "edges": []}}
+
+    child_col, parent_col = _DIRECTION[entity_type]
+    sql = _build_ancestry_sql(child_col, parent_col)
+
+    result = await session.execute(text(sql), {"entity_id": entity_id})
+    rows = [dict(r._mapping) for r in result]
+
+    nodes_seen: dict[str, str] = {}
+    edges: list[dict[str, str]] = []
+    for row in rows:
+        nid = row["node_id"]
+        name = row["node_name"]
+        came_from = row["came_from_id"]
+        if nid not in nodes_seen:
+            nodes_seen[nid] = name
+        if came_from is not None:
+            nodes_seen.setdefault(came_from, row.get("came_from_name", ""))
+            edges.append({"child_id": came_from, "parent_id": nid})
+
+    # Check which ancestor nodes have entity pages in the MV table.
+    page_ids = await _find_ids_with_pages(
+        session,
+        entity_type,
+        set(nodes_seen.keys()),
+    )
+
+    nodes = [
+        {"id": nid, "name": name, "has_page": nid in page_ids}
+        for nid, name in nodes_seen.items()
+    ]
+
+    return {
+        "data": {
+            "entity_id": entity_id,
+            "nodes": nodes,
+            "edges": edges,
+        }
+    }
+
+
+async def _resolve_entity_id(
+    session: AsyncSession,
+    common_name: str,
+    entity_type: str,
+) -> str | None:
+    """Look up foodatlas_id from the materialized entity view."""
+    table = _MV_TABLE[entity_type]
+    result = await session.execute(
+        text(f"SELECT foodatlas_id FROM {table} WHERE common_name = :name"),
+        {"name": common_name},
+    )
+    row = result.first()
+    return row[0] if row else None
+
+
+async def _find_ids_with_pages(
+    session: AsyncSession,
+    entity_type: str,
+    ids: set[str],
+) -> set[str]:
+    """Return the subset of *ids* that exist in the MV entity table."""
+    if not ids:
+        return set()
+    table = _MV_TABLE[entity_type]
+    result = await session.execute(
+        text(f"SELECT foodatlas_id FROM {table} WHERE foodatlas_id = ANY(:ids)"),
+        {"ids": list(ids)},
+    )
+    return {row[0] for row in result}
+
+
+def _build_ancestry_sql(child_col: str, parent_col: str) -> str:
+    """Build the recursive CTE for walking IS_A ancestors.
+
+    Column names come from an internal allowlist, not user input.
+    """
+    return f"""
+        WITH RECURSIVE ancestry AS (
+            SELECT
+                be.foodatlas_id AS node_id,
+                be.common_name  AS node_name,
+                NULL::VARCHAR   AS came_from_id,
+                NULL::VARCHAR   AS came_from_name,
+                0               AS depth,
+                ARRAY[be.foodatlas_id]::TEXT[] AS visited
+            FROM base_entities be
+            WHERE be.foodatlas_id = :entity_id
+
+            UNION ALL
+
+            SELECT
+                p.foodatlas_id  AS node_id,
+                p.common_name   AS node_name,
+                a.node_id       AS came_from_id,
+                a.node_name     AS came_from_name,
+                a.depth + 1,
+                a.visited || p.foodatlas_id
+            FROM ancestry a
+            JOIN base_triplets bt
+                ON bt.{child_col} = a.node_id
+                AND bt.relationship_id = 'r2'
+            JOIN base_entities p
+                ON p.foodatlas_id = bt.{parent_col}
+            WHERE p.foodatlas_id != ALL(a.visited)
+              AND a.depth < {_MAX_DEPTH}
+        )
+        SELECT node_id, node_name, came_from_id, came_from_name
+        FROM ancestry
+    """

--- a/backend/api/src/routes/chemical.py
+++ b/backend/api/src/routes/chemical.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.dependencies import get_db, verify_api_key
-from src.repositories import chemical
+from src.repositories import chemical, taxonomy
 
 router = APIRouter(prefix="/chemical", dependencies=[Depends(verify_api_key)])
 
@@ -15,6 +15,14 @@ async def chemical_metadata(
     db: AsyncSession = Depends(get_db),
 ):
     return await chemical.get_metadata(db, common_name)
+
+
+@router.get("/taxonomy")
+async def chemical_taxonomy(
+    common_name: str = Query(...),
+    db: AsyncSession = Depends(get_db),
+):
+    return await taxonomy.get_taxonomy(db, common_name, "chemical")
 
 
 @router.get("/composition")

--- a/backend/api/src/routes/disease.py
+++ b/backend/api/src/routes/disease.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.dependencies import get_db, verify_api_key
-from src.repositories import disease
+from src.repositories import disease, taxonomy
 
 router = APIRouter(prefix="/disease", dependencies=[Depends(verify_api_key)])
 
@@ -15,6 +15,14 @@ async def disease_metadata(
     db: AsyncSession = Depends(get_db),
 ):
     return await disease.get_metadata(db, common_name)
+
+
+@router.get("/taxonomy")
+async def disease_taxonomy(
+    common_name: str = Query(...),
+    db: AsyncSession = Depends(get_db),
+):
+    return await taxonomy.get_taxonomy(db, common_name, "disease")
 
 
 @router.get("/correlation")

--- a/backend/api/src/routes/food.py
+++ b/backend/api/src/routes/food.py
@@ -4,7 +4,7 @@ from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.dependencies import get_db, verify_api_key
-from src.repositories import food
+from src.repositories import food, taxonomy
 
 router = APIRouter(prefix="/food", dependencies=[Depends(verify_api_key)])
 
@@ -15,6 +15,14 @@ async def food_metadata(
     db: AsyncSession = Depends(get_db),
 ):
     return await food.get_metadata(db, common_name)
+
+
+@router.get("/taxonomy")
+async def food_taxonomy(
+    common_name: str = Query(...),
+    db: AsyncSession = Depends(get_db),
+):
+    return await taxonomy.get_taxonomy(db, common_name, "food")
 
 
 @router.get("/profile")

--- a/backend/api/tests/test_repo_taxonomy.py
+++ b/backend/api/tests/test_repo_taxonomy.py
@@ -1,0 +1,189 @@
+"""Tests for taxonomy repository functions."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from src.repositories.taxonomy import get_taxonomy
+
+
+def _make_row(**kwargs: object) -> MagicMock:
+    row = MagicMock()
+    row._mapping = kwargs
+    return row
+
+
+def _mock_resolve_result(entity_id: str | None) -> MagicMock:
+    """Mock the result from _resolve_entity_id."""
+    result = MagicMock()
+    if entity_id is None:
+        result.first.return_value = None
+    else:
+        result.first.return_value = (entity_id,)
+    return result
+
+
+def _mock_iter_result(rows: list[MagicMock]) -> MagicMock:
+    result = MagicMock()
+    result.__iter__ = lambda self: iter(rows)
+    return result
+
+
+def _mock_page_ids_result(ids: list[str]) -> MagicMock:
+    result = MagicMock()
+    result.__iter__ = lambda self: iter([(i,) for i in ids])
+    return result
+
+
+class TestGetTaxonomy:
+    @pytest.mark.asyncio
+    async def test_linear_ancestry(self) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = [
+            _mock_resolve_result("e123"),
+            _mock_iter_result(
+                [
+                    _make_row(
+                        node_id="e123",
+                        node_name="apple",
+                        came_from_id=None,
+                        came_from_name=None,
+                    ),
+                    _make_row(
+                        node_id="e59",
+                        node_name="plant fruit food product",
+                        came_from_id="e123",
+                        came_from_name="apple",
+                    ),
+                    _make_row(
+                        node_id="e19",
+                        node_name="plant food product",
+                        came_from_id="e59",
+                        came_from_name="plant fruit food product",
+                    ),
+                ]
+            ),
+            _mock_page_ids_result(["e123", "e59"]),
+        ]
+        result = await get_taxonomy(session, "apple", "food")
+        data = result["data"]
+        assert data["entity_id"] == "e123"
+        assert len(data["nodes"]) == 3
+        assert len(data["edges"]) == 2
+        page_map = {n["id"]: n["has_page"] for n in data["nodes"]}
+        assert page_map["e123"] is True
+        assert page_map["e19"] is False
+
+    @pytest.mark.asyncio
+    async def test_dag_multiple_parents(self) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = [
+            _mock_resolve_result("e100"),
+            _mock_iter_result(
+                [
+                    _make_row(
+                        node_id="e100",
+                        node_name="quercetin",
+                        came_from_id=None,
+                        came_from_name=None,
+                    ),
+                    _make_row(
+                        node_id="e200",
+                        node_name="flavonol",
+                        came_from_id="e100",
+                        came_from_name="quercetin",
+                    ),
+                    _make_row(
+                        node_id="e300",
+                        node_name="polyphenol",
+                        came_from_id="e100",
+                        came_from_name="quercetin",
+                    ),
+                ]
+            ),
+            _mock_page_ids_result(["e100"]),
+        ]
+        result = await get_taxonomy(session, "quercetin", "chemical")
+        data = result["data"]
+        assert len(data["edges"]) == 2
+        edge_parents = {e["parent_id"] for e in data["edges"]}
+        assert edge_parents == {"e200", "e300"}
+        assert all(e["child_id"] == "e100" for e in data["edges"])
+
+    @pytest.mark.asyncio
+    async def test_no_ancestors(self) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = [
+            _mock_resolve_result("e999"),
+            _mock_iter_result(
+                [
+                    _make_row(
+                        node_id="e999",
+                        node_name="isolated",
+                        came_from_id=None,
+                        came_from_name=None,
+                    ),
+                ]
+            ),
+            _mock_page_ids_result(["e999"]),
+        ]
+        result = await get_taxonomy(session, "isolated", "disease")
+        data = result["data"]
+        assert data["entity_id"] == "e999"
+        assert len(data["nodes"]) == 1
+        assert len(data["edges"]) == 0
+
+    @pytest.mark.asyncio
+    async def test_unknown_entity(self) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = [_mock_resolve_result(None)]
+        result = await get_taxonomy(session, "nonexistent", "food")
+        assert result["data"]["entity_id"] is None
+        assert result["data"]["nodes"] == []
+        assert result["data"]["edges"] == []
+
+    @pytest.mark.asyncio
+    async def test_deduplicates_nodes(self) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = [
+            _mock_resolve_result("e1"),
+            _mock_iter_result(
+                [
+                    _make_row(
+                        node_id="e1",
+                        node_name="child",
+                        came_from_id=None,
+                        came_from_name=None,
+                    ),
+                    _make_row(
+                        node_id="e2",
+                        node_name="parent_a",
+                        came_from_id="e1",
+                        came_from_name="child",
+                    ),
+                    _make_row(
+                        node_id="e3",
+                        node_name="parent_b",
+                        came_from_id="e1",
+                        came_from_name="child",
+                    ),
+                    _make_row(
+                        node_id="e4",
+                        node_name="grandparent",
+                        came_from_id="e2",
+                        came_from_name="parent_a",
+                    ),
+                    _make_row(
+                        node_id="e4",
+                        node_name="grandparent",
+                        came_from_id="e3",
+                        came_from_name="parent_b",
+                    ),
+                ]
+            ),
+            _mock_page_ids_result(["e1"]),
+        ]
+        result = await get_taxonomy(session, "child", "food")
+        data = result["data"]
+        node_ids = [n["id"] for n in data["nodes"]]
+        assert len(node_ids) == len(set(node_ids))
+        assert len(data["edges"]) == 4

--- a/backend/api/tests/test_routes_taxonomy.py
+++ b/backend/api/tests/test_routes_taxonomy.py
@@ -1,0 +1,76 @@
+"""Tests for taxonomy route endpoints across all entity types."""
+
+from unittest.mock import AsyncMock, patch
+
+from fastapi.testclient import TestClient
+
+TAXONOMY_SAMPLE = {
+    "data": {
+        "entity_id": "e123",
+        "nodes": [
+            {"id": "e123", "name": "apple"},
+            {"id": "e59", "name": "plant fruit food product"},
+        ],
+        "edges": [
+            {"child_id": "e123", "parent_id": "e59"},
+        ],
+    }
+}
+
+TAXONOMY_EMPTY: dict[str, object] = {
+    "data": {"entity_id": None, "nodes": [], "edges": []},
+}
+
+
+class TestFoodTaxonomy:
+    def test_returns_taxonomy_data(
+        self, client: TestClient, mock_db: AsyncMock
+    ) -> None:
+        with patch(
+            "src.repositories.taxonomy.get_taxonomy",
+            return_value=TAXONOMY_SAMPLE,
+        ):
+            resp = client.get("/food/taxonomy", params={"common_name": "apple"})
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"]["entity_id"] == "e123"
+        assert len(body["data"]["nodes"]) == 2
+        assert len(body["data"]["edges"]) == 1
+
+    def test_missing_param_returns_422(self, client: TestClient) -> None:
+        resp = client.get("/food/taxonomy")
+        assert resp.status_code == 422
+
+
+class TestChemicalTaxonomy:
+    def test_returns_taxonomy_data(
+        self, client: TestClient, mock_db: AsyncMock
+    ) -> None:
+        with patch(
+            "src.repositories.taxonomy.get_taxonomy",
+            return_value=TAXONOMY_SAMPLE,
+        ):
+            resp = client.get("/chemical/taxonomy", params={"common_name": "glucose"})
+        assert resp.status_code == 200
+        assert "nodes" in resp.json()["data"]
+
+    def test_missing_param_returns_422(self, client: TestClient) -> None:
+        resp = client.get("/chemical/taxonomy")
+        assert resp.status_code == 422
+
+
+class TestDiseaseTaxonomy:
+    def test_returns_taxonomy_data(
+        self, client: TestClient, mock_db: AsyncMock
+    ) -> None:
+        with patch(
+            "src.repositories.taxonomy.get_taxonomy",
+            return_value=TAXONOMY_SAMPLE,
+        ):
+            resp = client.get("/disease/taxonomy", params={"common_name": "diabetes"})
+        assert resp.status_code == 200
+        assert "edges" in resp.json()["data"]
+
+    def test_missing_param_returns_422(self, client: TestClient) -> None:
+        resp = client.get("/disease/taxonomy")
+        assert resp.status_code == 422

--- a/frontend/components/entities/MetainformationSection.tsx
+++ b/frontend/components/entities/MetainformationSection.tsx
@@ -5,6 +5,7 @@ import Card from "@/components/basic/Card";
 import Link from "@/components/basic/Link";
 import Heading from "@/components/basic/Heading";
 import Synonyms from "@/components/entities/food/Synonyms";
+import TaxonomySection from "@/components/entities/TaxonomySection";
 import { getMetaData } from "@/utils/fetching";
 import { capitalizeFirstLetter } from "@/utils/utils";
 
@@ -129,6 +130,11 @@ const MetainformationSection = async ({
             {data?.synonyms && data.synonyms.length > 0 && (
               <Synonyms synonyms={data.synonyms} />
             )}
+            {/* taxonomy */}
+            <TaxonomySection
+              commonName={commonName}
+              entityType={entityType}
+            />
           </div>
         </div>
         {/* identifiers container */}

--- a/frontend/components/entities/TaxonomySection.tsx
+++ b/frontend/components/entities/TaxonomySection.tsx
@@ -1,0 +1,130 @@
+import { Fragment } from "react";
+
+import Card from "@/components/basic/Card";
+import Heading from "@/components/basic/Heading";
+import { getTaxonomyData } from "@/utils/fetching";
+import { TaxonomyEdge, TaxonomyNode } from "@/types";
+import { encodeSpace } from "@/utils/utils";
+
+interface TaxonomySectionProps {
+  commonName: string;
+  entityType: string;
+}
+
+const ENTITY_COLOR: Record<string, string> = {
+  food: "text-amber-500",
+  chemical: "text-cyan-500",
+  disease: "text-purple-400",
+};
+
+/**
+ * Build all root-to-entity paths from a flat node+edge graph.
+ * Walks from the entity upward, then reverses each path.
+ */
+function buildPaths(
+  entityId: string,
+  nodes: TaxonomyNode[],
+  edges: TaxonomyEdge[]
+): TaxonomyNode[][] {
+  const nameMap = new Map(nodes.map((n) => [n.id, n]));
+  // child -> parents
+  const parentMap = new Map<string, string[]>();
+  for (const e of edges) {
+    const existing = parentMap.get(e.child_id) ?? [];
+    existing.push(e.parent_id);
+    parentMap.set(e.child_id, existing);
+  }
+
+  const paths: TaxonomyNode[][] = [];
+  const MAX_PATHS = 500;
+
+  function walk(nodeId: string, path: TaxonomyNode[], visited: Set<string>) {
+    if (paths.length >= MAX_PATHS) return;
+    const node = nameMap.get(nodeId);
+    if (!node || visited.has(nodeId)) return;
+    const current = [node, ...path];
+    const next = new Set(visited).add(nodeId);
+    const parents = parentMap.get(nodeId);
+    if (!parents || parents.length === 0) {
+      paths.push(current);
+    } else {
+      for (const pid of parents) {
+        walk(pid, current, next);
+      }
+    }
+  }
+
+  walk(entityId, [], new Set());
+  return paths;
+}
+
+const TaxonomySection = async ({
+  commonName,
+  entityType,
+}: TaxonomySectionProps) => {
+  let data;
+  try {
+    data = await getTaxonomyData(commonName, entityType);
+  } catch {
+    return null;
+  }
+
+  if (!data.entity_id || data.edges.length === 0) {
+    return null;
+  }
+
+  const paths = buildPaths(data.entity_id, data.nodes, data.edges);
+
+  if (paths.length === 0) {
+    return null;
+  }
+
+  const colorClass = ENTITY_COLOR[entityType] ?? "text-light-100";
+
+  return (
+    <Card>
+      <Heading type="h4" className="font-mono italic text-light-400 text-xs">
+        Taxonomy
+      </Heading>
+      <div className="mt-3 flex flex-col gap-1.5">
+        {paths.map((path, i) => (
+          <div
+            key={i}
+            className="flex flex-wrap items-center gap-1 text-sm leading-relaxed"
+          >
+            {path.map((node, j) => {
+              const isEntity = node.id === data.entity_id;
+              return (
+                <Fragment key={`${node.id}-${j}`}>
+                  {j > 0 && (
+                    <span className="text-light-400 mx-1 text-base font-bold">&#8594;</span>
+                  )}
+                  {isEntity ? (
+                    <span className={`font-medium ${colorClass} capitalize`}>
+                      {node.name}
+                    </span>
+                  ) : node.has_page ? (
+                    <a
+                      href={`/${entityType}/${encodeURIComponent(encodeSpace(node.name))}`}
+                      className="text-light-300 capitalize underline decoration-1 underline-offset-4 hover:text-light-100 transition duration-300"
+                    >
+                      {node.name}
+                    </a>
+                  ) : (
+                    <span className="text-light-500 capitalize">
+                      {node.name}
+                    </span>
+                  )}
+                </Fragment>
+              );
+            })}
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+};
+
+TaxonomySection.displayName = "TaxonomySection";
+
+export default TaxonomySection;

--- a/frontend/types/TaxonomyData.ts
+++ b/frontend/types/TaxonomyData.ts
@@ -1,0 +1,16 @@
+export type TaxonomyNode = {
+  id: string;
+  name: string;
+  has_page: boolean;
+};
+
+export type TaxonomyEdge = {
+  child_id: string;
+  parent_id: string;
+};
+
+export type TaxonomyData = {
+  entity_id: string | null;
+  nodes: TaxonomyNode[];
+  edges: TaxonomyEdge[];
+};

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -13,6 +13,7 @@ import { Metadata } from "@/types/Metadata";
 import { ChemicalCorrelation } from "@/types/ChemicalCorrelation";
 import { FoodCompositionData } from "@/types/FoodCompositionData";
 import { MacroAndMicroData } from "./MacroAndMicroData";
+import { TaxonomyData, TaxonomyNode, TaxonomyEdge } from "./TaxonomyData";
 
 export type {
   TeamMember,
@@ -30,4 +31,7 @@ export type {
   ChemicalCorrelation,
   FoodCompositionData,
   MacroAndMicroData,
+  TaxonomyData,
+  TaxonomyNode,
+  TaxonomyEdge,
 };

--- a/frontend/utils/fetching.ts
+++ b/frontend/utils/fetching.ts
@@ -1,4 +1,4 @@
-import { MacroAndMicroData, Metadata } from "@/types";
+import { MacroAndMicroData, Metadata, TaxonomyData } from "@/types";
 
 // fetch metadata for a given entity
 export async function getMetaData(
@@ -24,6 +24,34 @@ export async function getMetaData(
   const data = await res.json();
 
   return data.data[0];
+}
+
+// fetch taxonomy ancestry for a given entity
+export async function getTaxonomyData(
+  commonName: string,
+  entityType: string
+): Promise<TaxonomyData> {
+  const res = await fetch(
+    `${
+      process.env.NEXT_PUBLIC_API_URL
+    }/${entityType}/taxonomy?common_name=${encodeURIComponent(commonName)}`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY}`,
+      },
+      next: { revalidate: 86400 },
+    }
+  );
+
+  if (!res.ok) {
+    throw new Error(
+      `Failed to fetch taxonomy for ${entityType} ${commonName}`
+    );
+  }
+
+  const data = await res.json();
+
+  return data.data;
 }
 
 // fetch food macro & micro data


### PR DESCRIPTION
## Summary

- Add `/taxonomy` API endpoint to food, chemical, and disease routes that walks the IS_A (r2) hierarchy via a recursive CTE, returning ancestor nodes and parent-child edges
- Add `TaxonomySection` frontend component that renders breadcrumb-style ancestry paths (root → ... → parent → **entity**) inside the entity overview
- Ancestors with entity pages are clickable links; ontology-only nodes are plain text
- Handles differing IS_A edge directions per entity type (food/disease: head=child, chemical: head=parent)
- Includes cycle prevention (visited set) and path cap (500) as safety nets against DAG issues

## Test plan

- [x] Backend: 68 tests pass, 86% coverage (above 80% threshold)
- [x] Frontend: `npm run build` clean, `npm run lint` zero warnings
- [x] Manual: food taxonomy paths render correctly with clickable ancestors
- [ ] Manual: verify chemical and disease taxonomy (blocked by #82 OOM on chemical page)