### PR TITLE
fix: chemical page OOM, taxonomy edge dedup, and tree view UI (#82)

### DIFF
--- a/backend/api/src/repositories/taxonomy.py
+++ b/backend/api/src/repositories/taxonomy.py
@@ -42,6 +42,7 @@ async def get_taxonomy(
     rows = [dict(r._mapping) for r in result]
 
     nodes_seen: dict[str, str] = {}
+    edges_seen: set[tuple[str, str]] = set()
     edges: list[dict[str, str]] = []
     for row in rows:
         nid = row["node_id"]
@@ -51,7 +52,10 @@ async def get_taxonomy(
             nodes_seen[nid] = name
         if came_from is not None:
             nodes_seen.setdefault(came_from, row.get("came_from_name", ""))
-            edges.append({"child_id": came_from, "parent_id": nid})
+            pair = (came_from, nid)
+            if pair not in edges_seen:
+                edges_seen.add(pair)
+                edges.append({"child_id": came_from, "parent_id": nid})
 
     # Check which ancestor nodes have entity pages in the MV table.
     page_ids = await _find_ids_with_pages(

--- a/frontend/components/entities/TaxonomySection.tsx
+++ b/frontend/components/entities/TaxonomySection.tsx
@@ -1,10 +1,9 @@
-import { Fragment } from "react";
-
 import Card from "@/components/basic/Card";
 import Heading from "@/components/basic/Heading";
+import TaxonomyTree from "@/components/entities/TaxonomyTree";
 import { getTaxonomyData } from "@/utils/fetching";
 import { TaxonomyEdge, TaxonomyNode } from "@/types";
-import { encodeSpace } from "@/utils/utils";
+import type { TreeNode } from "@/components/entities/TaxonomyTree";
 
 interface TaxonomySectionProps {
   commonName: string;
@@ -18,44 +17,59 @@ const ENTITY_COLOR: Record<string, string> = {
 };
 
 /**
- * Build all root-to-entity paths from a flat node+edge graph.
- * Walks from the entity upward, then reverses each path.
+ * Build a tree from roots down to the target entity.
+ * In a DAG a node may appear under multiple parents (branches).
  */
-function buildPaths(
+function buildTree(
   entityId: string,
   nodes: TaxonomyNode[],
   edges: TaxonomyEdge[]
-): TaxonomyNode[][] {
+): TreeNode[] {
   const nameMap = new Map(nodes.map((n) => [n.id, n]));
-  // child -> parents
-  const parentMap = new Map<string, string[]>();
+
+  const childrenOf = new Map<string, string[]>();
+  const hasParent = new Set<string>();
   for (const e of edges) {
-    const existing = parentMap.get(e.child_id) ?? [];
-    existing.push(e.parent_id);
-    parentMap.set(e.child_id, existing);
+    const existing = childrenOf.get(e.parent_id) ?? [];
+    existing.push(e.child_id);
+    childrenOf.set(e.parent_id, existing);
+    hasParent.add(e.child_id);
   }
 
-  const paths: TaxonomyNode[][] = [];
-  const MAX_PATHS = 500;
+  const allIds = new Set(nodes.map((n) => n.id));
+  const roots = Array.from(allIds).filter((id) => !hasParent.has(id));
 
-  function walk(nodeId: string, path: TaxonomyNode[], visited: Set<string>) {
-    if (paths.length >= MAX_PATHS) return;
-    const node = nameMap.get(nodeId);
-    if (!node || visited.has(nodeId)) return;
-    const current = [node, ...path];
-    const next = new Set(visited).add(nodeId);
-    const parents = parentMap.get(nodeId);
-    if (!parents || parents.length === 0) {
-      paths.push(current);
-    } else {
-      for (const pid of parents) {
-        walk(pid, current, next);
-      }
+  const reachable = new Set<string>();
+  function markReachable(nodeId: string): boolean {
+    if (nodeId === entityId) {
+      reachable.add(nodeId);
+      return true;
     }
+    const kids = childrenOf.get(nodeId) ?? [];
+    let reaches = false;
+    for (const kid of kids) {
+      if (markReachable(kid)) reaches = true;
+    }
+    if (reaches) reachable.add(nodeId);
+    return reaches;
+  }
+  for (const r of roots) markReachable(r);
+
+  function build(nodeId: string, visited: Set<string>): TreeNode | null {
+    const node = nameMap.get(nodeId);
+    if (!node || visited.has(nodeId)) return null;
+    const next = new Set(visited).add(nodeId);
+    const kids = (childrenOf.get(nodeId) ?? [])
+      .filter((kid) => reachable.has(kid))
+      .map((kid) => build(kid, next))
+      .filter((t): t is TreeNode => t !== null);
+    return { node, children: kids };
   }
 
-  walk(entityId, [], new Set());
-  return paths;
+  return roots
+    .filter((r) => reachable.has(r))
+    .map((r) => build(r, new Set()))
+    .filter((t): t is TreeNode => t !== null);
 }
 
 const TaxonomySection = async ({
@@ -73,11 +87,8 @@ const TaxonomySection = async ({
     return null;
   }
 
-  const paths = buildPaths(data.entity_id, data.nodes, data.edges);
-
-  if (paths.length === 0) {
-    return null;
-  }
+  const trees = buildTree(data.entity_id, data.nodes, data.edges);
+  if (trees.length === 0) return null;
 
   const colorClass = ENTITY_COLOR[entityType] ?? "text-light-100";
 
@@ -86,40 +97,13 @@ const TaxonomySection = async ({
       <Heading type="h4" className="font-mono italic text-light-400 text-xs">
         Taxonomy
       </Heading>
-      <div className="mt-3 flex flex-col gap-1.5">
-        {paths.map((path, i) => (
-          <div
-            key={i}
-            className="flex flex-wrap items-center gap-1 text-sm leading-relaxed"
-          >
-            {path.map((node, j) => {
-              const isEntity = node.id === data.entity_id;
-              return (
-                <Fragment key={`${node.id}-${j}`}>
-                  {j > 0 && (
-                    <span className="text-light-400 mx-1 text-base font-bold">&#8594;</span>
-                  )}
-                  {isEntity ? (
-                    <span className={`font-medium ${colorClass} capitalize`}>
-                      {node.name}
-                    </span>
-                  ) : node.has_page ? (
-                    <a
-                      href={`/${entityType}/${encodeURIComponent(encodeSpace(node.name))}`}
-                      className="text-light-300 capitalize underline decoration-1 underline-offset-4 hover:text-light-100 transition duration-300"
-                    >
-                      {node.name}
-                    </a>
-                  ) : (
-                    <span className="text-light-500 capitalize">
-                      {node.name}
-                    </span>
-                  )}
-                </Fragment>
-              );
-            })}
-          </div>
-        ))}
+      <div className="mt-3">
+        <TaxonomyTree
+          trees={trees}
+          entityId={data.entity_id}
+          entityType={entityType}
+          colorClass={colorClass}
+        />
       </div>
     </Card>
   );

--- a/frontend/components/entities/TaxonomyTree.tsx
+++ b/frontend/components/entities/TaxonomyTree.tsx
@@ -1,0 +1,171 @@
+"use client";
+
+import { useState } from "react";
+import { TaxonomyNode } from "@/types";
+import { encodeSpace } from "@/utils/utils";
+import Button from "@/components/basic/Button";
+
+type TreeNode = {
+  node: TaxonomyNode;
+  children: TreeNode[];
+};
+
+function countPaths(tree: TreeNode): number {
+  if (tree.children.length === 0) return 1;
+  return tree.children.reduce((sum, c) => sum + countPaths(c), 0);
+}
+
+/** Extract the leftmost root-to-leaf path as a linear chain. */
+function primaryPath(tree: TreeNode): TreeNode {
+  if (tree.children.length === 0) return { node: tree.node, children: [] };
+  return {
+    node: tree.node,
+    children: [primaryPath(tree.children[0])],
+  };
+}
+
+function NodeLabel({
+  node,
+  entityId,
+  entityType,
+  colorClass,
+}: {
+  node: TaxonomyNode;
+  entityId: string;
+  entityType: string;
+  colorClass: string;
+}) {
+  const isEntity = node.id === entityId;
+  if (isEntity) {
+    return (
+      <span className={`font-medium ${colorClass} capitalize`}>
+        {node.name}
+      </span>
+    );
+  }
+  if (node.has_page) {
+    return (
+      <a
+        href={`/${entityType}/${encodeURIComponent(encodeSpace(node.name))}`}
+        className="text-light-300 capitalize underline decoration-1 underline-offset-4 hover:text-light-100 transition duration-300"
+      >
+        {node.name}
+      </a>
+    );
+  }
+  return <span className="text-light-500 capitalize">{node.name}</span>;
+}
+
+function TreeBranch({
+  tree,
+  entityId,
+  entityType,
+  colorClass,
+  depth,
+  isLast,
+}: {
+  tree: TreeNode;
+  entityId: string;
+  entityType: string;
+  colorClass: string;
+  depth: number;
+  isLast: boolean;
+}) {
+  return (
+    <div
+      className={
+        depth > 0
+          ? `ml-4 border-l pl-3 ${
+              isLast ? "border-transparent" : "border-light-50/25"
+            }`
+          : ""
+      }
+    >
+      <div
+        className={`relative py-0.5 text-sm ${
+          depth > 0
+            ? `before:content-[''] before:absolute before:top-0 before:left-[-13px] before:w-[13px] before:h-[50%] before:border-b before:border-light-50/25 ${
+                isLast ? "before:border-l" : ""
+              }`
+            : ""
+        }`}
+      >
+        <NodeLabel
+          node={tree.node}
+          entityId={entityId}
+          entityType={entityType}
+          colorClass={colorClass}
+        />
+      </div>
+      {tree.children.map((child, i) => (
+        <TreeBranch
+          key={`${child.node.id}-${i}`}
+          tree={child}
+          entityId={entityId}
+          entityType={entityType}
+          colorClass={colorClass}
+          depth={depth + 1}
+          isLast={i === tree.children.length - 1}
+        />
+      ))}
+    </div>
+  );
+}
+
+interface TaxonomyTreeProps {
+  trees: TreeNode[];
+  entityId: string;
+  entityType: string;
+  colorClass: string;
+}
+
+const TaxonomyTree = ({
+  trees,
+  entityId,
+  entityType,
+  colorClass,
+}: TaxonomyTreeProps) => {
+  const totalPaths = trees.reduce((sum, t) => sum + countPaths(t), 0);
+  const collapsible = totalPaths > 1;
+  const [expanded, setExpanded] = useState(false);
+
+  const displayTrees =
+    expanded || !collapsible ? trees : [primaryPath(trees[0])];
+
+  return (
+    <div>
+      <div>
+        {displayTrees.map((tree, i) => (
+          <TreeBranch
+            key={`root-${i}`}
+            tree={tree}
+            entityId={entityId}
+            entityType={entityType}
+            colorClass={colorClass}
+            depth={0}
+            isLast={i === displayTrees.length - 1}
+          />
+        ))}
+      </div>
+      {collapsible && (
+        <div className="mt-2">
+          <Button
+            variant="outlined"
+            size="xs"
+            className="rounded-full"
+            onClick={() => setExpanded(!expanded)}
+          >
+            {expanded
+              ? "Collapse"
+              : `+ ${totalPaths - 1} more path${totalPaths - 1 > 1 ? "s" : ""}`}
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+};
+
+TaxonomyTree.displayName = "TaxonomyTree";
+
+export type { TreeNode };
+export default TaxonomyTree;

--- a/frontend/components/entities/chemical/ChemicalCompositionSection.tsx
+++ b/frontend/components/entities/chemical/ChemicalCompositionSection.tsx
@@ -1,6 +1,11 @@
+import dynamic from "next/dynamic";
 import NoConcentrationComposition from "@/components/entities/chemical/NoConcentrationComposition";
-import ConcentrationCompositionPlot from "@/components/entities/chemical/ConcentrationCompositionPlot";
 import Heading from "@/components/basic/Heading";
+
+const ConcentrationCompositionPlot = dynamic(
+  () => import("@/components/entities/chemical/ConcentrationCompositionPlot"),
+  { ssr: false }
+);
 import { getChemicalCompositionData, getMetaData } from "@/utils/fetching";
 import { capitalizeFirstLetter } from "@/utils/utils";
 


### PR DESCRIPTION
## Summary

- **Chemical page OOM fix**: Dynamically import `ConcentrationCompositionPlot` (recharts) with `ssr: false` so the ~40MB charting library is never loaded server-side. The server renders a placeholder; the chart loads client-side. Food/disease pages were unaffected.
- **Taxonomy edge deduplication**: The recursive CTE could return the same parent-child edge via different traversal paths, causing hundreds of duplicated paths in the UI. Edges are now deduplicated before returning.
- **Tree view UI**: Replace flat breadcrumb paths with a collapsible tree using CSS pseudo-element connectors. Collapsed view shows one full root-to-entity path; expand button reveals all paths.

## Test plan

- [x] `npm run lint` — zero warnings, TypeScript passes
- [x] `npm run build` — clean production build
- [ ] Visit `/chemical/quercetin` — page loads without OOM, chart renders client-side
- [ ] Visit `/food/chicken--wing` — tree shows branching paths, collapse/expand works
- [ ] Visit `/food/cow--milk` — single path, no expand button shown