### PR TITLE
fix: chemical r2 direction, correlation scoping, and MV perf (#103)

### DIFF
--- a/backend/db/README.md
+++ b/backend/db/README.md
@@ -14,6 +14,10 @@ uv run alembic upgrade head
 
 # Load KGC parquet output into the database
 uv run python main.py load
+
+# Rebuild materialized views from existing base tables (skip parquet
+# read + base inserts). Use when iterating on materializer logic.
+uv run python main.py refresh
 ```
 
 ## Production
@@ -87,11 +91,14 @@ The `load` CLI command reads KGC parquet output and populates the database:
 2. **Materialize** API tables by joining and denormalizing base data
 3. **Build** search indexes (trigram-based autocomplete)
 
+The `refresh` CLI command re-runs steps 2–3 against the existing base tables
+without touching parquet. Use this when iterating on materializer logic.
+
 ## Project Structure
 
 ```
 db/
-├── main.py                 # Click CLI entry point (load command)
+├── main.py                 # Click CLI entry point (load, refresh)
 ├── Dockerfile              # Multi-stage build for the foodatlas-db image
 ├── .dockerignore
 ├── pyproject.toml

--- a/backend/db/main.py
+++ b/backend/db/main.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import click
 from src.config import DBSettings
 from src.engine import create_sync_engine
-from src.etl.loader import load_kg
+from src.etl.loader import load_kg, refresh_materialized_views
 from src.etl.s3_sync import download_s3_prefix, is_s3_uri
 
 logging.basicConfig(
@@ -54,6 +54,20 @@ def load(parquet_dir: str) -> None:
         with engine.connect() as conn:
             load_kg(conn, local_path)
 
+    click.echo("Done.")
+
+
+@cli.command("refresh")
+def refresh() -> None:
+    """Rebuild materialized views from existing base tables.
+
+    Skips parquet read and base table inserts. Use this when iterating on
+    materializer logic without touching the underlying KG data.
+    """
+    settings = DBSettings()
+    engine = create_sync_engine(settings)
+    with engine.connect() as conn:
+        refresh_materialized_views(conn)
     click.echo("Done.")
 
 

--- a/backend/db/src/etl/loader.py
+++ b/backend/db/src/etl/loader.py
@@ -121,10 +121,13 @@ def load_kg(conn: Connection, parquet_dir: Path) -> None:
     conn.commit()
 
     # 4. Materialize API tables
+    refresh_materialized_views(conn)
+    logger.info("ETL complete.")
+
+
+def refresh_materialized_views(conn: Connection) -> None:
+    """Rebuild all materialized views from existing base tables."""
     logger.info("Materializing entity views + composition tables...")
     refresh_all(conn)
-
     logger.info("Materializing search + statistics...")
     refresh_search(conn)
-
-    logger.info("ETL complete.")

--- a/backend/db/src/etl/materializer.py
+++ b/backend/db/src/etl/materializer.py
@@ -90,12 +90,17 @@ def _materialize_entity_views(conn: Connection) -> None:
 def _collect_ancestors(
     r2: pd.DataFrame, seed_ids: set[str], entities: pd.DataFrame
 ) -> set[str]:
-    """Return all chemical ancestors of seed_ids via IS_A (r2) triplets."""
+    """Return all chemical ancestors of seed_ids via IS_A (r2) triplets.
+
+    Chemical-chemical r2 uses head=parent, tail=child (see
+    backend/api/src/repositories/taxonomy.py), so a child's parents are the
+    head_ids of rows where it appears as tail.
+    """
     chem_ids_all = set(entities[entities["entity_type"] == "chemical"]["foodatlas_id"])
     chem_r2 = r2[r2["head_id"].isin(chem_ids_all) & r2["tail_id"].isin(chem_ids_all)]
     parents_of: dict[str, set[str]] = {}
     for _, row in chem_r2.iterrows():
-        parents_of.setdefault(row["head_id"], set()).add(row["tail_id"])
+        parents_of.setdefault(row["tail_id"], set()).add(row["head_id"])
 
     ancestors: set[str] = set()
     for node in seed_ids:

--- a/backend/db/src/etl/materializer_composition.py
+++ b/backend/db/src/etl/materializer_composition.py
@@ -2,12 +2,12 @@
 
 import json
 import logging
+from collections import defaultdict
 
 import numpy as np
 import pandas as pd
 from sqlalchemy import text
 from sqlalchemy.engine import Connection
-from tqdm import tqdm
 
 from .bulk_insert import bulk_copy
 
@@ -78,15 +78,22 @@ def materialize_food_chemical_composition(conn: Connection) -> None:
         lambda x: x if isinstance(x, dict) else {}
     )
 
-    # Group by triplet and build evidence JSON.
-    grouped = merged.groupby(["head_id", "tail_id"])
-    result_rows = []
+    # Group by triplet in pure Python (faster than pandas get_group per key
+    # when there are many small groups).
+    groups: dict[tuple[str, str], list[tuple]] = defaultdict(list)
+    for head_id, tail_id, source, ref, extraction in zip(
+        merged["head_id"],
+        merged["tail_id"],
+        merged["source"],
+        merged["_ref"],
+        merged["_extraction"],
+        strict=False,
+    ):
+        groups[(head_id, tail_id)].append((source, ref, extraction))
 
-    # Convert groups to tuples for faster iteration.
-    group_keys = list(grouped.groups.keys())
-    for head_id, tail_id in tqdm(group_keys, desc="composition", leave=True):
-        group = grouped.get_group((head_id, tail_id))
-        ev = _build_evidence_from_precomputed(group)
+    result_rows = []
+    for (head_id, tail_id), rows in groups.items():
+        ev = _build_evidence_from_rows(rows)
         if not any(ev.values()):
             continue
         all_ev = (ev["fdc"] or []) + (ev["foodatlas"] or []) + (ev["dmd"] or [])
@@ -176,17 +183,27 @@ def _build_evidence_json(group: pd.DataFrame) -> dict[str, list | None]:
 def _build_evidence_from_precomputed(
     group: pd.DataFrame,
 ) -> dict[str, list | None]:
-    """Build evidence JSON from pre-computed extraction dicts."""
+    """Build evidence JSON from a DataFrame group with pre-computed columns."""
+    rows = list(
+        zip(
+            group["source"],
+            group["_ref"],
+            group["_extraction"],
+            strict=False,
+        )
+    )
+    return _build_evidence_from_rows(rows)
+
+
+def _build_evidence_from_rows(
+    rows: list[tuple],
+) -> dict[str, list | None]:
+    """Build evidence JSON from a list of (source, ref, extraction) tuples."""
     fdc: list[dict] = []
     foodatlas: list[dict] = []
     dmd: list[dict] = []
 
-    for source, ref, extraction in zip(
-        group["source"],
-        group["_ref"],
-        group["_extraction"],
-        strict=False,
-    ):
+    for source, ref, extraction in rows:
         if source in ("fdc", "dmd"):
             bucket = fdc if source == "fdc" else dmd
             upper = source.upper()

--- a/backend/db/src/etl/materializer_correlation.py
+++ b/backend/db/src/etl/materializer_correlation.py
@@ -7,7 +7,6 @@ from collections import defaultdict
 import pandas as pd
 from sqlalchemy import text
 from sqlalchemy.engine import Connection
-from tqdm import tqdm
 
 from .bulk_insert import bulk_copy
 
@@ -22,7 +21,10 @@ def materialize_chemical_disease_correlation(conn: Connection) -> None:
 
     For each chemical, includes disease correlations from itself and all
     descendant chemicals (via IS_A hierarchy) so that parent categories
-    like "Vitamin" surface their children's connections.
+    like "Vitamin" surface their children's connections. Inherited rows
+    only fire when the descendant is food-connected (appears as an r1
+    tail); purely ontological descendants with no food presence would
+    otherwise flood parent pages with irrelevant disease rows.
 
     Each (chemical, source_chemical, disease, rel) gets its own row so
     the frontend can show which descendant contributes the connection.
@@ -37,56 +39,73 @@ def materialize_chemical_disease_correlation(conn: Connection) -> None:
         text("SELECT foodatlas_id, common_name, entity_type FROM base_entities"),
         conn,
     )
+    food_chem_ids = set(
+        pd.read_sql(
+            text(
+                "SELECT DISTINCT tail_id FROM base_triplets"
+                " WHERE relationship_id = 'r1'"
+            ),
+            conn,
+        )["tail_id"]
+    )
 
     name_map = entities.set_index("foodatlas_id")["common_name"].to_dict()
     etype_map = entities.set_index("foodatlas_id")["entity_type"].to_dict()
-    att_map = attestations.set_index("attestation_id")
-    ev_map = evidence.set_index("evidence_id")
+    # Pure-dict lookups are ~100x faster than pandas .loc in tight loops.
+    att_dict = attestations.set_index("attestation_id").to_dict("index")
+    ev_dict = evidence.set_index("evidence_id")["reference"].to_dict()
 
     ancestors_of = _build_ancestors(conn, etype_map)
 
-    # Keyed by (chemical_id, source_chemical_id, disease_id, rel_id)
-    agg: dict[tuple, dict] = {}
-
-    for _, triplet in tqdm(
-        r3r4.iterrows(), total=len(r3r4), desc="correlation", leave=True
+    rows: list[dict] = []
+    for head_id, tail_id, rel_id, att_ids in zip(
+        r3r4["head_id"],
+        r3r4["tail_id"],
+        r3r4["relationship_id"],
+        r3r4["attestation_ids"],
+        strict=False,
     ):
-        chem_id = triplet["head_id"]
-        disease_id = triplet["tail_id"]
-        rel_id = triplet["relationship_id"]
-        att_ids = triplet["attestation_ids"] or []
+        sources, evidences = _extract_evidence(att_ids or [], att_dict, ev_dict)
+        deduped = _deduplicate_evidences(evidences)
+        evidences_json = json.dumps(deduped)
+        source_list = list(sources)
 
-        sources, evidences = _get_correlation_evidence(att_ids, att_map, ev_map)
-
-        # Direct row: source_chemical = chemical itself
-        _merge_into(agg, chem_id, chem_id, disease_id, rel_id, sources, evidences)
-
-        # Inherited rows: source_chemical = the actual descendant (chem_id)
-        for ancestor_id in ancestors_of.get(chem_id, set()):
-            _merge_into(
-                agg, ancestor_id, chem_id, disease_id, rel_id, sources, evidences
+        # Direct row: source_chemical = chemical itself. Always emitted
+        # so the chemical's own page shows its own disease edges.
+        rows.append(
+            _make_row(
+                head_id,
+                head_id,
+                tail_id,
+                rel_id,
+                source_list,
+                evidences_json,
+                len(deduped),
+                name_map,
+            )
+        )
+        # Inherited rows — only propagate disease edges up the ChEBI tree
+        # when the descendant itself is food-connected. A purely
+        # ontological descendant with disease data but no food presence
+        # is not useful on a food-chemical-disease page.
+        if head_id not in food_chem_ids:
+            continue
+        for ancestor_id in ancestors_of.get(head_id, ()):
+            rows.append(
+                _make_row(
+                    ancestor_id,
+                    head_id,
+                    tail_id,
+                    rel_id,
+                    source_list,
+                    evidences_json,
+                    len(deduped),
+                    name_map,
+                )
             )
 
-    if not agg:
+    if not rows:
         return
-
-    rows = []
-    for (chem_id, src_chem_id, disease_id, rel_id), data in agg.items():
-        deduped = _deduplicate_evidences(data["evidences"])
-        rows.append(
-            {
-                "chemical_name": name_map.get(chem_id, ""),
-                "chemical_foodatlas_id": chem_id,
-                "relationship_id": rel_id,
-                "disease_name": name_map.get(disease_id, ""),
-                "disease_foodatlas_id": disease_id,
-                "source_chemical_name": name_map.get(src_chem_id, ""),
-                "source_chemical_foodatlas_id": src_chem_id,
-                "sources": list(data["sources"]),
-                "evidences": json.dumps(deduped),
-                "evidence_count": len(deduped),
-            }
-        )
 
     result = pd.DataFrame(rows)
     columns = [
@@ -105,21 +124,28 @@ def materialize_chemical_disease_correlation(conn: Connection) -> None:
     logger.info("Chemical-disease correlations: %d rows", len(result))
 
 
-def _merge_into(
-    agg: dict[tuple, dict],
+def _make_row(
     chem_id: str,
     src_chem_id: str,
     disease_id: str,
     rel_id: str,
     sources: list[str],
-    evidences: list[dict],
-) -> None:
-    """Merge evidence into aggregated row."""
-    key = (chem_id, src_chem_id, disease_id, rel_id)
-    if key not in agg:
-        agg[key] = {"sources": set(), "evidences": []}
-    agg[key]["sources"].update(sources)
-    agg[key]["evidences"].extend(evidences)
+    evidences_json: str,
+    evidence_count: int,
+    name_map: dict[str, str],
+) -> dict:
+    return {
+        "chemical_name": name_map.get(chem_id, ""),
+        "chemical_foodatlas_id": chem_id,
+        "relationship_id": rel_id,
+        "disease_name": name_map.get(disease_id, ""),
+        "disease_foodatlas_id": disease_id,
+        "source_chemical_name": name_map.get(src_chem_id, ""),
+        "source_chemical_foodatlas_id": src_chem_id,
+        "sources": sources,
+        "evidences": evidences_json,
+        "evidence_count": evidence_count,
+    }
 
 
 def _deduplicate_evidences(evidences: list[dict]) -> list[dict]:
@@ -138,7 +164,12 @@ def _deduplicate_evidences(evidences: list[dict]) -> list[dict]:
 def _build_ancestors(
     conn: Connection, etype_map: dict[str, str]
 ) -> dict[str, set[str]]:
-    """Build child -> all ancestors map from chemical IS_A triplets."""
+    """Build child -> all ancestors map from chemical IS_A triplets.
+
+    Chemical-chemical r2 uses head=parent, tail=child (see
+    backend/api/src/repositories/taxonomy.py), so a child's parents are the
+    head_ids of rows where it appears as tail.
+    """
     r2 = pd.read_sql(
         text("SELECT head_id, tail_id FROM base_triplets WHERE relationship_id = 'r2'"),
         conn,
@@ -151,7 +182,7 @@ def _build_ancestors(
 
     parents_of: dict[str, set[str]] = defaultdict(set)
     for _, row in r2.iterrows():
-        parents_of[row["head_id"]].add(row["tail_id"])
+        parents_of[row["tail_id"]].add(row["head_id"])
 
     cache: dict[str, set[str]] = {}
 
@@ -172,6 +203,46 @@ def _build_ancestors(
         _ancestors(node)
 
     return cache
+
+
+def _extract_evidence(
+    att_ids: list[str],
+    att_dict: dict[str, dict],
+    ev_dict: dict[str, object],
+) -> tuple[set[str], list[dict]]:
+    """Extract sources and PMID/PMCID evidence from plain-dict lookups."""
+    sources: set[str] = set()
+    evidences: list[dict] = []
+    for att_id in att_ids:
+        att = att_dict.get(att_id)
+        if att is None:
+            continue
+        sources.add(att["source"])
+
+        ref_raw = ev_dict.get(att["evidence_id"])
+        if ref_raw is None:
+            continue
+        if isinstance(ref_raw, str):
+            ref: dict = json.loads(ref_raw)
+        elif isinstance(ref_raw, dict):
+            ref = ref_raw
+        else:
+            continue
+
+        ev_dict_row: dict = {}
+        if "pmcid" in ref:
+            ev_dict_row["pmcid"] = {
+                "id": ref["pmcid"],
+                "url": f"{_PMC_URL}{ref['pmcid']}",
+            }
+        if "pmid" in ref:
+            ev_dict_row["pmid"] = {
+                "id": str(ref["pmid"]),
+                "url": f"{_PUBMED_URL}{ref['pmid']}",
+            }
+        if ev_dict_row:
+            evidences.append(ev_dict_row)
+    return sources, evidences
 
 
 def _get_correlation_evidence(

--- a/backend/db/src/etl/materializer_search.py
+++ b/backend/db/src/etl/materializer_search.py
@@ -32,10 +32,11 @@ def _materialize_search_auto_complete(conn: Connection) -> None:
     r1 = triplets[triplets["relationship_id"] == "r1"]
     r3r4 = triplets[triplets["relationship_id"].isin(["r3", "r4"])]
 
-    # Vectorized association counts
-    assoc_counts = (
-        pd.concat([triplets["head_id"], triplets["tail_id"]]).value_counts().to_dict()
-    )
+    # Per-entity association counts mirror what the entity page actually
+    # renders: row counts from the already-populated composition and
+    # correlation MVs. refresh_search runs after refresh_all (see loader.py),
+    # so both tables exist at this point.
+    assoc_counts = _load_assoc_counts(conn)
 
     # Pre-compute relevant entity ID sets
     food_ids = set(r1["head_id"])
@@ -107,6 +108,29 @@ def _materialize_search_auto_complete(conn: Connection) -> None:
     logger.info("Search autocomplete: %d rows", len(result))
 
 
+def _load_assoc_counts(conn: Connection) -> dict[str, int]:
+    """Sum entity row counts across composition and correlation MVs.
+
+    Each MV uses type-specific ID columns (food_/chemical_/disease_foodatlas_id)
+    so adding all four groupings never cross-contaminates entity types.
+    """
+    queries = (
+        "SELECT food_foodatlas_id AS fid, COUNT(*) AS n"
+        " FROM mv_food_chemical_composition GROUP BY food_foodatlas_id",
+        "SELECT chemical_foodatlas_id AS fid, COUNT(*) AS n"
+        " FROM mv_food_chemical_composition GROUP BY chemical_foodatlas_id",
+        "SELECT chemical_foodatlas_id AS fid, COUNT(*) AS n"
+        " FROM mv_chemical_disease_correlation GROUP BY chemical_foodatlas_id",
+        "SELECT disease_foodatlas_id AS fid, COUNT(*) AS n"
+        " FROM mv_chemical_disease_correlation GROUP BY disease_foodatlas_id",
+    )
+    counts: dict[str, int] = {}
+    for sql in queries:
+        for fid, n in conn.execute(text(sql)).all():
+            counts[fid] = counts.get(fid, 0) + n
+    return counts
+
+
 def _extract_external_id_values(ext_ids: dict, entity_type: str) -> list[str]:
     """Extract flat list of external ID values for search tokens."""
     values = []
@@ -169,10 +193,18 @@ def _materialize_statistics(conn: Connection) -> None:
     scoped_r3r4 = r3r4[r3r4["head_id"].isin(chem_ids)]
     disease_ids = set(scoped_r3r4["tail_id"])
 
+    # Chemical r2 stores head=parent, tail=child; food/disease r2 stores
+    # head=child, tail=parent (see backend/api/src/repositories/taxonomy.py).
     assoc_r2 = (
-        _count_scoped_r2(r2, food_ids, type_map.get("food", set()))
-        + _count_scoped_r2(r2, chem_ids, type_map.get("chemical", set()))
-        + _count_scoped_r2(r2, disease_ids, type_map.get("disease", set()))
+        _count_scoped_r2(
+            r2, food_ids, type_map.get("food", set()), "head_id", "tail_id"
+        )
+        + _count_scoped_r2(
+            r2, chem_ids, type_map.get("chemical", set()), "tail_id", "head_id"
+        )
+        + _count_scoped_r2(
+            r2, disease_ids, type_map.get("disease", set()), "head_id", "tail_id"
+        )
     )
     associations = len(r1) + len(scoped_r3r4) + assoc_r2
 
@@ -216,12 +248,22 @@ def _materialize_statistics(conn: Connection) -> None:
     logger.info("Statistics: %d entries", len(rows))
 
 
-def _count_scoped_r2(r2: pd.DataFrame, seed_ids: set[str], type_ids: set[str]) -> int:
-    """Count IS_A edges reachable from seed entities to root."""
+def _count_scoped_r2(
+    r2: pd.DataFrame,
+    seed_ids: set[str],
+    type_ids: set[str],
+    child_col: str,
+    parent_col: str,
+) -> int:
+    """Count IS_A edges reachable from seed entities to root.
+
+    child_col/parent_col select the r2 direction for the entity type
+    (see backend/api/src/repositories/taxonomy.py).
+    """
     typed_r2 = r2[r2["head_id"].isin(type_ids) & r2["tail_id"].isin(type_ids)]
     parents_of: dict[str, set[str]] = {}
     for _, row in typed_r2.iterrows():
-        parents_of.setdefault(row["head_id"], set()).add(row["tail_id"])
+        parents_of.setdefault(row[child_col], set()).add(row[parent_col])
 
     reachable = set(seed_ids)
     stack = list(seed_ids)

--- a/backend/db/tests/test_correlation_helpers.py
+++ b/backend/db/tests/test_correlation_helpers.py
@@ -6,7 +6,6 @@ import pandas as pd
 from src.etl.materializer_correlation import (
     _deduplicate_evidences,
     _get_correlation_evidence,
-    _merge_into,
 )
 
 
@@ -125,34 +124,6 @@ class TestGetCorrelationEvidence:
         _sources, evidences = _get_correlation_evidence(["at1"], att_map, ev_map)
         assert len(evidences) == 1
         assert evidences[0]["pmid"]["id"] == "12345"
-
-
-class TestMergeInto:
-    def test_creates_new_entry(self):
-        agg: dict = {}
-        _merge_into(agg, "c1", "c1", "d1", "r3", ["ctd"], [{"pmid": {"id": "1"}}])
-        assert ("c1", "c1", "d1", "r3") in agg
-        assert "ctd" in agg[("c1", "c1", "d1", "r3")]["sources"]
-        assert len(agg[("c1", "c1", "d1", "r3")]["evidences"]) == 1
-
-    def test_merges_into_existing(self):
-        agg: dict = {}
-        _merge_into(agg, "c1", "c1", "d1", "r3", ["ctd"], [{"pmid": {"id": "1"}}])
-        _merge_into(agg, "c1", "c1", "d1", "r3", ["mesh"], [{"pmid": {"id": "2"}}])
-        assert agg[("c1", "c1", "d1", "r3")]["sources"] == {"ctd", "mesh"}
-        assert len(agg[("c1", "c1", "d1", "r3")]["evidences"]) == 2
-
-    def test_different_source_chemicals_separate(self):
-        agg: dict = {}
-        _merge_into(
-            agg, "parent", "child1", "d1", "r3", ["ctd"], [{"pmid": {"id": "1"}}]
-        )
-        _merge_into(
-            agg, "parent", "child2", "d1", "r3", ["ctd"], [{"pmid": {"id": "2"}}]
-        )
-        assert len(agg) == 2
-        assert ("parent", "child1", "d1", "r3") in agg
-        assert ("parent", "child2", "d1", "r3") in agg
 
 
 class TestDeduplicateEvidences:

--- a/backend/db/tests/test_materialize_statistics.py
+++ b/backend/db/tests/test_materialize_statistics.py
@@ -6,16 +6,17 @@ import pandas as pd
 from src.etl.materializer_search import _materialize_statistics
 
 # Minimal triplets: food→chem (r1), chem IS_A chem (r2), chem→disease (r3)
+# Chemical r2 direction: head=parent, tail=child.
+# Food/disease r2 direction: head=child, tail=parent.
 _TRIPLETS = pd.DataFrame(
     {
-        "head_id": ["f1", "f1", "c1", "c1", "c2", "d1"],
-        "tail_id": ["c1", "c2", "c3", "d1", "d2", "d3"],
+        "head_id": ["f1", "f1", "c3", "c1", "c2", "d1"],
+        "tail_id": ["c1", "c2", "c1", "d1", "d2", "d3"],
         "relationship_id": ["r1", "r1", "r2", "r3", "r3", "r2"],
     }
 )
-# c1 is in r1 tail (food-connected), c2 is in r1 tail, c2→d2 is scoped
-# c1→c3 is r2 (IS_A), d1→d3 is r2 (IS_A)
-# Scoped r3/r4: c1→d1 and c2→d2 (both heads are r1 tails)
+# c1/c2 are r1 tails (food-connected). c1's chemical parent is c3 (r2 head=c3).
+# d1's disease parent is d3 (r2 head=d1). Scoped r3/r4: c1→d1 and c2→d2.
 
 _ENTITIES = pd.DataFrame(
     {

--- a/backend/db/tests/test_materializer.py
+++ b/backend/db/tests/test_materializer.py
@@ -168,7 +168,10 @@ class TestInsertMvEntities:
 
 
 class TestCollectAncestors:
-    """Test _collect_ancestors IS_A hierarchy traversal."""
+    """Test _collect_ancestors IS_A hierarchy traversal.
+
+    Chemical r2 convention: head=parent, tail=child.
+    """
 
     def _make_entities(self, ids_and_types):
         return pd.DataFrame(
@@ -179,7 +182,7 @@ class TestCollectAncestors:
         )
 
     def test_direct_parent(self):
-        r2 = pd.DataFrame([{"head_id": "c1", "tail_id": "p1"}])
+        r2 = pd.DataFrame([{"head_id": "p1", "tail_id": "c1"}])
         entities = self._make_entities([("c1", "chemical"), ("p1", "chemical")])
         result = _collect_ancestors(r2, {"c1"}, entities)
         assert result == {"p1"}
@@ -187,8 +190,8 @@ class TestCollectAncestors:
     def test_transitive_ancestors(self):
         r2 = pd.DataFrame(
             [
-                {"head_id": "c1", "tail_id": "p1"},
-                {"head_id": "p1", "tail_id": "gp1"},
+                {"head_id": "p1", "tail_id": "c1"},
+                {"head_id": "gp1", "tail_id": "p1"},
             ]
         )
         entities = self._make_entities(
@@ -202,7 +205,7 @@ class TestCollectAncestors:
         assert result == {"p1", "gp1"}
 
     def test_ignores_non_chemical(self):
-        r2 = pd.DataFrame([{"head_id": "c1", "tail_id": "d1"}])
+        r2 = pd.DataFrame([{"head_id": "d1", "tail_id": "c1"}])
         entities = self._make_entities([("c1", "chemical"), ("d1", "disease")])
         result = _collect_ancestors(r2, {"c1"}, entities)
         assert result == set()
@@ -214,7 +217,7 @@ class TestCollectAncestors:
         assert result == set()
 
     def test_seed_not_in_hierarchy(self):
-        r2 = pd.DataFrame([{"head_id": "c2", "tail_id": "p1"}])
+        r2 = pd.DataFrame([{"head_id": "p1", "tail_id": "c2"}])
         entities = self._make_entities(
             [
                 ("c1", "chemical"),

--- a/backend/db/tests/test_materializer_correlation.py
+++ b/backend/db/tests/test_materializer_correlation.py
@@ -1,9 +1,14 @@
 """Tests for src.etl.materializer_correlation — pure helper functions."""
 
 import json
+from unittest.mock import MagicMock
 
 import pandas as pd
-from src.etl.materializer_correlation import _get_correlation_evidence
+from src.etl.materializer_correlation import (
+    _build_ancestors,
+    _get_correlation_evidence,
+    materialize_chemical_disease_correlation,
+)
 
 
 class TestGetCorrelationEvidence:
@@ -144,3 +149,177 @@ class TestGetCorrelationEvidence:
         _, evidences = _get_correlation_evidence(["att_empty"], att_data, ev_data)
         # No pmcid or pmid in reference, so ev_dict is empty and not appended
         assert evidences == []
+
+
+class TestBuildAncestors:
+    """Verify chemical r2 direction: head=parent, tail=child."""
+
+    def test_leaf_walks_up_to_ancestors(self, monkeypatch):
+        # Chemical hierarchy: gp -> p -> c (KG direction: head=parent, tail=child)
+        monkeypatch.setattr(
+            "src.etl.materializer_correlation.pd.read_sql",
+            lambda _q, _c: pd.DataFrame(
+                [("gp", "p"), ("p", "c")], columns=["head_id", "tail_id"]
+            ),
+        )
+        etype = {"gp": "chemical", "p": "chemical", "c": "chemical"}
+        ancestors_of = _build_ancestors(MagicMock(), etype)
+        assert ancestors_of["c"] == {"p", "gp"}
+        assert ancestors_of["p"] == {"gp"}
+
+    def test_non_chemical_edges_ignored(self, monkeypatch):
+        monkeypatch.setattr(
+            "src.etl.materializer_correlation.pd.read_sql",
+            lambda _q, _c: pd.DataFrame(
+                [("p", "c"), ("dparent", "dchild")],
+                columns=["head_id", "tail_id"],
+            ),
+        )
+        etype = {
+            "p": "chemical",
+            "c": "chemical",
+            "dparent": "disease",
+            "dchild": "disease",
+        }
+        ancestors_of = _build_ancestors(MagicMock(), etype)
+        assert ancestors_of.get("c") == {"p"}
+        assert "dchild" not in ancestors_of
+
+
+class TestFoodScopedInheritance:
+    """Inherited rows only fire for food-connected descendants (issue #103)."""
+
+    @staticmethod
+    def _fake_read_sql(responses: dict[str, pd.DataFrame]):
+        def reader(query, _conn):
+            sql = str(query)
+            for key, df in responses.items():
+                if key in sql:
+                    return df.copy()
+            return pd.DataFrame()
+
+        return reader
+
+    def test_non_food_descendant_does_not_propagate(self, monkeypatch):
+        # Chain: ancestor A -> direct child C. C has an r3 edge to disease D.
+        # C is NOT in r1 tails (no food), so A should see nothing inherited.
+        responses = {
+            "WHERE relationship_id IN ('r3', 'r4')": pd.DataFrame(
+                [
+                    {
+                        "head_id": "c_chem",
+                        "tail_id": "d_disease",
+                        "relationship_id": "r3",
+                        "attestation_ids": [],
+                    }
+                ]
+            ),
+            "FROM base_attestations": pd.DataFrame(
+                columns=["attestation_id", "evidence_id", "source"]
+            ),
+            "FROM base_evidence": pd.DataFrame(columns=["evidence_id", "reference"]),
+            "FROM base_entities": pd.DataFrame(
+                [
+                    {
+                        "foodatlas_id": "a_chem",
+                        "common_name": "A",
+                        "entity_type": "chemical",
+                    },
+                    {
+                        "foodatlas_id": "c_chem",
+                        "common_name": "C",
+                        "entity_type": "chemical",
+                    },
+                    {
+                        "foodatlas_id": "d_disease",
+                        "common_name": "D",
+                        "entity_type": "disease",
+                    },
+                ]
+            ),
+            # No r1 rows → food_chem_ids is empty
+            "WHERE relationship_id = 'r1'": pd.DataFrame(columns=["tail_id"]),
+            # chem r2: a_chem is parent of c_chem (chemical convention)
+            "WHERE relationship_id = 'r2'": pd.DataFrame(
+                [{"head_id": "a_chem", "tail_id": "c_chem"}]
+            ),
+        }
+        monkeypatch.setattr(
+            "src.etl.materializer_correlation.pd.read_sql",
+            self._fake_read_sql(responses),
+        )
+        captured: list[pd.DataFrame] = []
+        monkeypatch.setattr(
+            "src.etl.materializer_correlation.bulk_copy",
+            lambda _c, _t, df, _cols: captured.append(df.copy()),
+        )
+
+        materialize_chemical_disease_correlation(MagicMock())
+
+        assert captured, "expected at least one bulk_copy call"
+        df = captured[0]
+        # Only the direct row (C, C, D) should exist. No (A, C, D) row.
+        assert len(df) == 1
+        assert df.iloc[0]["chemical_foodatlas_id"] == "c_chem"
+        assert df.iloc[0]["source_chemical_foodatlas_id"] == "c_chem"
+
+    def test_food_descendant_propagates(self, monkeypatch):
+        # Same chain but C IS in r1 tails → inherited row on A should fire.
+        responses = {
+            "WHERE relationship_id IN ('r3', 'r4')": pd.DataFrame(
+                [
+                    {
+                        "head_id": "c_chem",
+                        "tail_id": "d_disease",
+                        "relationship_id": "r3",
+                        "attestation_ids": [],
+                    }
+                ]
+            ),
+            "FROM base_attestations": pd.DataFrame(
+                columns=["attestation_id", "evidence_id", "source"]
+            ),
+            "FROM base_evidence": pd.DataFrame(columns=["evidence_id", "reference"]),
+            "FROM base_entities": pd.DataFrame(
+                [
+                    {
+                        "foodatlas_id": "a_chem",
+                        "common_name": "A",
+                        "entity_type": "chemical",
+                    },
+                    {
+                        "foodatlas_id": "c_chem",
+                        "common_name": "C",
+                        "entity_type": "chemical",
+                    },
+                    {
+                        "foodatlas_id": "d_disease",
+                        "common_name": "D",
+                        "entity_type": "disease",
+                    },
+                ]
+            ),
+            # C is in r1 tail → food-connected
+            "WHERE relationship_id = 'r1'": pd.DataFrame([{"tail_id": "c_chem"}]),
+            "WHERE relationship_id = 'r2'": pd.DataFrame(
+                [{"head_id": "a_chem", "tail_id": "c_chem"}]
+            ),
+        }
+        monkeypatch.setattr(
+            "src.etl.materializer_correlation.pd.read_sql",
+            self._fake_read_sql(responses),
+        )
+        captured: list[pd.DataFrame] = []
+        monkeypatch.setattr(
+            "src.etl.materializer_correlation.bulk_copy",
+            lambda _c, _t, df, _cols: captured.append(df.copy()),
+        )
+
+        materialize_chemical_disease_correlation(MagicMock())
+
+        df = captured[0]
+        assert len(df) == 2
+        chem_ids = set(df["chemical_foodatlas_id"])
+        assert chem_ids == {"a_chem", "c_chem"}
+        # Both rows attribute to source=C
+        assert set(df["source_chemical_foodatlas_id"]) == {"c_chem"}

--- a/backend/db/tests/test_materializer_search.py
+++ b/backend/db/tests/test_materializer_search.py
@@ -1,10 +1,13 @@
 """Tests for src.etl.materializer_search — search helper functions."""
 
+from unittest.mock import MagicMock
+
 import pandas as pd
 from src.etl.materializer_search import (
     _build_exact_tokens,
     _count_scoped_r2,
     _extract_external_id_values,
+    _load_assoc_counts,
 )
 
 
@@ -94,42 +97,122 @@ class TestBuildExactTokens:
 
 
 class TestCountScopedR2:
-    """Test _count_scoped_r2 — IS_A edge counting from seeds to root."""
+    """Test _count_scoped_r2 — IS_A edge counting from seeds to root.
+
+    Edges below use the food/disease convention (head=child, tail=parent).
+    """
 
     @staticmethod
     def _make_r2(edges: list[tuple[str, str]]) -> pd.DataFrame:
         return pd.DataFrame(edges, columns=["head_id", "tail_id"])
 
+    @staticmethod
+    def _count(r2, seeds, type_ids):
+        return _count_scoped_r2(r2, seeds, type_ids, "head_id", "tail_id")
+
     def test_basic_chain(self):
         # A -> B -> C, seed={A}
         r2 = self._make_r2([("A", "B"), ("B", "C")])
-        assert _count_scoped_r2(r2, {"A"}, {"A", "B", "C"}) == 2
+        assert self._count(r2, {"A"}, {"A", "B", "C"}) == 2
 
     def test_only_reachable_edges(self):
         # A -> B -> C, D -> E (disconnected), seed={A}
         r2 = self._make_r2([("A", "B"), ("B", "C"), ("D", "E")])
-        assert _count_scoped_r2(r2, {"A"}, {"A", "B", "C", "D", "E"}) == 2
+        assert self._count(r2, {"A"}, {"A", "B", "C", "D", "E"}) == 2
 
     def test_empty_seeds(self):
         r2 = self._make_r2([("A", "B")])
-        assert _count_scoped_r2(r2, set(), {"A", "B"}) == 0
+        assert self._count(r2, set(), {"A", "B"}) == 0
 
     def test_cycle_does_not_loop(self):
         # A -> B -> A (cycle)
         r2 = self._make_r2([("A", "B"), ("B", "A")])
-        assert _count_scoped_r2(r2, {"A"}, {"A", "B"}) == 2
+        assert self._count(r2, {"A"}, {"A", "B"}) == 2
 
     def test_filters_by_type_ids(self):
         # A -> B -> C, but C not in type_ids
         r2 = self._make_r2([("A", "B"), ("B", "C")])
-        assert _count_scoped_r2(r2, {"A"}, {"A", "B"}) == 1
+        assert self._count(r2, {"A"}, {"A", "B"}) == 1
 
     def test_diamond(self):
         # A -> B, A -> C, B -> D, C -> D
         r2 = self._make_r2([("A", "B"), ("A", "C"), ("B", "D"), ("C", "D")])
-        assert _count_scoped_r2(r2, {"A"}, {"A", "B", "C", "D"}) == 4
+        assert self._count(r2, {"A"}, {"A", "B", "C", "D"}) == 4
 
     def test_multiple_seeds(self):
         # A -> C, B -> C (seeds={A, B})
         r2 = self._make_r2([("A", "C"), ("B", "C")])
-        assert _count_scoped_r2(r2, {"A", "B"}, {"A", "B", "C"}) == 2
+        assert self._count(r2, {"A", "B"}, {"A", "B", "C"}) == 2
+
+    def test_chemical_direction(self):
+        # Chemical convention: head=parent, tail=child.
+        # parent -> child edges; seed is a leaf child.
+        r2 = pd.DataFrame([("gp", "p"), ("p", "c")], columns=["head_id", "tail_id"])
+        result = _count_scoped_r2(r2, {"c"}, {"gp", "p", "c"}, "tail_id", "head_id")
+        assert result == 2
+
+
+class TestLoadAssocCounts:
+    """Test _load_assoc_counts sums row counts across composition/correlation MVs."""
+
+    @staticmethod
+    def _conn_with_results(
+        query_to_rows: dict[str, list[tuple[str, int]]],
+    ) -> MagicMock:
+        conn = MagicMock()
+
+        def fake_execute(query):
+            sql = str(query)
+            for substr, rows in query_to_rows.items():
+                if substr in sql:
+                    result = MagicMock()
+                    result.all.return_value = rows
+                    return result
+            result = MagicMock()
+            result.all.return_value = []
+            return result
+
+        conn.execute.side_effect = fake_execute
+        return conn
+
+    def test_food_counts_from_composition(self):
+        conn = self._conn_with_results(
+            {
+                "food_foodatlas_id AS fid,"
+                " COUNT(*) AS n FROM mv_food_chemical_composition"
+                " GROUP BY food_foodatlas_id": [("f1", 3), ("f2", 5)],
+            }
+        )
+        counts = _load_assoc_counts(conn)
+        assert counts["f1"] == 3
+        assert counts["f2"] == 5
+
+    def test_chemical_sums_composition_and_correlation(self):
+        conn = self._conn_with_results(
+            {
+                "chemical_foodatlas_id AS fid,"
+                " COUNT(*) AS n FROM mv_food_chemical_composition"
+                " GROUP BY chemical_foodatlas_id": [("c1", 4)],
+                "chemical_foodatlas_id AS fid,"
+                " COUNT(*) AS n FROM mv_chemical_disease_correlation"
+                " GROUP BY chemical_foodatlas_id": [("c1", 10)],
+            }
+        )
+        counts = _load_assoc_counts(conn)
+        assert counts["c1"] == 14
+
+    def test_disease_counts_from_correlation(self):
+        conn = self._conn_with_results(
+            {
+                "disease_foodatlas_id AS fid,"
+                " COUNT(*) AS n FROM mv_chemical_disease_correlation"
+                " GROUP BY disease_foodatlas_id": [("d1", 7)],
+            }
+        )
+        counts = _load_assoc_counts(conn)
+        assert counts["d1"] == 7
+
+    def test_missing_entity_returns_nothing(self):
+        conn = self._conn_with_results({})
+        counts = _load_assoc_counts(conn)
+        assert counts == {}


### PR DESCRIPTION
## Summary

Resolves #103 — peptide (and similar ChEBI ancestor classes) showed ~7k "associations" in the search bar while the health-impact tab was empty and other pages were mostly noise. Root cause turned out to be three separate bugs in the DB ETL materializers, not in the KG itself.

Also includes perf work so the full `load` goes from ~7 min to ~3 min and adds a `refresh` subcommand for iterating on materializer logic.

## Key changes

**Chemical r2 direction (the big one).** The KG stores chemical IS_A as \`head=parent, tail=child\` (explicitly documented in \`backend/api/src/repositories/taxonomy.py:6-13\`); food and disease use the opposite convention. Three materializers were hardcoding the food/disease direction, so their chemical ancestor walks always returned empty:
- \`materializer.py:_collect_ancestors\`
- \`materializer_correlation.py:_build_ancestors\`
- \`materializer_search.py:_count_scoped_r2\` (now parameterized per entity type)

This is why peptide's correlation tab was 0 despite 189 of its 14,856 ChEBI descendants carrying 2,744 disease edges — the inheritance never fired. Fix restores it to ~202 rows.

**Food-scoped correlation inheritance.** Even with the direction fix, inherited rows fired for every ChEBI descendant with a disease edge, 92.6% of which have zero food presence. Inherited rows are now gated on \`source_chem ∈ food_chem_ids\` so purely ontological descendants don't pollute ancestor pages. Direct rows remain unconditional.

**Search bar assoc_counts.** Replaced the raw-triplet-concat counter (which counted every r2 endpoint as an "association") with \`_load_assoc_counts\`, which sums row counts from the already-populated \`mv_food_chemical_composition\` and \`mv_chemical_disease_correlation\` MVs. The search count now matches exactly what the entity page will render.

**Landing-page stat** \`number of associations\` drops from ~457k → ~205k. The old value was inflated by the chemical-direction bug fanning the BFS into 197k ChEBI descendant subtrees with no food connection. 205k is the correct count under the existing docstring definition ("empirical + IS_A from seeds to root").

**Perf — composition materializer.** Replaced \`grouped.get_group()\` called 154k times with a single pure-Python \`defaultdict\` pass. Old \`_build_evidence_from_precomputed\` kept as a shim delegating to the new \`_build_evidence_from_rows\`.

**Perf — correlation materializer.** Replaced \`iterrows()\` + per-row \`.loc[]\` pandas lookups with column-zip iteration and dict-based lookups (\`.to_dict("index")\` once). Dedupe happens once per direct triplet and the JSON + sources list are reused across direct and inherited rows.

**New \`refresh\` subcommand.** \`cd backend/db && uv run main.py refresh\` re-runs \`refresh_all\` + \`refresh_search\` against the existing base tables without re-inserting parquet data. Cuts iteration from ~7 min to ~1–1.5 min when only materializer logic has changed.

## Test plan

- [ ] \`cd backend/db && uv run pytest\` — 241 tests pass, 88% coverage
- [ ] Ruff + mypy + bandit pre-commit hooks clean
- [ ] On a refreshed DB, verify peptide's chemical page: correlation tab has ~200 rows (not 0 or 2744), source chemicals are all food-connected, composition tab still shows ~156 rows
- [ ] Verify the search bar for peptide shows ~350 associations (not 7153 or 156)
- [ ] Verify landing-page "number of associations" shows ~205k
- [ ] Run \`uv run main.py refresh\` end-to-end and confirm it completes in ~1–1.5 min
- [ ] Spot-check taxonomy tree on a ChEBI parent page (e.g. peptide) is unchanged