### PR TITLE
feat(kgc): add unclassified entity diagnostic (#109)

### DIFF
--- a/backend/kgc/main.py
+++ b/backend/kgc/main.py
@@ -123,7 +123,10 @@ def diagnostics_cmd(ctx: click.Context) -> None:
     ).set_index("foodatlas_id")
     trips = pd.read_parquet(
         kg_path / "triplets.parquet",
-        columns=["head_id", "relationship_id", "tail_id"],
+        columns=["head_id", "relationship_id", "tail_id", "attestation_ids"],
+    )
+    trips["attestation_ids"] = trips["attestation_ids"].apply(
+        lambda x: json.loads(x) if isinstance(x, str) else (x or [])
     )
     diag_dir = kg_path / DIR_DIAGNOSTICS
 

--- a/backend/kgc/main.py
+++ b/backend/kgc/main.py
@@ -17,6 +17,7 @@ from src.pipeline.runner import PipelineRunner
 from src.pipeline.stages import PipelineStage
 from src.stores.schema import DIR_DIAGNOSTICS
 from src.utils.orphans import write_orphans_jsonl
+from src.utils.unclassified import write_unclassified_jsonl
 
 _STAGE_NAMES = [s.name.lower() for s in PipelineStage]
 _VALID_STAGES = _STAGE_NAMES + [str(s.value) for s in PipelineStage]
@@ -110,10 +111,10 @@ def init(ctx: click.Context) -> None:
     runner.run([PipelineStage.INGEST, PipelineStage.ENTITIES])
 
 
-@cli.command("orphans")
+@cli.command("diagnostics")
 @click.pass_context
-def orphans_cmd(ctx: click.Context) -> None:
-    """Write orphan entities from the current KG parquet to diagnostics."""
+def diagnostics_cmd(ctx: click.Context) -> None:
+    """Regenerate KGC diagnostics (orphans, unclassified) from current KG."""
     settings: KGCSettings = ctx.obj["settings"]
     kg_path = Path(settings.kg_dir)
     ents = pd.read_parquet(
@@ -121,11 +122,18 @@ def orphans_cmd(ctx: click.Context) -> None:
         columns=["foodatlas_id", "entity_type", "common_name"],
     ).set_index("foodatlas_id")
     trips = pd.read_parquet(
-        kg_path / "triplets.parquet", columns=["head_id", "tail_id"]
+        kg_path / "triplets.parquet",
+        columns=["head_id", "relationship_id", "tail_id"],
     )
-    out = kg_path / DIR_DIAGNOSTICS / "kgc_orphans.jsonl"
-    count = write_orphans_jsonl(ents, trips, out)
-    click.echo(f"Wrote {count} orphan entities to {out}")
+    diag_dir = kg_path / DIR_DIAGNOSTICS
+
+    orphans_out = diag_dir / "kgc_orphans.jsonl"
+    n_orphans = write_orphans_jsonl(ents, trips, orphans_out)
+    click.echo(f"Wrote {n_orphans} orphan entities to {orphans_out}")
+
+    unclass_out = diag_dir / "kgc_unclassified.jsonl"
+    n_unclass = write_unclassified_jsonl(ents, trips, unclass_out)
+    click.echo(f"Wrote {n_unclass} unclassified entities to {unclass_out}")
 
 
 @cli.command("diff")

--- a/backend/kgc/src/pipeline/ie/runner.py
+++ b/backend/kgc/src/pipeline/ie/runner.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from ...stores.schema import DIR_DIAGNOSTICS
 from ...utils.orphans import write_orphans_jsonl
 from ...utils.timing import log_duration
+from ...utils.unclassified import write_unclassified_jsonl
 from ..checkpoint import load_checkpoint, save_checkpoint
 from ..knowledge_graph import KnowledgeGraph
 from ..triplets.ambiguity import write_ambiguous_attestations
@@ -55,6 +56,12 @@ class IERunner:
                 kg.entities._entities, kg.triplets._triplets, out
             )
             logger.info("Wrote %d orphan entities to %s", count, out)
+        with log_duration("Write unclassified entities", logger):
+            out = kg_dir / DIR_DIAGNOSTICS / "kgc_unclassified.jsonl"
+            count = write_unclassified_jsonl(
+                kg.entities._entities, kg.triplets._triplets, out
+            )
+            logger.info("Wrote %d unclassified entities to %s", count, out)
         with log_duration("Save checkpoint (ie)", logger):
             save_checkpoint(kg_dir, "ie")
         logger.info("IE stage complete.")

--- a/backend/kgc/src/utils/unclassified.py
+++ b/backend/kgc/src/utils/unclassified.py
@@ -35,20 +35,50 @@ def find_unclassified(ents: pd.DataFrame, trips: pd.DataFrame) -> pd.DataFrame:
     return pd.concat([unclassified_chems, unclassified_foods])
 
 
+def _attestation_counts(trips: pd.DataFrame) -> dict[str, int]:
+    """Sum attestation_ids length per entity across all triplets it touches.
+
+    An entity's attestation count is the total number of attestations on
+    every triplet it appears in (as head or tail). Ontology IS_A triplets
+    have empty attestation_ids and contribute 0.
+    """
+    if "attestation_ids" not in trips.columns:
+        return {}
+    counts: dict[str, int] = {}
+    for _, row in trips.iterrows():
+        atts = row["attestation_ids"] or []
+        n = len(atts)
+        if n == 0:
+            continue
+        counts[row["head_id"]] = counts.get(row["head_id"], 0) + n
+        counts[row["tail_id"]] = counts.get(row["tail_id"], 0) + n
+    return counts
+
+
 def write_unclassified_jsonl(
     ents: pd.DataFrame,
     trips: pd.DataFrame,
     out_path: Path,
 ) -> int:
-    """Write unclassified entities to *out_path* as JSONL. Returns count."""
+    """Write unclassified entities to *out_path* as JSONL, sorted by
+    attestation count (descending). Returns count written.
+    """
     unclassified = find_unclassified(ents, trips)
+    att_counts = _attestation_counts(trips)
+
+    rows = [
+        {
+            "foodatlas_id": eid,
+            "entity_type": row.get("entity_type", ""),
+            "common_name": row.get("common_name", ""),
+            "attestation_count": att_counts.get(eid, 0),
+        }
+        for eid, row in unclassified.iterrows()
+    ]
+    rows.sort(key=lambda r: r["attestation_count"], reverse=True)
+
     out_path.parent.mkdir(parents=True, exist_ok=True)
     with out_path.open("w") as f:
-        for eid, row in unclassified.iterrows():
-            record = {
-                "foodatlas_id": eid,
-                "entity_type": row.get("entity_type", ""),
-                "common_name": row.get("common_name", ""),
-            }
+        for record in rows:
             f.write(json.dumps(record) + "\n")
-    return len(unclassified)
+    return len(rows)

--- a/backend/kgc/src/utils/unclassified.py
+++ b/backend/kgc/src/utils/unclassified.py
@@ -1,0 +1,54 @@
+"""Unclassified entity detection: foods/chemicals with no IS_A parent."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_IS_A_RELATIONSHIP = "r2"
+
+
+def find_unclassified(ents: pd.DataFrame, trips: pd.DataFrame) -> pd.DataFrame:
+    """Return food/chemical entities with no IS_A parent.
+
+    The two ontologies use opposite IS_A direction conventions:
+
+    - ChEBI (chemicals): ``head=parent, tail=child`` — a chemical has a
+      parent iff it appears as a *tail*.
+    - FoodOn (foods): ``head=child, tail=parent`` — a food has a parent
+      iff it appears as a *head*.
+    """
+    is_a = trips[trips["relationship_id"] == _IS_A_RELATIONSHIP]
+    chem_classified = set(is_a["tail_id"])
+    food_classified = set(is_a["head_id"])
+
+    chems = ents[ents["entity_type"] == "chemical"]
+    foods = ents[ents["entity_type"] == "food"]
+
+    unclassified_chems = chems[~chems.index.isin(chem_classified)]
+    unclassified_foods = foods[~foods.index.isin(food_classified)]
+    return pd.concat([unclassified_chems, unclassified_foods])
+
+
+def write_unclassified_jsonl(
+    ents: pd.DataFrame,
+    trips: pd.DataFrame,
+    out_path: Path,
+) -> int:
+    """Write unclassified entities to *out_path* as JSONL. Returns count."""
+    unclassified = find_unclassified(ents, trips)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w") as f:
+        for eid, row in unclassified.iterrows():
+            record = {
+                "foodatlas_id": eid,
+                "entity_type": row.get("entity_type", ""),
+                "common_name": row.get("common_name", ""),
+            }
+            f.write(json.dumps(record) + "\n")
+    return len(unclassified)

--- a/backend/kgc/tests/test_ie_runner.py
+++ b/backend/kgc/tests/test_ie_runner.py
@@ -116,9 +116,13 @@ class TestDiscoverIEFiles:
         assert all(m == "gpt-5.2" for m, _ in entries)
 
 
+@patch("src.pipeline.ie.runner.write_unclassified_jsonl")
+@patch("src.pipeline.ie.runner.write_orphans_jsonl")
 @patch("src.pipeline.ie.runner.KnowledgeGraph")
 def test_run_skips_expansion_when_no_ie_dir(
     mock_kg_cls: MagicMock,
+    _mock_orphans: MagicMock,
+    _mock_unclassified: MagicMock,
     settings: KGCSettings,
 ) -> None:
     kg = MagicMock()
@@ -131,6 +135,8 @@ def test_run_skips_expansion_when_no_ie_dir(
     kg.save.assert_called_once()
 
 
+@patch("src.pipeline.ie.runner.write_unclassified_jsonl")
+@patch("src.pipeline.ie.runner.write_orphans_jsonl")
 @patch("src.pipeline.ie.runner.write_unresolved_report")
 @patch("src.pipeline.ie.runner.resolve_ie_metadata")
 @patch("src.pipeline.ie.runner.load_ie_raw")
@@ -140,6 +146,8 @@ def test_ie_expansion_calls_resolver(
     mock_load_ie: MagicMock,
     mock_resolve: MagicMock,
     mock_write_report: MagicMock,
+    _mock_orphans: MagicMock,
+    _mock_unclassified: MagicMock,
     tmp_path: Path,
 ) -> None:
     ie_dir = tmp_path / "extractions"

--- a/backend/kgc/tests/test_utils_unclassified.py
+++ b/backend/kgc/tests/test_utils_unclassified.py
@@ -18,7 +18,18 @@ def _ents(rows: list[tuple[str, str, str]]) -> pd.DataFrame:
 
 
 def _trips(rows: list[tuple[str, str, str]]) -> pd.DataFrame:
-    return pd.DataFrame(rows, columns=["head_id", "relationship_id", "tail_id"])
+    df = pd.DataFrame(rows, columns=["head_id", "relationship_id", "tail_id"])
+    df["attestation_ids"] = [[] for _ in range(len(df))]
+    return df
+
+
+def _trips_with_atts(
+    rows: list[tuple[str, str, str, list[str]]],
+) -> pd.DataFrame:
+    return pd.DataFrame(
+        rows,
+        columns=["head_id", "relationship_id", "tail_id", "attestation_ids"],
+    )
 
 
 class TestFindUnclassified:
@@ -78,3 +89,36 @@ class TestWriteUnclassifiedJsonl:
         records = [json.loads(line) for line in out.read_text().splitlines()]
         ids = {r["foodatlas_id"] for r in records}
         assert ids == {"c2", "f2"}
+        # With no attestations, count is 0 for all.
+        assert all(r["attestation_count"] == 0 for r in records)
+
+    def test_sorted_by_attestation_count(self, tmp_path: Path) -> None:
+        # c1 unclassified chemical with 3 attestations (via one CONTAINS edge);
+        # c2 unclassified chemical with 1 attestation;
+        # c3 unclassified chemical with 0 attestations.
+        ents = _ents(
+            [
+                ("food1", "food", "apple"),
+                ("food2", "food", "pear"),
+                ("c1", "chemical", "x"),
+                ("c2", "chemical", "y"),
+                ("c3", "chemical", "z"),
+            ]
+        )
+        trips = _trips_with_atts(
+            [
+                ("food1", "r1", "c1", ["a1", "a2", "a3"]),
+                ("food2", "r1", "c2", ["a4"]),
+                # food classification edges so food1/food2 aren't unclassified
+                ("food1", "r2", "food_root", []),
+                ("food2", "r2", "food_root", []),
+            ]
+        )
+        out = tmp_path / "kgc_unclassified.jsonl"
+        count = write_unclassified_jsonl(ents, trips, out)
+        assert count == 3  # c1, c2, c3
+
+        records = [json.loads(line) for line in out.read_text().splitlines()]
+        # Sorted descending by attestation_count
+        assert [r["foodatlas_id"] for r in records] == ["c1", "c2", "c3"]
+        assert [r["attestation_count"] for r in records] == [3, 1, 0]

--- a/backend/kgc/tests/test_utils_unclassified.py
+++ b/backend/kgc/tests/test_utils_unclassified.py
@@ -1,0 +1,80 @@
+"""Tests for utils.unclassified — entities without IS_A parents."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pandas as pd
+from src.utils.unclassified import find_unclassified, write_unclassified_jsonl
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _ents(rows: list[tuple[str, str, str]]) -> pd.DataFrame:
+    df = pd.DataFrame(rows, columns=["foodatlas_id", "entity_type", "common_name"])
+    return df.set_index("foodatlas_id")
+
+
+def _trips(rows: list[tuple[str, str, str]]) -> pd.DataFrame:
+    return pd.DataFrame(rows, columns=["head_id", "relationship_id", "tail_id"])
+
+
+class TestFindUnclassified:
+    def test_chemical_with_parent_is_classified(self) -> None:
+        # ChEBI convention: head=parent, tail=child.
+        # c1 (child) has parent c2 -> c1 is classified, c2 is not.
+        ents = _ents([("c1", "chemical", "water"), ("c2", "chemical", "compound")])
+        trips = _trips([("c2", "r2", "c1")])
+        result = find_unclassified(ents, trips)
+        assert list(result.index) == ["c2"]
+
+    def test_food_with_parent_is_classified(self) -> None:
+        # FoodOn convention: head=child, tail=parent.
+        # f1 (child) has parent f2 -> f1 is classified, f2 is not.
+        ents = _ents([("f1", "food", "apple"), ("f2", "food", "fruit")])
+        trips = _trips([("f1", "r2", "f2")])
+        result = find_unclassified(ents, trips)
+        assert list(result.index) == ["f2"]
+
+    def test_ignores_non_food_non_chemical(self) -> None:
+        ents = _ents([("d1", "disease", "flu")])
+        trips = _trips([])
+        result = find_unclassified(ents, trips)
+        assert list(result.index) == []
+
+    def test_ignores_non_is_a_edges(self) -> None:
+        # c1 has a CONTAINS edge but no IS_A edge
+        ents = _ents([("c1", "chemical", "x")])
+        trips = _trips([("food1", "r1", "c1")])
+        result = find_unclassified(ents, trips)
+        assert list(result.index) == ["c1"]
+
+    def test_empty_triplets(self) -> None:
+        ents = _ents([("c1", "chemical", "x"), ("f1", "food", "y")])
+        trips = _trips([])
+        assert set(find_unclassified(ents, trips).index) == {"c1", "f1"}
+
+
+class TestWriteUnclassifiedJsonl:
+    def test_writes_jsonl(self, tmp_path: Path) -> None:
+        # c1 is a chemical under parent c2 (ChEBI: head=parent);
+        # f1 is a food under parent f2 (FoodOn: head=child).
+        # Unclassified: c2 (no parent) and f2 (no parent).
+        ents = _ents(
+            [
+                ("c1", "chemical", "water"),
+                ("c2", "chemical", "compound"),
+                ("f1", "food", "apple"),
+                ("f2", "food", "fruit"),
+            ]
+        )
+        trips = _trips([("c2", "r2", "c1"), ("f1", "r2", "f2")])
+        out = tmp_path / "diagnostics" / "kgc_unclassified.jsonl"
+        count = write_unclassified_jsonl(ents, trips, out)
+        assert count == 2
+
+        records = [json.loads(line) for line in out.read_text().splitlines()]
+        ids = {r["foodatlas_id"] for r in records}
+        assert ids == {"c2", "f2"}


### PR DESCRIPTION
## Summary
- Write `outputs/kg/diagnostics/kgc_unclassified.jsonl` at the end of the IE stage listing foods and chemicals that have no IS_A parent (the ones that hurt searchability because they can't be rolled up into a category).
- Account for the fact that ChEBI and FoodOn use opposite IS_A direction conventions: ChEBI stores `head=parent, tail=child`, while FoodOn stores `head=child, tail=parent`. Checking only one side (as a first pass did) flagged honey and 7k+ correctly classified foods as unclassified.
- Collapse the former `orphans` CLI command into a broader `diagnostics` command that regenerates both `kgc_orphans.jsonl` and `kgc_unclassified.jsonl` from the current KG parquet without rerunning the pipeline.

## Implementation notes
- New `src/utils/unclassified.py` with `find_unclassified` / `write_unclassified_jsonl`; splits the lookup by entity type so each convention is applied correctly.
- `IERunner.run()` writes the new file alongside `kgc_orphans.jsonl` after `kg.save()`, using in-memory stores like the ambiguous-attestations writer.
- IE runner tests patch the two writers since the KG mock doesn't provide real DataFrames.

## Verified on current KG
- orphans: 175
- unclassified: 6,222 (6,197 chemicals + 25 foods)
- honey no longer listed; the remaining 25 foods are genuine FoodOn-parentless FDC bulk entries that can be addressed separately.

Closes #109

## Test plan
- [x] `uv run pytest` (488 passing)
- [x] `uv run python main.py diagnostics` on real KG