### PR TITLE
fix: unify r2 is_a direction — head=child, tail=parent for all types

### DIFF
--- a/backend/api/src/repositories/taxonomy.py
+++ b/backend/api/src/repositories/taxonomy.py
@@ -3,14 +3,9 @@
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-# IS_A direction per entity type: (child_column, parent_column).
-# Food & Disease: head=child, tail=parent.
-# Chemical: head=parent, tail=child.
-_DIRECTION: dict[str, tuple[str, str]] = {
-    "food": ("head_id", "tail_id"),
-    "chemical": ("tail_id", "head_id"),
-    "disease": ("head_id", "tail_id"),
-}
+# All r2 triplets use natural is_a direction: head=child, tail=parent.
+_CHILD_COL = "head_id"
+_PARENT_COL = "tail_id"
 
 _MV_TABLE: dict[str, str] = {
     "food": "mv_food_entities",
@@ -35,8 +30,7 @@ async def get_taxonomy(
     if entity_id is None:
         return {"data": {"entity_id": None, "nodes": [], "edges": []}}
 
-    child_col, parent_col = _DIRECTION[entity_type]
-    sql = _build_ancestry_sql(child_col, parent_col)
+    sql = _build_ancestry_sql(_CHILD_COL, _PARENT_COL)
 
     result = await session.execute(text(sql), {"entity_id": entity_id})
     rows = [dict(r._mapping) for r in result]

--- a/backend/db/src/etl/materializer.py
+++ b/backend/db/src/etl/materializer.py
@@ -92,15 +92,13 @@ def _collect_ancestors(
 ) -> set[str]:
     """Return all chemical ancestors of seed_ids via IS_A (r2) triplets.
 
-    Chemical-chemical r2 uses head=parent, tail=child (see
-    backend/api/src/repositories/taxonomy.py), so a child's parents are the
-    head_ids of rows where it appears as tail.
+    All r2 triplets use natural direction: head=child, tail=parent.
     """
     chem_ids_all = set(entities[entities["entity_type"] == "chemical"]["foodatlas_id"])
     chem_r2 = r2[r2["head_id"].isin(chem_ids_all) & r2["tail_id"].isin(chem_ids_all)]
     parents_of: dict[str, set[str]] = {}
     for _, row in chem_r2.iterrows():
-        parents_of.setdefault(row["tail_id"], set()).add(row["head_id"])
+        parents_of.setdefault(row["head_id"], set()).add(row["tail_id"])
 
     ancestors: set[str] = set()
     for node in seed_ids:

--- a/backend/db/src/etl/materializer_correlation.py
+++ b/backend/db/src/etl/materializer_correlation.py
@@ -166,9 +166,7 @@ def _build_ancestors(
 ) -> dict[str, set[str]]:
     """Build child -> all ancestors map from chemical IS_A triplets.
 
-    Chemical-chemical r2 uses head=parent, tail=child (see
-    backend/api/src/repositories/taxonomy.py), so a child's parents are the
-    head_ids of rows where it appears as tail.
+    All r2 triplets use natural direction: head=child, tail=parent.
     """
     r2 = pd.read_sql(
         text("SELECT head_id, tail_id FROM base_triplets WHERE relationship_id = 'r2'"),
@@ -182,7 +180,7 @@ def _build_ancestors(
 
     parents_of: dict[str, set[str]] = defaultdict(set)
     for _, row in r2.iterrows():
-        parents_of[row["tail_id"]].add(row["head_id"])
+        parents_of[row["head_id"]].add(row["tail_id"])
 
     cache: dict[str, set[str]] = {}
 

--- a/backend/db/src/etl/materializer_search.py
+++ b/backend/db/src/etl/materializer_search.py
@@ -193,18 +193,11 @@ def _materialize_statistics(conn: Connection) -> None:
     scoped_r3r4 = r3r4[r3r4["head_id"].isin(chem_ids)]
     disease_ids = set(scoped_r3r4["tail_id"])
 
-    # Chemical r2 stores head=parent, tail=child; food/disease r2 stores
-    # head=child, tail=parent (see backend/api/src/repositories/taxonomy.py).
+    # All r2 triplets use natural direction: head=child, tail=parent.
     assoc_r2 = (
-        _count_scoped_r2(
-            r2, food_ids, type_map.get("food", set()), "head_id", "tail_id"
-        )
-        + _count_scoped_r2(
-            r2, chem_ids, type_map.get("chemical", set()), "tail_id", "head_id"
-        )
-        + _count_scoped_r2(
-            r2, disease_ids, type_map.get("disease", set()), "head_id", "tail_id"
-        )
+        _count_scoped_r2(r2, food_ids, type_map.get("food", set()))
+        + _count_scoped_r2(r2, chem_ids, type_map.get("chemical", set()))
+        + _count_scoped_r2(r2, disease_ids, type_map.get("disease", set()))
     )
     associations = len(r1) + len(scoped_r3r4) + assoc_r2
 
@@ -252,18 +245,15 @@ def _count_scoped_r2(
     r2: pd.DataFrame,
     seed_ids: set[str],
     type_ids: set[str],
-    child_col: str,
-    parent_col: str,
 ) -> int:
     """Count IS_A edges reachable from seed entities to root.
 
-    child_col/parent_col select the r2 direction for the entity type
-    (see backend/api/src/repositories/taxonomy.py).
+    All r2 triplets use natural direction: head=child, tail=parent.
     """
     typed_r2 = r2[r2["head_id"].isin(type_ids) & r2["tail_id"].isin(type_ids)]
     parents_of: dict[str, set[str]] = {}
     for _, row in typed_r2.iterrows():
-        parents_of.setdefault(row[child_col], set()).add(row[parent_col])
+        parents_of.setdefault(row["head_id"], set()).add(row["tail_id"])
 
     reachable = set(seed_ids)
     stack = list(seed_ids)

--- a/backend/db/tests/test_materialize_statistics.py
+++ b/backend/db/tests/test_materialize_statistics.py
@@ -5,18 +5,17 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 from src.etl.materializer_search import _materialize_statistics
 
-# Minimal triplets: food→chem (r1), chem IS_A chem (r2), chem→disease (r3)
-# Chemical r2 direction: head=parent, tail=child.
-# Food/disease r2 direction: head=child, tail=parent.
+# Minimal triplets: food→chem (r1), chem IS_A chem (r2), chem→disease (r3).
+# All r2 triplets use natural direction: head=child, tail=parent.
 _TRIPLETS = pd.DataFrame(
     {
-        "head_id": ["f1", "f1", "c3", "c1", "c2", "d1"],
-        "tail_id": ["c1", "c2", "c1", "d1", "d2", "d3"],
+        "head_id": ["f1", "f1", "c1", "c1", "c2", "d1"],
+        "tail_id": ["c1", "c2", "c3", "d1", "d2", "d3"],
         "relationship_id": ["r1", "r1", "r2", "r3", "r3", "r2"],
     }
 )
-# c1/c2 are r1 tails (food-connected). c1's chemical parent is c3 (r2 head=c3).
-# d1's disease parent is d3 (r2 head=d1). Scoped r3/r4: c1→d1 and c2→d2.
+# c1/c2 are r1 tails (food-connected). c1's chemical parent is c3 (r2 c1→c3).
+# d1's disease parent is d3 (r2 d1→d3). Scoped r3/r4: c1→d1 and c2→d2.
 
 _ENTITIES = pd.DataFrame(
     {

--- a/backend/db/tests/test_materializer.py
+++ b/backend/db/tests/test_materializer.py
@@ -170,7 +170,7 @@ class TestInsertMvEntities:
 class TestCollectAncestors:
     """Test _collect_ancestors IS_A hierarchy traversal.
 
-    Chemical r2 convention: head=parent, tail=child.
+    All r2 triplets use natural direction: head=child, tail=parent.
     """
 
     def _make_entities(self, ids_and_types):
@@ -182,7 +182,7 @@ class TestCollectAncestors:
         )
 
     def test_direct_parent(self):
-        r2 = pd.DataFrame([{"head_id": "p1", "tail_id": "c1"}])
+        r2 = pd.DataFrame([{"head_id": "c1", "tail_id": "p1"}])
         entities = self._make_entities([("c1", "chemical"), ("p1", "chemical")])
         result = _collect_ancestors(r2, {"c1"}, entities)
         assert result == {"p1"}
@@ -190,8 +190,8 @@ class TestCollectAncestors:
     def test_transitive_ancestors(self):
         r2 = pd.DataFrame(
             [
-                {"head_id": "p1", "tail_id": "c1"},
-                {"head_id": "gp1", "tail_id": "p1"},
+                {"head_id": "c1", "tail_id": "p1"},
+                {"head_id": "p1", "tail_id": "gp1"},
             ]
         )
         entities = self._make_entities(
@@ -205,7 +205,7 @@ class TestCollectAncestors:
         assert result == {"p1", "gp1"}
 
     def test_ignores_non_chemical(self):
-        r2 = pd.DataFrame([{"head_id": "d1", "tail_id": "c1"}])
+        r2 = pd.DataFrame([{"head_id": "c1", "tail_id": "d1"}])
         entities = self._make_entities([("c1", "chemical"), ("d1", "disease")])
         result = _collect_ancestors(r2, {"c1"}, entities)
         assert result == set()
@@ -217,7 +217,7 @@ class TestCollectAncestors:
         assert result == set()
 
     def test_seed_not_in_hierarchy(self):
-        r2 = pd.DataFrame([{"head_id": "p1", "tail_id": "c2"}])
+        r2 = pd.DataFrame([{"head_id": "c2", "tail_id": "p1"}])
         entities = self._make_entities(
             [
                 ("c1", "chemical"),

--- a/backend/db/tests/test_materializer_correlation.py
+++ b/backend/db/tests/test_materializer_correlation.py
@@ -152,14 +152,14 @@ class TestGetCorrelationEvidence:
 
 
 class TestBuildAncestors:
-    """Verify chemical r2 direction: head=parent, tail=child."""
+    """Verify r2 direction: head=child, tail=parent (natural)."""
 
     def test_leaf_walks_up_to_ancestors(self, monkeypatch):
-        # Chemical hierarchy: gp -> p -> c (KG direction: head=parent, tail=child)
+        # Chain: c is_a p is_a gp. Natural direction: head=child, tail=parent.
         monkeypatch.setattr(
             "src.etl.materializer_correlation.pd.read_sql",
             lambda _q, _c: pd.DataFrame(
-                [("gp", "p"), ("p", "c")], columns=["head_id", "tail_id"]
+                [("c", "p"), ("p", "gp")], columns=["head_id", "tail_id"]
             ),
         )
         etype = {"gp": "chemical", "p": "chemical", "c": "chemical"}
@@ -168,10 +168,11 @@ class TestBuildAncestors:
         assert ancestors_of["p"] == {"gp"}
 
     def test_non_chemical_edges_ignored(self, monkeypatch):
+        # Natural direction: head=child, tail=parent.
         monkeypatch.setattr(
             "src.etl.materializer_correlation.pd.read_sql",
             lambda _q, _c: pd.DataFrame(
-                [("p", "c"), ("dparent", "dchild")],
+                [("c", "p"), ("dchild", "dparent")],
                 columns=["head_id", "tail_id"],
             ),
         )
@@ -239,9 +240,9 @@ class TestFoodScopedInheritance:
             ),
             # No r1 rows → food_chem_ids is empty
             "WHERE relationship_id = 'r1'": pd.DataFrame(columns=["tail_id"]),
-            # chem r2: a_chem is parent of c_chem (chemical convention)
+            # Natural r2: c_chem is_a a_chem (head=child, tail=parent).
             "WHERE relationship_id = 'r2'": pd.DataFrame(
-                [{"head_id": "a_chem", "tail_id": "c_chem"}]
+                [{"head_id": "c_chem", "tail_id": "a_chem"}]
             ),
         }
         monkeypatch.setattr(
@@ -301,8 +302,9 @@ class TestFoodScopedInheritance:
             ),
             # C is in r1 tail → food-connected
             "WHERE relationship_id = 'r1'": pd.DataFrame([{"tail_id": "c_chem"}]),
+            # Natural r2: c_chem is_a a_chem (head=child, tail=parent).
             "WHERE relationship_id = 'r2'": pd.DataFrame(
-                [{"head_id": "a_chem", "tail_id": "c_chem"}]
+                [{"head_id": "c_chem", "tail_id": "a_chem"}]
             ),
         }
         monkeypatch.setattr(

--- a/backend/db/tests/test_materializer_search.py
+++ b/backend/db/tests/test_materializer_search.py
@@ -99,7 +99,7 @@ class TestBuildExactTokens:
 class TestCountScopedR2:
     """Test _count_scoped_r2 — IS_A edge counting from seeds to root.
 
-    Edges below use the food/disease convention (head=child, tail=parent).
+    All r2 triplets use natural direction: head=child, tail=parent.
     """
 
     @staticmethod
@@ -108,7 +108,7 @@ class TestCountScopedR2:
 
     @staticmethod
     def _count(r2, seeds, type_ids):
-        return _count_scoped_r2(r2, seeds, type_ids, "head_id", "tail_id")
+        return _count_scoped_r2(r2, seeds, type_ids)
 
     def test_basic_chain(self):
         # A -> B -> C, seed={A}
@@ -143,13 +143,6 @@ class TestCountScopedR2:
         # A -> C, B -> C (seeds={A, B})
         r2 = self._make_r2([("A", "C"), ("B", "C")])
         assert self._count(r2, {"A", "B"}, {"A", "B", "C"}) == 2
-
-    def test_chemical_direction(self):
-        # Chemical convention: head=parent, tail=child.
-        # parent -> child edges; seed is a leaf child.
-        r2 = pd.DataFrame([("gp", "p"), ("p", "c")], columns=["head_id", "tail_id"])
-        result = _count_scoped_r2(r2, {"c"}, {"gp", "p", "c"}, "tail_id", "head_id")
-        assert result == 2
 
 
 class TestLoadAssocCounts:

--- a/backend/kgc/src/pipeline/enrichment/classification.py
+++ b/backend/kgc/src/pipeline/enrichment/classification.py
@@ -91,14 +91,14 @@ def _build_parent_child_map(
 ) -> dict[str, set[str]]:
     """Build parent -> children mapping from IS_A triplets.
 
-    In the KG, IS_A triplets are stored as ``head=parent, tail=child``.
+    IS_A triplets use natural direction: ``head=child, tail=parent``.
     """
     is_a = triplets[triplets["relationship_id"] == _IS_A_RELATIONSHIP]
     is_a_cc = is_a[is_a["head_id"].isin(chem_ids) & is_a["tail_id"].isin(chem_ids)]
 
     parent_to_children: dict[str, set[str]] = {}
     for _, row in is_a_cc.iterrows():
-        parent_to_children.setdefault(row["head_id"], set()).add(row["tail_id"])
+        parent_to_children.setdefault(row["tail_id"], set()).add(row["head_id"])
     return parent_to_children
 
 

--- a/backend/kgc/src/pipeline/enrichment/food_classification.py
+++ b/backend/kgc/src/pipeline/enrichment/food_classification.py
@@ -5,9 +5,7 @@ whether it is a descendant of curated FoodOn anchor nodes.  Multi-label:
 a single food can belong to multiple categories (e.g. a fruit juice is
 both "botanical fruit food product" and "plant derived beverage").
 
-Note: FoodOn IS_A direction is head=child, tail=parent — the inverse of
-the chemical (ChEBI) convention.  ``_build_parent_child_map`` accounts
-for this by mapping tail -> head.
+All r2 triplets use natural direction: ``head=child, tail=parent``.
 """
 
 from __future__ import annotations

--- a/backend/kgc/src/pipeline/triplets/chemical_chemical/chebi.py
+++ b/backend/kgc/src/pipeline/triplets/chemical_chemical/chebi.py
@@ -38,16 +38,18 @@ def merge_chemical_ontology(
     if lookup.empty:
         return
 
-    # ChEBI is_a semantics: head is_a tail → reversed in KG (head=parent).
+    # Natural is_a direction (matches FoodOn): head=child, tail=parent.
+    # Phase-1 ChEBI edges already use this direction after the adapter
+    # translates ChEBI's raw INIT=parent/FINAL=child convention.
     df = is_a.merge(
-        lookup, left_on="tail_native_id", right_on="native_id", how="inner"
+        lookup, left_on="head_native_id", right_on="native_id", how="inner"
     ).drop(columns=["native_id"])
     df = df.rename(
         columns={"foodatlas_id": "_head_id", "candidates": "head_candidates"}
     )
 
     df = df.merge(
-        lookup, left_on="head_native_id", right_on="native_id", how="inner"
+        lookup, left_on="tail_native_id", right_on="native_id", how="inner"
     ).drop(columns=["native_id"])
     df = df.rename(
         columns={"foodatlas_id": "_tail_id", "candidates": "tail_candidates"}
@@ -61,8 +63,8 @@ def merge_chemical_ontology(
     df["source_type"] = _SOURCE
     df["reference"] = ref
     df["source"] = _SOURCE
-    df["head_name_raw"] = df["tail_native_id"].astype(str)
-    df["tail_name_raw"] = df["head_native_id"].astype(str)
+    df["head_name_raw"] = df["head_native_id"].astype(str)
+    df["tail_name_raw"] = df["tail_native_id"].astype(str)
 
     ev_result = kg.evidence.create(df[["source_type", "reference"]])
     df["evidence_id"] = ev_result.index

--- a/backend/kgc/src/utils/unclassified.py
+++ b/backend/kgc/src/utils/unclassified.py
@@ -16,22 +16,17 @@ _IS_A_RELATIONSHIP = "r2"
 def find_unclassified(ents: pd.DataFrame, trips: pd.DataFrame) -> pd.DataFrame:
     """Return food/chemical entities with no IS_A parent.
 
-    The two ontologies use opposite IS_A direction conventions:
-
-    - ChEBI (chemicals): ``head=parent, tail=child`` — a chemical has a
-      parent iff it appears as a *tail*.
-    - FoodOn (foods): ``head=child, tail=parent`` — a food has a parent
-      iff it appears as a *head*.
+    All is_a triplets use natural direction: ``head=child, tail=parent``.
+    An entity has a parent iff it appears as a ``head_id``.
     """
     is_a = trips[trips["relationship_id"] == _IS_A_RELATIONSHIP]
-    chem_classified = set(is_a["tail_id"])
-    food_classified = set(is_a["head_id"])
+    classified = set(is_a["head_id"])
 
     chems = ents[ents["entity_type"] == "chemical"]
     foods = ents[ents["entity_type"] == "food"]
 
-    unclassified_chems = chems[~chems.index.isin(chem_classified)]
-    unclassified_foods = foods[~foods.index.isin(food_classified)]
+    unclassified_chems = chems[~chems.index.isin(classified)]
+    unclassified_foods = foods[~foods.index.isin(classified)]
     return pd.concat([unclassified_chems, unclassified_foods])
 
 

--- a/backend/kgc/tests/test_classification.py
+++ b/backend/kgc/tests/test_classification.py
@@ -26,10 +26,11 @@ def _get_groups(entities: pd.DataFrame, eid: str) -> list[str]:
 
 class TestBuildParentChildMap:
     def test_builds_map(self) -> None:
+        # Natural is_a: head=child, tail=parent. e2 and e3 are children of e1.
         triplets = pd.DataFrame(
             [
-                {IC: "t0", "head_id": "e1", "tail_id": "e2", "relationship_id": "r2"},
-                {IC: "t1", "head_id": "e1", "tail_id": "e3", "relationship_id": "r2"},
+                {IC: "t0", "head_id": "e2", "tail_id": "e1", "relationship_id": "r2"},
+                {IC: "t1", "head_id": "e3", "tail_id": "e1", "relationship_id": "r2"},
                 {IC: "t2", "head_id": "e4", "tail_id": "e5", "relationship_id": "r1"},
             ]
         ).set_index(IC)
@@ -37,6 +38,7 @@ class TestBuildParentChildMap:
         assert result == {"e1": {"e2", "e3"}}
 
     def test_filters_to_chem_ids(self) -> None:
+        # Natural is_a: head=child, tail=parent. e1 is a child of e2.
         triplets = pd.DataFrame(
             [
                 {IC: "t0", "head_id": "e1", "tail_id": "e2", "relationship_id": "r2"},
@@ -129,18 +131,19 @@ class TestClassifyChemicals:
             ]
         ).set_index(IC)
 
+        # Natural is_a: head=child, tail=parent.
         triplets = pd.DataFrame(
             [
                 {
                     IC: "t0",
-                    "head_id": "e65128",
-                    "tail_id": "child1",
+                    "head_id": "child1",
+                    "tail_id": "e65128",
                     "relationship_id": "r2",
                 },
                 {
                     IC: "t1",
-                    "head_id": "e12451",
-                    "tail_id": "child2",
+                    "head_id": "child2",
+                    "tail_id": "e12451",
                     "relationship_id": "r2",
                 },
             ]
@@ -198,18 +201,20 @@ class TestClassifyChemicals:
             ]
         ).set_index(IC)
 
+        # Natural is_a: head=child, tail=parent.
+        # leaf is_a tannin (e13486); tannin is_a polyphenol (e12163).
         triplets = pd.DataFrame(
             [
                 {
                     IC: "t0",
-                    "head_id": "e12163",
-                    "tail_id": "e13486",
+                    "head_id": "e13486",
+                    "tail_id": "e12163",
                     "relationship_id": "r2",
                 },
                 {
                     IC: "t1",
-                    "head_id": "e13486",
-                    "tail_id": "leaf",
+                    "head_id": "leaf",
+                    "tail_id": "e13486",
                     "relationship_id": "r2",
                 },
             ]

--- a/backend/kgc/tests/test_utils_unclassified.py
+++ b/backend/kgc/tests/test_utils_unclassified.py
@@ -34,15 +34,15 @@ def _trips_with_atts(
 
 class TestFindUnclassified:
     def test_chemical_with_parent_is_classified(self) -> None:
-        # ChEBI convention: head=parent, tail=child.
+        # Natural is_a: head=child, tail=parent.
         # c1 (child) has parent c2 -> c1 is classified, c2 is not.
         ents = _ents([("c1", "chemical", "water"), ("c2", "chemical", "compound")])
-        trips = _trips([("c2", "r2", "c1")])
+        trips = _trips([("c1", "r2", "c2")])
         result = find_unclassified(ents, trips)
         assert list(result.index) == ["c2"]
 
     def test_food_with_parent_is_classified(self) -> None:
-        # FoodOn convention: head=child, tail=parent.
+        # Natural is_a: head=child, tail=parent.
         # f1 (child) has parent f2 -> f1 is classified, f2 is not.
         ents = _ents([("f1", "food", "apple"), ("f2", "food", "fruit")])
         trips = _trips([("f1", "r2", "f2")])
@@ -70,8 +70,8 @@ class TestFindUnclassified:
 
 class TestWriteUnclassifiedJsonl:
     def test_writes_jsonl(self, tmp_path: Path) -> None:
-        # c1 is a chemical under parent c2 (ChEBI: head=parent);
-        # f1 is a food under parent f2 (FoodOn: head=child).
+        # Natural is_a (head=child, tail=parent) for both chemicals and foods.
+        # c1 is a chemical under parent c2; f1 is a food under parent f2.
         # Unclassified: c2 (no parent) and f2 (no parent).
         ents = _ents(
             [
@@ -81,7 +81,7 @@ class TestWriteUnclassifiedJsonl:
                 ("f2", "food", "fruit"),
             ]
         )
-        trips = _trips([("c2", "r2", "c1"), ("f1", "r2", "f2")])
+        trips = _trips([("c1", "r2", "c2"), ("f1", "r2", "f2")])
         out = tmp_path / "diagnostics" / "kgc_unclassified.jsonl"
         count = write_unclassified_jsonl(ents, trips, out)
         assert count == 2


### PR DESCRIPTION
## Summary

Every r2 is_a triplet in the KG now uses **natural direction** (`head=child, tail=parent`), matching FoodOn's existing convention. Previously, chemical r2 triplets were stored reversed (`head=parent, tail=child`) due to a redundant flip in `merge_chemical_ontology`, which has been causing downstream bugs and compensation logic.

## Root cause

- **Mar 30 (`419b934`)** — The ChEBI adapter was fixed to translate ChEBI's raw SQL dump convention (`INIT_ID=parent, FINAL_ID=child`) into standard natural is_a direction (`head=child, tail=parent`) at ingest time. Commit message: *"Fix ChEBI edge direction so subtree filter correctly finds 193K molecular entities instead of 2"*.
- **Apr 3 (`05cc6b0`)** — The pipeline refactor introduced the current `merge_chemical_ontology` with a comment `"ChEBI is_a semantics: head is_a tail → reversed in KG (head=parent)"`. This added a **second flip** that undid the adapter's work at the KG table level, leaving the KG with reversed chemical r2 while food/disease r2 stayed natural.
- **Apr 14 (`9b58986`)** — Fixed inflated peptide association counts (#103) by teaching three DB materializers about the reversed convention, rather than fixing the root cause in the merger. Added explicit `# Chemical r2 stores head=parent, tail=child` comments across the materializers.
- **Apr 14 (`d343d17`)** — The unclassified diagnostic was added with the same biconvention baked in: `chem_classified = set(tail_id)` vs `food_classified = set(head_id)`.

All compensation code was written in the last 11 days. This PR removes both the redundant flip and the compensations.

## Changes

### Swapper (delete the reversal)

- `backend/kgc/src/pipeline/triplets/chemical_chemical/chebi.py` — remove the head/tail swap in `merge_chemical_ontology`; Phase-1 edges flow through unchanged.

### Readers (unify with food/disease)

- `backend/kgc/src/utils/unclassified.py` — one unified `classified = set(head_id)` for chemicals and foods.
- `backend/kgc/src/pipeline/enrichment/classification.py` — `parent_to_children` now reads `tail_id → head_id`.
- `backend/kgc/src/pipeline/enrichment/food_classification.py` — docstring cleanup (logic already natural).
- `backend/api/src/repositories/taxonomy.py` — `_DIRECTION` dict deleted; single `_CHILD_COL="head_id"`, `_PARENT_COL="tail_id"` used for all entity types.
- `backend/db/src/etl/materializer.py` / `materializer_search.py` / `materializer_correlation.py` — all `parents_of[head_id].add(tail_id)`. `_count_scoped_r2` signature simplified (dropped `child_col`/`parent_col` parameters).

### Tests

- 6 test files updated to use natural direction fixture triplets. All 798 tests pass across the three backends (489 kgc + 240 db + 69 api).

## Post-merge deployment

Requires re-running the KGC pipeline from stage 2 onward and reloading the DB:

\`\`\`
cd backend/kgc
uv run python main.py run --stages 2:4

cd ../db
uv run python main.py load
\`\`\`

No re-ingest or re-resolve needed — Phase-1 parquet and entity resolution outputs are unchanged.

## Verification

After regenerating the KG, confirm glycine's r2 edges show the expected directions:

- **as head** (glycine → X): parents should appear — \`amino acid\`, \`alpha-amino acid\`, etc.
- **as tail** (X → glycine): children should appear — \`glycine-d5\`, \`glycine-13c2,15n\`, etc.

Statistics counts should match post-#106 values (both the bug and its compensation are gone, so the results cancel cleanly).

## Test plan

- [ ] Run \`uv run pytest\` in backend/kgc, backend/db, backend/api — all green (verified locally: 798 tests)
- [ ] Re-run KGC stages 2:4 on real data
- [ ] Reload DB via \`uv run python main.py load\`
- [ ] Verify glycine r2 direction in triplets.parquet
- [ ] Spot-check entity taxonomy pages in the frontend render correctly
- [ ] Confirm statistics endpoint shows same association counts as pre-merge