### PR TITLE
fix: set API_CORS_ORIGINS on ECS task for foodatlas.ai (#97)

### DIFF
--- a/infra/cdk/stacks/api_stack.py
+++ b/infra/cdk/stacks/api_stack.py
@@ -114,6 +114,14 @@ class ApiStack(cdk.Stack):
                 # API_HOST is set via the Dockerfile ENV to bind all
                 # interfaces inside the container; no need to duplicate here.
                 "API_DEBUG": "False",
+                "API_CORS_ORIGINS": ",".join(
+                    [
+                        "https://foodatlas.ai",
+                        "https://www.foodatlas.ai",
+                        "https://dev.foodatlas.ai",
+                        "http://localhost:3000",
+                    ],
+                ),
                 "DB_HOST": db_instance.db_instance_endpoint_address,
                 "DB_PORT": db_instance.db_instance_endpoint_port,
                 "DB_NAME": "foodatlas",


### PR DESCRIPTION
## Summary

Hot-fix discovered immediately after the Step 5 DNS cutover for #97. The new ECS task was missing the `API_CORS_ORIGINS` env var, so FastAPI's `CORSMiddleware` fell back to its config default of `http://localhost:3000` and rejected preflight `OPTIONS` requests from `https://foodatlas.ai` with HTTP 400. Browsers then refused all subsequent API calls.

## What changed

Set `API_CORS_ORIGINS` on the Fargate task definition's environment dict in `infra/cdk/stacks/api_stack.py`:

- `https://foodatlas.ai` (apex production)
- `https://www.foodatlas.ai` (www variant)
- `https://dev.foodatlas.ai` (dev tier — both prod and dev share one backend per #97 spec)
- `http://localhost:3000` (so devs can hit prod backend from a local frontend if needed)

Already deployed to AWS via emergency `cdk deploy FoodAtlasApiStack` during the cutover; this PR aligns the repo with the deployed state.

## Why Step 4 validation didn't catch it

End-to-end validation in Step 4 used `curl --resolve` against `api.foodatlas.ai`. Plain HTTP requests like that don't trigger CORS preflight checks — only browsers do, and only for cross-origin requests. The validation suite covered the API contract but not the browser-level CORS handshake.

**Lesson**: when adding routes to a backend that serves a Vercel frontend, validate at least one request from a real browser before flipping DNS, even if `curl` says everything's fine.

## Test plan

- [x] CDK redeploy already shipped during the cutover (exit 0, no rollback needed)
- [x] `curl -X OPTIONS` from `Origin: https://foodatlas.ai` returns 200 with correct `Access-Control-Allow-*` headers
- [x] Authenticated `GET /metadata/statistics` returns the expected entity counts
- [x] Live site at `https://foodatlas.ai` confirmed working by repo owner
- [ ] Existing snapshot tests in `infra/cdk/tests/test_api_stack.py` still pass (haven't added a snapshot test for the env var since it's a one-line change; can add if reviewers want)