### PR TITLE
feat: ECS API HTTPS termination and bearer-token auth (#97)

### DIFF
--- a/infra/cdk/stacks/api_stack.py
+++ b/infra/cdk/stacks/api_stack.py
@@ -2,8 +2,12 @@
 
 The Fargate task runs the FastAPI backend image from the ECR repository
 provided by :class:`stacks.ecr_stack.EcrStack`. Secrets Manager supplies DB
-credentials at task start; the ALB listens on port 80 (HTTPS upgrade pending
-ACM cert) and forwards to the task on port 8000.
+credentials at task start; the ALB forwards to the task on port 8000.
+
+When the context variable ``api_cert_arn`` is set, the ALB listens on 443
+with HTTPS (cert imported from ACM by ARN) and redirects port 80 → 443.
+Without the context variable, the ALB falls back to plain HTTP on port 80
+so that local ``cdk synth`` and snapshot tests don't require a real cert.
 
 Networking: tasks are placed in public subnets with public IPs so they can
 pull from ECR and reach Secrets Manager without a NAT gateway. Security
@@ -16,20 +20,24 @@ the service will fail to start. Deploy :class:`EcrStack`, then build + push
 the API image from ``backend/api/`` to that repository, then deploy this
 stack.
 
-The stack uses a build-time context variable `api_image_tag` (default `latest`)
-to pick the image tag. Override with `cdk deploy -c api_image_tag=<sha>`.
+Context variables:
+- ``api_image_tag`` (default ``latest``): image tag in ECR to deploy.
+- ``api_cert_arn`` (optional): ACM certificate ARN in the same region as
+  the ALB. When set, enables HTTPS termination on port 443.
 """
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import aws_cdk as cdk
 from aws_cdk import Duration, RemovalPolicy
+from aws_cdk import aws_certificatemanager as acm
 from aws_cdk import aws_ec2 as ec2
 from aws_cdk import aws_ecr as ecr
 from aws_cdk import aws_ecs as ecs
 from aws_cdk import aws_ecs_patterns as ecs_patterns
+from aws_cdk import aws_elasticloadbalancingv2 as elbv2
 from aws_cdk import aws_logs as logs
 from aws_cdk import aws_rds as rds
 from aws_cdk import aws_s3 as s3
@@ -71,6 +79,16 @@ class ApiStack(cdk.Stack):
             removal_policy=RemovalPolicy.DESTROY,
         )
 
+        api_key_secret = secretsmanager.Secret(
+            self,
+            "ApiKeySecret",
+            description="Bearer token for the FoodAtlas API (polite gate).",
+            generate_secret_string=secretsmanager.SecretStringGenerator(
+                password_length=32,
+                exclude_punctuation=True,
+            ),
+        )
+
         task_definition = ecs.FargateTaskDefinition(
             self,
             "ApiTaskDefinition",
@@ -104,6 +122,7 @@ class ApiStack(cdk.Stack):
             secrets={
                 "DB_USER": ecs.Secret.from_secrets_manager(db_secret, "username"),
                 "DB_PASSWORD": ecs.Secret.from_secrets_manager(db_secret, "password"),
+                "API_KEY": ecs.Secret.from_secrets_manager(api_key_secret),
             },
             port_mappings=[
                 ecs.PortMapping(container_port=8000, protocol=ecs.Protocol.TCP),
@@ -113,18 +132,36 @@ class ApiStack(cdk.Stack):
         # Task role needs read access to KGC bucket for ad-hoc fetches
         kgc_bucket.grant_read(task_definition.task_role)
 
+        cert_arn = self.node.try_get_context("api_cert_arn")
+        service_kwargs: dict[str, Any] = {
+            "cluster": self.cluster,
+            "task_definition": task_definition,
+            "desired_count": 1,
+            "min_healthy_percent": 100,
+            "public_load_balancer": True,
+            "assign_public_ip": True,
+            "task_subnets": ec2.SubnetSelection(subnet_type=ec2.SubnetType.PUBLIC),
+            "health_check_grace_period": Duration.seconds(60),
+        }
+        if cert_arn:
+            certificate = acm.Certificate.from_certificate_arn(
+                self,
+                "ApiCertificate",
+                cert_arn,
+            )
+            service_kwargs.update(
+                certificate=certificate,
+                protocol=elbv2.ApplicationProtocol.HTTPS,
+                redirect_http=True,
+                listener_port=443,
+            )
+        else:
+            service_kwargs["listener_port"] = 80
+
         self.service = ecs_patterns.ApplicationLoadBalancedFargateService(
             self,
             "ApiService",
-            cluster=self.cluster,
-            task_definition=task_definition,
-            desired_count=1,
-            min_healthy_percent=100,
-            public_load_balancer=True,
-            assign_public_ip=True,
-            task_subnets=ec2.SubnetSelection(subnet_type=ec2.SubnetType.PUBLIC),
-            listener_port=80,  # TODO: switch to 443 after ACM cert is added
-            health_check_grace_period=Duration.seconds(60),
+            **service_kwargs,
         )
 
         self.service.target_group.configure_health_check(
@@ -136,9 +173,21 @@ class ApiStack(cdk.Stack):
             unhealthy_threshold_count=3,
         )
 
+        scheme = "https" if cert_arn else "http"
         cdk.CfnOutput(
             self,
             "ApiUrl",
-            value=f"http://{self.service.load_balancer.load_balancer_dns_name}",
+            value=f"{scheme}://{self.service.load_balancer.load_balancer_dns_name}",
             description="Public API URL (ALB DNS)",
+        )
+
+        cdk.CfnOutput(
+            self,
+            "ApiKeySecretArn",
+            value=api_key_secret.secret_arn,
+            description=(
+                "Secrets Manager ARN for the API bearer token. Fetch the "
+                "value with: aws secretsmanager get-secret-value "
+                "--secret-id <arn> --query SecretString --output text"
+            ),
         )

--- a/infra/cdk/tests/test_api_stack.py
+++ b/infra/cdk/tests/test_api_stack.py
@@ -11,9 +11,15 @@ from stacks.ecr_stack import EcrStack
 from stacks.network_stack import NetworkStack
 from stacks.storage_stack import StorageStack
 
+_FAKE_CERT_ARN = (
+    "arn:aws:acm:us-west-1:123456789012:certificate/"
+    "11111111-2222-3333-4444-555555555555"
+)
 
-def _synth() -> Template:
-    app = cdk.App()
+
+def _synth(*, cert_arn: str | None = None) -> Template:
+    context = {"api_cert_arn": cert_arn} if cert_arn else None
+    app = cdk.App(context=context)
     network = NetworkStack(app, "TestNetworkStack")
     storage = StorageStack(app, "TestStorageStack")
     ecr_stack = EcrStack(app, "TestEcrStack")
@@ -87,4 +93,92 @@ def test_log_group_retention_one_month() -> None:
     template.has_resource_properties(
         "AWS::Logs::LogGroup",
         Match.object_like({"RetentionInDays": 30}),
+    )
+
+
+def test_api_key_secret_resource_exists() -> None:
+    template = _synth()
+    template.has_resource_properties(
+        "AWS::SecretsManager::Secret",
+        Match.object_like(
+            {
+                "GenerateSecretString": Match.object_like(
+                    {
+                        "PasswordLength": 32,
+                        "ExcludePunctuation": True,
+                    },
+                ),
+            },
+        ),
+    )
+
+
+def test_task_definition_injects_api_key_secret() -> None:
+    template = _synth()
+    template.has_resource_properties(
+        "AWS::ECS::TaskDefinition",
+        Match.object_like(
+            {
+                "ContainerDefinitions": Match.array_with(
+                    [
+                        Match.object_like(
+                            {
+                                "Secrets": Match.array_with(
+                                    [Match.object_like({"Name": "API_KEY"})],
+                                ),
+                            },
+                        ),
+                    ],
+                ),
+            },
+        ),
+    )
+
+
+def test_http_mode_has_single_port_80_listener() -> None:
+    template = _synth()
+    template.resource_count_is("AWS::ElasticLoadBalancingV2::Listener", 1)
+    template.has_resource_properties(
+        "AWS::ElasticLoadBalancingV2::Listener",
+        Match.object_like({"Protocol": "HTTP", "Port": 80}),
+    )
+
+
+def test_https_mode_declares_443_listener_with_cert() -> None:
+    template = _synth(cert_arn=_FAKE_CERT_ARN)
+    template.has_resource_properties(
+        "AWS::ElasticLoadBalancingV2::Listener",
+        Match.object_like(
+            {
+                "Protocol": "HTTPS",
+                "Port": 443,
+                "Certificates": [{"CertificateArn": _FAKE_CERT_ARN}],
+            },
+        ),
+    )
+
+
+def test_https_mode_redirects_port_80_to_443() -> None:
+    template = _synth(cert_arn=_FAKE_CERT_ARN)
+    template.resource_count_is("AWS::ElasticLoadBalancingV2::Listener", 2)
+    template.has_resource_properties(
+        "AWS::ElasticLoadBalancingV2::Listener",
+        Match.object_like(
+            {
+                "Protocol": "HTTP",
+                "Port": 80,
+                "DefaultActions": [
+                    {
+                        "Type": "redirect",
+                        "RedirectConfig": Match.object_like(
+                            {
+                                "Protocol": "HTTPS",
+                                "Port": "443",
+                                "StatusCode": "HTTP_301",
+                            },
+                        ),
+                    },
+                ],
+            },
+        ),
     )


### PR DESCRIPTION
## Summary

Wires up HTTPS termination and a Secrets Manager–backed bearer token on `FoodAtlasApiStack`, in preparation for cutting `api.foodatlas.ai` over from the old API Gateway + Lambda backend to the new ECS Fargate API. Closes out the CDK-side work for issue #97.

The cutover itself (Vercel env var + Namecheap CNAME flip) is a separate operational step and is not part of this PR.

## What changed

### HTTPS on the ALB (Step 2 of #97)

- Import an existing ACM cert by ARN via `acm.Certificate.from_certificate_arn(...)`. The ARN is read from a new `api_cert_arn` CDK context variable so it stays out of git.
- When the context var is set, `ApplicationLoadBalancedFargateService` is configured with `certificate`, `protocol=HTTPS`, `redirect_http=True`, and `listener_port=443`. CDK auto-creates a port-80 listener that 301-redirects to HTTPS.
- When the context var is unset, the stack falls back to plain HTTP on port 80 — so env-agnostic `cdk synth` and the snapshot tests continue to work without a real cert.
- The cert is issued and validated via DNS (Namecheap CNAME) as part of the operational Step 1 of #97.

### API key bearer-token auth (Step 3 of #97)

- Add a `secretsmanager.Secret` with `generate_secret_string` (32 chars, no punctuation). AWS generates the random value server-side.
- Inject the secret into the ECS task definition as the `API_KEY` env var via `ecs.Secret.from_secrets_manager(...)`, alongside the existing `DB_USER` / `DB_PASSWORD` injections.
- CDK emits a new `ApiKeySecretArn` stack output so the generated value can be fetched with `aws secretsmanager get-secret-value`.
- No backend code change required: `APISettings.key` in `backend/api/src/dependencies.py` already reads `API_KEY` from env, and `verify_api_key` already enforces `Authorization: Bearer <key>` when it's set and debug mode is off.

### Tests

- New snapshot tests in `infra/cdk/tests/test_api_stack.py`:
  - HTTP-only mode: single listener on port 80.
  - HTTPS mode (via context-injected fake cert ARN): 443 HTTPS listener with the cert wired in, plus an 80 → 443 redirect listener.
  - API key secret resource exists with the correct generator config.
  - Task definition's container references the secret under `Secrets` as `API_KEY`.
- 36/36 CDK tests pass, 100% stack coverage.

## Context

The new backend has been fully verified end-to-end against the current frontend via `curl --resolve` (15/15 routes returning 200). The cert ARN, secret ARN, and ALB hostname are recorded; the secret value has already been rotated once as a rehearsal.

The only remaining work for #97 is operational — update Vercel's `NEXT_PUBLIC_API_KEY`, relink Vercel to the new frontend repo, and flip the Namecheap CNAME during a coordinated cutover window. Issue #97 stays open until that's done.

## Test plan

- [x] `uv run pytest` in `infra/cdk/` — 36 passed, 100% coverage
- [x] `uv run cdk synth FoodAtlasApiStack` with and without `api_cert_arn` context
- [x] `uv run cdk deploy FoodAtlasApiStack` succeeded; ALB now serves HTTPS with the new cert
- [x] `curl --resolve api.foodatlas.ai:443:<alb-ip> https://api.foodatlas.ai/health` returns 200 with `server: uvicorn` and a valid cert
- [x] `curl ... /metadata/statistics` without auth returns 401; with the bearer token returns entity counts
- [x] Rotation rehearsal: `aws secretsmanager put-secret-value` + `aws ecs update-service --force-new-deployment` rolls the task to pick up the new value; old key invalidated, new key accepted
- [ ] Cutover (Step 5 of #97): Vercel env var update + Namecheap CNAME flip — pending coordination