### PR TITLE
feat(kgc): classify DMD peptides and CDNO vitamins (#63)

### DIFF
--- a/backend/api/src/repositories/taxonomy.py
+++ b/backend/api/src/repositories/taxonomy.py
@@ -3,14 +3,9 @@
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-# IS_A direction per entity type: (child_column, parent_column).
-# Food & Disease: head=child, tail=parent.
-# Chemical: head=parent, tail=child.
-_DIRECTION: dict[str, tuple[str, str]] = {
-    "food": ("head_id", "tail_id"),
-    "chemical": ("tail_id", "head_id"),
-    "disease": ("head_id", "tail_id"),
-}
+# All r2 triplets use natural is_a direction: head=child, tail=parent.
+_CHILD_COL = "head_id"
+_PARENT_COL = "tail_id"
 
 _MV_TABLE: dict[str, str] = {
     "food": "mv_food_entities",
@@ -35,8 +30,7 @@ async def get_taxonomy(
     if entity_id is None:
         return {"data": {"entity_id": None, "nodes": [], "edges": []}}
 
-    child_col, parent_col = _DIRECTION[entity_type]
-    sql = _build_ancestry_sql(child_col, parent_col)
+    sql = _build_ancestry_sql(_CHILD_COL, _PARENT_COL)
 
     result = await session.execute(text(sql), {"entity_id": entity_id})
     rows = [dict(r._mapping) for r in result]

--- a/backend/db/src/etl/materializer.py
+++ b/backend/db/src/etl/materializer.py
@@ -92,15 +92,13 @@ def _collect_ancestors(
 ) -> set[str]:
     """Return all chemical ancestors of seed_ids via IS_A (r2) triplets.
 
-    Chemical-chemical r2 uses head=parent, tail=child (see
-    backend/api/src/repositories/taxonomy.py), so a child's parents are the
-    head_ids of rows where it appears as tail.
+    All r2 triplets use natural direction: head=child, tail=parent.
     """
     chem_ids_all = set(entities[entities["entity_type"] == "chemical"]["foodatlas_id"])
     chem_r2 = r2[r2["head_id"].isin(chem_ids_all) & r2["tail_id"].isin(chem_ids_all)]
     parents_of: dict[str, set[str]] = {}
     for _, row in chem_r2.iterrows():
-        parents_of.setdefault(row["tail_id"], set()).add(row["head_id"])
+        parents_of.setdefault(row["head_id"], set()).add(row["tail_id"])
 
     ancestors: set[str] = set()
     for node in seed_ids:

--- a/backend/db/src/etl/materializer_correlation.py
+++ b/backend/db/src/etl/materializer_correlation.py
@@ -166,9 +166,7 @@ def _build_ancestors(
 ) -> dict[str, set[str]]:
     """Build child -> all ancestors map from chemical IS_A triplets.
 
-    Chemical-chemical r2 uses head=parent, tail=child (see
-    backend/api/src/repositories/taxonomy.py), so a child's parents are the
-    head_ids of rows where it appears as tail.
+    All r2 triplets use natural direction: head=child, tail=parent.
     """
     r2 = pd.read_sql(
         text("SELECT head_id, tail_id FROM base_triplets WHERE relationship_id = 'r2'"),
@@ -182,7 +180,7 @@ def _build_ancestors(
 
     parents_of: dict[str, set[str]] = defaultdict(set)
     for _, row in r2.iterrows():
-        parents_of[row["tail_id"]].add(row["head_id"])
+        parents_of[row["head_id"]].add(row["tail_id"])
 
     cache: dict[str, set[str]] = {}
 

--- a/backend/db/src/etl/materializer_search.py
+++ b/backend/db/src/etl/materializer_search.py
@@ -157,6 +157,8 @@ def _build_exact_tokens(
 ) -> list[str]:
     """Build exact-match search tokens for an entity.
 
+    Tokens are lowercased because the search repository lowercases the
+    query term before matching against ``substr_auto``/``exact_auto``.
     Synonyms longer than ``_MAX_TOKEN_LEN`` (e.g. amino acid sequences)
     are excluded to stay within the GIN index page-size limit.
     """
@@ -165,7 +167,7 @@ def _build_exact_tokens(
         tokens.append(scientific_name)
     tokens.extend(s for s in synonyms if len(s) <= _MAX_TOKEN_LEN)
     tokens.extend(ext_id_values)
-    return [str(t) for t in tokens]
+    return [str(t).lower() for t in tokens]
 
 
 def _materialize_statistics(conn: Connection) -> None:

--- a/backend/db/src/etl/materializer_search.py
+++ b/backend/db/src/etl/materializer_search.py
@@ -193,18 +193,11 @@ def _materialize_statistics(conn: Connection) -> None:
     scoped_r3r4 = r3r4[r3r4["head_id"].isin(chem_ids)]
     disease_ids = set(scoped_r3r4["tail_id"])
 
-    # Chemical r2 stores head=parent, tail=child; food/disease r2 stores
-    # head=child, tail=parent (see backend/api/src/repositories/taxonomy.py).
+    # All r2 triplets use natural direction: head=child, tail=parent.
     assoc_r2 = (
-        _count_scoped_r2(
-            r2, food_ids, type_map.get("food", set()), "head_id", "tail_id"
-        )
-        + _count_scoped_r2(
-            r2, chem_ids, type_map.get("chemical", set()), "tail_id", "head_id"
-        )
-        + _count_scoped_r2(
-            r2, disease_ids, type_map.get("disease", set()), "head_id", "tail_id"
-        )
+        _count_scoped_r2(r2, food_ids, type_map.get("food", set()))
+        + _count_scoped_r2(r2, chem_ids, type_map.get("chemical", set()))
+        + _count_scoped_r2(r2, disease_ids, type_map.get("disease", set()))
     )
     associations = len(r1) + len(scoped_r3r4) + assoc_r2
 
@@ -252,18 +245,15 @@ def _count_scoped_r2(
     r2: pd.DataFrame,
     seed_ids: set[str],
     type_ids: set[str],
-    child_col: str,
-    parent_col: str,
 ) -> int:
     """Count IS_A edges reachable from seed entities to root.
 
-    child_col/parent_col select the r2 direction for the entity type
-    (see backend/api/src/repositories/taxonomy.py).
+    All r2 triplets use natural direction: head=child, tail=parent.
     """
     typed_r2 = r2[r2["head_id"].isin(type_ids) & r2["tail_id"].isin(type_ids)]
     parents_of: dict[str, set[str]] = {}
     for _, row in typed_r2.iterrows():
-        parents_of.setdefault(row[child_col], set()).add(row[parent_col])
+        parents_of.setdefault(row["head_id"], set()).add(row["tail_id"])
 
     reachable = set(seed_ids)
     stack = list(seed_ids)

--- a/backend/db/tests/test_materialize_statistics.py
+++ b/backend/db/tests/test_materialize_statistics.py
@@ -5,18 +5,17 @@ from unittest.mock import MagicMock, patch
 import pandas as pd
 from src.etl.materializer_search import _materialize_statistics
 
-# Minimal triplets: food→chem (r1), chem IS_A chem (r2), chem→disease (r3)
-# Chemical r2 direction: head=parent, tail=child.
-# Food/disease r2 direction: head=child, tail=parent.
+# Minimal triplets: food→chem (r1), chem IS_A chem (r2), chem→disease (r3).
+# All r2 triplets use natural direction: head=child, tail=parent.
 _TRIPLETS = pd.DataFrame(
     {
-        "head_id": ["f1", "f1", "c3", "c1", "c2", "d1"],
-        "tail_id": ["c1", "c2", "c1", "d1", "d2", "d3"],
+        "head_id": ["f1", "f1", "c1", "c1", "c2", "d1"],
+        "tail_id": ["c1", "c2", "c3", "d1", "d2", "d3"],
         "relationship_id": ["r1", "r1", "r2", "r3", "r3", "r2"],
     }
 )
-# c1/c2 are r1 tails (food-connected). c1's chemical parent is c3 (r2 head=c3).
-# d1's disease parent is d3 (r2 head=d1). Scoped r3/r4: c1→d1 and c2→d2.
+# c1/c2 are r1 tails (food-connected). c1's chemical parent is c3 (r2 c1→c3).
+# d1's disease parent is d3 (r2 d1→d3). Scoped r3/r4: c1→d1 and c2→d2.
 
 _ENTITIES = pd.DataFrame(
     {

--- a/backend/db/tests/test_materializer.py
+++ b/backend/db/tests/test_materializer.py
@@ -170,7 +170,7 @@ class TestInsertMvEntities:
 class TestCollectAncestors:
     """Test _collect_ancestors IS_A hierarchy traversal.
 
-    Chemical r2 convention: head=parent, tail=child.
+    All r2 triplets use natural direction: head=child, tail=parent.
     """
 
     def _make_entities(self, ids_and_types):
@@ -182,7 +182,7 @@ class TestCollectAncestors:
         )
 
     def test_direct_parent(self):
-        r2 = pd.DataFrame([{"head_id": "p1", "tail_id": "c1"}])
+        r2 = pd.DataFrame([{"head_id": "c1", "tail_id": "p1"}])
         entities = self._make_entities([("c1", "chemical"), ("p1", "chemical")])
         result = _collect_ancestors(r2, {"c1"}, entities)
         assert result == {"p1"}
@@ -190,8 +190,8 @@ class TestCollectAncestors:
     def test_transitive_ancestors(self):
         r2 = pd.DataFrame(
             [
-                {"head_id": "p1", "tail_id": "c1"},
-                {"head_id": "gp1", "tail_id": "p1"},
+                {"head_id": "c1", "tail_id": "p1"},
+                {"head_id": "p1", "tail_id": "gp1"},
             ]
         )
         entities = self._make_entities(
@@ -205,7 +205,7 @@ class TestCollectAncestors:
         assert result == {"p1", "gp1"}
 
     def test_ignores_non_chemical(self):
-        r2 = pd.DataFrame([{"head_id": "d1", "tail_id": "c1"}])
+        r2 = pd.DataFrame([{"head_id": "c1", "tail_id": "d1"}])
         entities = self._make_entities([("c1", "chemical"), ("d1", "disease")])
         result = _collect_ancestors(r2, {"c1"}, entities)
         assert result == set()
@@ -217,7 +217,7 @@ class TestCollectAncestors:
         assert result == set()
 
     def test_seed_not_in_hierarchy(self):
-        r2 = pd.DataFrame([{"head_id": "p1", "tail_id": "c2"}])
+        r2 = pd.DataFrame([{"head_id": "c2", "tail_id": "p1"}])
         entities = self._make_entities(
             [
                 ("c1", "chemical"),

--- a/backend/db/tests/test_materializer_correlation.py
+++ b/backend/db/tests/test_materializer_correlation.py
@@ -152,14 +152,14 @@ class TestGetCorrelationEvidence:
 
 
 class TestBuildAncestors:
-    """Verify chemical r2 direction: head=parent, tail=child."""
+    """Verify r2 direction: head=child, tail=parent (natural)."""
 
     def test_leaf_walks_up_to_ancestors(self, monkeypatch):
-        # Chemical hierarchy: gp -> p -> c (KG direction: head=parent, tail=child)
+        # Chain: c is_a p is_a gp. Natural direction: head=child, tail=parent.
         monkeypatch.setattr(
             "src.etl.materializer_correlation.pd.read_sql",
             lambda _q, _c: pd.DataFrame(
-                [("gp", "p"), ("p", "c")], columns=["head_id", "tail_id"]
+                [("c", "p"), ("p", "gp")], columns=["head_id", "tail_id"]
             ),
         )
         etype = {"gp": "chemical", "p": "chemical", "c": "chemical"}
@@ -168,10 +168,11 @@ class TestBuildAncestors:
         assert ancestors_of["p"] == {"gp"}
 
     def test_non_chemical_edges_ignored(self, monkeypatch):
+        # Natural direction: head=child, tail=parent.
         monkeypatch.setattr(
             "src.etl.materializer_correlation.pd.read_sql",
             lambda _q, _c: pd.DataFrame(
-                [("p", "c"), ("dparent", "dchild")],
+                [("c", "p"), ("dchild", "dparent")],
                 columns=["head_id", "tail_id"],
             ),
         )
@@ -239,9 +240,9 @@ class TestFoodScopedInheritance:
             ),
             # No r1 rows → food_chem_ids is empty
             "WHERE relationship_id = 'r1'": pd.DataFrame(columns=["tail_id"]),
-            # chem r2: a_chem is parent of c_chem (chemical convention)
+            # Natural r2: c_chem is_a a_chem (head=child, tail=parent).
             "WHERE relationship_id = 'r2'": pd.DataFrame(
-                [{"head_id": "a_chem", "tail_id": "c_chem"}]
+                [{"head_id": "c_chem", "tail_id": "a_chem"}]
             ),
         }
         monkeypatch.setattr(
@@ -301,8 +302,9 @@ class TestFoodScopedInheritance:
             ),
             # C is in r1 tail → food-connected
             "WHERE relationship_id = 'r1'": pd.DataFrame([{"tail_id": "c_chem"}]),
+            # Natural r2: c_chem is_a a_chem (head=child, tail=parent).
             "WHERE relationship_id = 'r2'": pd.DataFrame(
-                [{"head_id": "a_chem", "tail_id": "c_chem"}]
+                [{"head_id": "c_chem", "tail_id": "a_chem"}]
             ),
         }
         monkeypatch.setattr(

--- a/backend/db/tests/test_materializer_search.py
+++ b/backend/db/tests/test_materializer_search.py
@@ -99,7 +99,7 @@ class TestBuildExactTokens:
 class TestCountScopedR2:
     """Test _count_scoped_r2 — IS_A edge counting from seeds to root.
 
-    Edges below use the food/disease convention (head=child, tail=parent).
+    All r2 triplets use natural direction: head=child, tail=parent.
     """
 
     @staticmethod
@@ -108,7 +108,7 @@ class TestCountScopedR2:
 
     @staticmethod
     def _count(r2, seeds, type_ids):
-        return _count_scoped_r2(r2, seeds, type_ids, "head_id", "tail_id")
+        return _count_scoped_r2(r2, seeds, type_ids)
 
     def test_basic_chain(self):
         # A -> B -> C, seed={A}
@@ -143,13 +143,6 @@ class TestCountScopedR2:
         # A -> C, B -> C (seeds={A, B})
         r2 = self._make_r2([("A", "C"), ("B", "C")])
         assert self._count(r2, {"A", "B"}, {"A", "B", "C"}) == 2
-
-    def test_chemical_direction(self):
-        # Chemical convention: head=parent, tail=child.
-        # parent -> child edges; seed is a leaf child.
-        r2 = pd.DataFrame([("gp", "p"), ("p", "c")], columns=["head_id", "tail_id"])
-        result = _count_scoped_r2(r2, {"c"}, {"gp", "p", "c"}, "tail_id", "head_id")
-        assert result == 2
 
 
 class TestLoadAssocCounts:

--- a/backend/db/tests/test_materializer_search.py
+++ b/backend/db/tests/test_materializer_search.py
@@ -49,7 +49,9 @@ class TestExtractExternalIdValues:
 
 
 class TestBuildExactTokens:
-    """Test _build_exact_tokens."""
+    """Test _build_exact_tokens. All tokens are lowercased so the search
+    repository's lowercased query term matches regardless of original case.
+    """
 
     def test_basic_tokens(self):
         result = _build_exact_tokens(
@@ -61,26 +63,40 @@ class TestBuildExactTokens:
         )
         assert result == [
             "food",
-            "Apple",
-            "Malus domestica",
+            "apple",
+            "malus domestica",
             "apple fruit",
-            "FOODON:123",
+            "foodon:123",
         ]
 
     def test_no_scientific_name(self):
         result = _build_exact_tokens("chemical", "Vitamin C", "", ["ascorbic acid"], [])
-        assert "Vitamin C" in result
+        assert "vitamin c" in result
         assert "" not in result
         assert "ascorbic acid" in result
 
     def test_entity_type_always_first(self):
         result = _build_exact_tokens("disease", "Scurvy", "", [], [])
         assert result[0] == "disease"
-        assert result[1] == "Scurvy"
+        assert result[1] == "scurvy"
 
     def test_empty_synonyms_and_ext_ids(self):
         result = _build_exact_tokens("food", "X", "", [], [])
-        assert result == ["food", "X"]
+        assert result == ["food", "x"]
+
+    def test_uppercase_dmd_peptide_searchable(self):
+        # DMD peptides have uppercase common names like "CBL_0001". The token
+        # must be lowercased so a search for "cbl" matches.
+        result = _build_exact_tokens(
+            "chemical",
+            "CBL_0001",
+            "",
+            ["CBL_0001", "APFP"],
+            ["DMD300001"],
+        )
+        assert "cbl_0001" in result
+        assert "apfp" in result
+        assert "dmd300001" in result
 
     def test_all_values_are_strings(self):
         nums_as_synonyms: list[str] = ["123"]

--- a/backend/db/tests/test_materializer_search_helpers.py
+++ b/backend/db/tests/test_materializer_search_helpers.py
@@ -27,6 +27,8 @@ class TestExtractExternalIdValues:
 
 class TestBuildExactTokens:
     def test_includes_all_fields(self):
+        # Tokens are lowercased to match the search repository's lowercased
+        # query term.
         tokens = _build_exact_tokens(
             "food",
             "tomato",
@@ -36,9 +38,9 @@ class TestBuildExactTokens:
         )
         assert "food" in tokens
         assert "tomato" in tokens
-        assert "Solanum lycopersicum" in tokens
+        assert "solanum lycopersicum" in tokens
         assert "tomate" in tokens
-        assert "FDC:123" in tokens
+        assert "fdc:123" in tokens
 
     def test_skips_empty_scientific_name(self):
         tokens = _build_exact_tokens("chemical", "caffeine", "", [], [])

--- a/backend/kgc/src/config/corrections.py
+++ b/backend/kgc/src/config/corrections.py
@@ -63,6 +63,9 @@ class OntologyRoots:
     foodon_is_food: str = "http://purl.obolibrary.org/obo/FOODON_00002381"
     foodon_is_organism: str = "http://purl.obolibrary.org/obo/OBI_0100026"
     chebi_molecular_entity: int = 23367
+    cdno_keep_subtrees: tuple[str, ...] = (
+        "http://purl.obolibrary.org/obo/CDNO_0200179",
+    )
 
 
 @dataclass(frozen=True)
@@ -130,5 +133,11 @@ def load_corrections(path: Path | None = None) -> Corrections:
                 "http://purl.obolibrary.org/obo/OBI_0100026",
             ),
             chebi_molecular_entity=roots_raw.get("chebi_molecular_entity", 23367),
+            cdno_keep_subtrees=tuple(
+                roots_raw.get(
+                    "cdno_keep_subtrees",
+                    ["http://purl.obolibrary.org/obo/CDNO_0200179"],
+                )
+            ),
         ),
     )

--- a/backend/kgc/src/config/corrections.yaml
+++ b/backend/kgc/src/config/corrections.yaml
@@ -59,3 +59,7 @@ ontology_roots:
   foodon_is_food: "http://purl.obolibrary.org/obo/FOODON_00002381"
   foodon_is_organism: "http://purl.obolibrary.org/obo/OBI_0100026"
   chebi_molecular_entity: 23367
+  # CDNO category subtrees preserved through the FDC-xref filter.
+  # Used to keep classification roots like "vitamin" that have no FDC ID.
+  cdno_keep_subtrees:
+    - "http://purl.obolibrary.org/obo/CDNO_0200179"  # vitamin

--- a/backend/kgc/src/config/foodatlas_classifications.yaml
+++ b/backend/kgc/src/config/foodatlas_classifications.yaml
@@ -1,0 +1,25 @@
+# FoodAtlas-curated chemical ontology bridges.
+# These are manual is_a edges we assert to connect classification roots from
+# one source into another source's ontology spine. Each entry becomes a single
+# triplet with source=foodatlas.
+#
+# Semantics: "child is_a parent".
+# Format:
+#   is_a:
+#     - child:  {source, native_id}
+#       parent: {source, native_id}
+#       note:   "why this bridge exists"
+
+is_a:
+  # Attach the CDNO "vitamin" root to the ChEBI molecular-entity root.
+  # ChEBI only has "vitamin (role)" which is filtered out by the molecular
+  # entity subtree filter, so there is no ChEBI-native path from vitamin to
+  # molecular entity. We create one here so graph traversal from the chemical
+  # root reaches the vitamin classification.
+  - child:
+      source: cdno
+      native_id: "http://purl.obolibrary.org/obo/CDNO_0200179"
+    parent:
+      source: chebi
+      native_id: "23367"
+    note: "Attach CDNO vitamin class to ChEBI molecular entity spine"

--- a/backend/kgc/src/pipeline/enrichment/classification.py
+++ b/backend/kgc/src/pipeline/enrichment/classification.py
@@ -38,6 +38,8 @@ CHEMICAL_CATEGORIES: dict[str, str] = {
     "amino acid": "e64236",
     "fatty acid": "e64324",
     "nucleotide": "e64474",
+    "peptide": "e60858",
+    "vitamin": "e227338",
 }
 
 _IS_A_RELATIONSHIP = "r2"

--- a/backend/kgc/src/pipeline/enrichment/classification.py
+++ b/backend/kgc/src/pipeline/enrichment/classification.py
@@ -91,14 +91,14 @@ def _build_parent_child_map(
 ) -> dict[str, set[str]]:
     """Build parent -> children mapping from IS_A triplets.
 
-    In the KG, IS_A triplets are stored as ``head=parent, tail=child``.
+    IS_A triplets use natural direction: ``head=child, tail=parent``.
     """
     is_a = triplets[triplets["relationship_id"] == _IS_A_RELATIONSHIP]
     is_a_cc = is_a[is_a["head_id"].isin(chem_ids) & is_a["tail_id"].isin(chem_ids)]
 
     parent_to_children: dict[str, set[str]] = {}
     for _, row in is_a_cc.iterrows():
-        parent_to_children.setdefault(row["head_id"], set()).add(row["tail_id"])
+        parent_to_children.setdefault(row["tail_id"], set()).add(row["head_id"])
     return parent_to_children
 
 

--- a/backend/kgc/src/pipeline/enrichment/food_classification.py
+++ b/backend/kgc/src/pipeline/enrichment/food_classification.py
@@ -5,9 +5,7 @@ whether it is a descendant of curated FoodOn anchor nodes.  Multi-label:
 a single food can belong to multiple categories (e.g. a fruit juice is
 both "botanical fruit food product" and "plant derived beverage").
 
-Note: FoodOn IS_A direction is head=child, tail=parent — the inverse of
-the chemical (ChEBI) convention.  ``_build_parent_child_map`` accounts
-for this by mapping tail -> head.
+All r2 triplets use natural direction: ``head=child, tail=parent``.
 """
 
 from __future__ import annotations

--- a/backend/kgc/src/pipeline/entities/utils/subtree_filter.py
+++ b/backend/kgc/src/pipeline/entities/utils/subtree_filter.py
@@ -29,7 +29,7 @@ def filter_sources(
     _filter_foodon(sources, roots)
     _filter_chebi(sources, roots)
     _filter_ctd(sources)
-    _filter_cdno(sources)
+    _filter_cdno(sources, roots)
     return sources
 
 
@@ -129,20 +129,39 @@ def _filter_ctd(sources: dict[str, dict[str, pd.DataFrame]]) -> None:
     logger.info("CTD: %d → %d edges (direct evidence).", before, after)
 
 
-def _filter_cdno(sources: dict[str, dict[str, pd.DataFrame]]) -> None:
+def _filter_cdno(
+    sources: dict[str, dict[str, pd.DataFrame]],
+    roots: OntologyRoots,
+) -> None:
     cdno = sources.get("cdno")
     if cdno is None:
         return
     nodes: pd.DataFrame = cdno["nodes"]
+    edges: pd.DataFrame = cdno["edges"]
     xrefs = cdno.get("xrefs", pd.DataFrame())
     before = len(nodes)
 
     if xrefs.empty:
-        cdno["nodes"] = nodes.iloc[0:0].copy()
+        ids_with_fdc: set[str] = set()
     else:
         fdc_xrefs = xrefs[xrefs["target_source"] == "fdc_nutrient"]
         ids_with_fdc = set(fdc_xrefs["native_id"])
-        cdno["nodes"] = nodes[nodes["native_id"].isin(ids_with_fdc)].copy()
+
+    # Preserve whitelisted classification subtrees even without FDC xrefs.
+    subtree_ids: set[str] = set()
+    for root_id in roots.cdno_keep_subtrees:
+        subtree_ids |= _compute_descendants(edges, root_id)
+
+    keep = ids_with_fdc | subtree_ids
+    cdno["nodes"] = nodes[nodes["native_id"].isin(keep)].copy()
+    cdno["edges"] = edges[
+        edges["head_native_id"].isin(keep) & edges["tail_native_id"].isin(keep)
+    ].copy()
 
     after = len(cdno["nodes"])
-    logger.info("CDNO: %d → %d nodes (FDC nutrient).", before, after)
+    logger.info(
+        "CDNO: %d → %d nodes (FDC nutrient + %d whitelisted subtrees).",
+        before,
+        after,
+        len(roots.cdno_keep_subtrees),
+    )

--- a/backend/kgc/src/pipeline/ingest/adapters/cdno.py
+++ b/backend/kgc/src/pipeline/ingest/adapters/cdno.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from typing import TYPE_CHECKING, Any
 
 import pandas as pd
@@ -22,6 +23,18 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 SOURCE_ID = "cdno"
+
+_CONC_PREFIX = re.compile(r"^concentration of\s+", re.IGNORECASE)
+_MATERIAL_SUFFIX = re.compile(r"\s+in material entity$", re.IGNORECASE)
+_MOL_ENT_PAREN = re.compile(r"\s*\(molecular entity\)", re.IGNORECASE)
+
+
+def _clean_label(raw: str) -> str:
+    """Strip CDNO's "concentration of X ... in material entity" wrapper."""
+    s = _CONC_PREFIX.sub("", raw)
+    s = _MATERIAL_SUFFIX.sub("", s)
+    s = _MOL_ENT_PAREN.sub("", s)
+    return s.strip()
 
 
 class CDNOAdapter:
@@ -91,15 +104,16 @@ def _parse_cdno(
             continue
 
         label_el = class_.find("rdfs:label")
-        label = label_el.text if label_el else ""
+        raw_label = label_el.text if label_el else ""
+        name = _clean_label(raw_label).lower() if raw_label else ""
 
         node_rows.append(
             {
                 "source_id": SOURCE_ID,
                 "native_id": cdno_id,
-                "name": label.lower().strip(),
-                "synonyms": [label.lower().strip()] if label else [],
-                "synonym_types": ["label"] if label else [],
+                "name": name,
+                "synonyms": [name] if name else [],
+                "synonym_types": ["label"] if name else [],
                 "node_type": "class",
                 "raw_attrs": {},
             }

--- a/backend/kgc/src/pipeline/triplets/builder.py
+++ b/backend/kgc/src/pipeline/triplets/builder.py
@@ -6,7 +6,12 @@ import logging
 from typing import TYPE_CHECKING
 
 from ...utils.timing import log_duration
-from .chemical_chemical import merge_chemical_ontology
+from .chemical_chemical import (
+    merge_chemical_ontology,
+    merge_chemical_ontology_cdno,
+    merge_chemical_ontology_dmd,
+    merge_chemical_ontology_foodatlas,
+)
 from .chemical_disease import merge_ctd_triplets
 from .disease_disease import merge_disease_ontology
 from .food_chemical import merge_dmd_triplets, merge_fdc_triplets
@@ -31,8 +36,14 @@ def build_triplets(
     """
     with log_duration("Food ontology triplets", logger):
         merge_food_ontology(kg, sources)
-    with log_duration("Chemical ontology triplets", logger):
+    with log_duration("Chemical ontology triplets (ChEBI)", logger):
         merge_chemical_ontology(kg, sources)
+    with log_duration("Chemical ontology triplets (CDNO)", logger):
+        merge_chemical_ontology_cdno(kg, sources)
+    with log_duration("Chemical ontology triplets (DMD classifications)", logger):
+        merge_chemical_ontology_dmd(kg, sources)
+    with log_duration("Chemical ontology triplets (FoodAtlas bridges)", logger):
+        merge_chemical_ontology_foodatlas(kg, sources)
     with log_duration("Disease ontology triplets", logger):
         merge_disease_ontology(kg, sources)
     with log_duration("FDC food-chemical triplets", logger):

--- a/backend/kgc/src/pipeline/triplets/chemical_chemical/__init__.py
+++ b/backend/kgc/src/pipeline/triplets/chemical_chemical/__init__.py
@@ -1,5 +1,13 @@
 """Chemical ontology (IS_A) triplet builders."""
 
+from .cdno import merge_chemical_ontology_cdno
 from .chebi import merge_chemical_ontology
+from .dmd import merge_chemical_ontology_dmd
+from .foodatlas import merge_chemical_ontology_foodatlas
 
-__all__ = ["merge_chemical_ontology"]
+__all__ = [
+    "merge_chemical_ontology",
+    "merge_chemical_ontology_cdno",
+    "merge_chemical_ontology_dmd",
+    "merge_chemical_ontology_foodatlas",
+]

--- a/backend/kgc/src/pipeline/triplets/chemical_chemical/cdno.py
+++ b/backend/kgc/src/pipeline/triplets/chemical_chemical/cdno.py
@@ -1,0 +1,89 @@
+"""Build chemical ontology triplets (is_a) from Phase 1 CDNO edges."""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from ..utils import explode_external_ids
+
+if TYPE_CHECKING:
+    from ...knowledge_graph import KnowledgeGraph
+
+logger = logging.getLogger(__name__)
+
+_SOURCE = "cdno"
+_REL_ID = "r2"
+
+
+def merge_chemical_ontology_cdno(
+    kg: KnowledgeGraph,
+    sources: dict[str, dict[str, pd.DataFrame]],
+) -> None:
+    """Generate is_a triplets from Phase 1 CDNO edges.
+
+    CDNO classifies chemicals into nutrient categories (vitamin, amino acid,
+    lipid, etc.). Most CDNO leaves and intermediates have ChEBI equivalents and
+    therefore share a foodatlas_id with their ChEBI counterpart after xref
+    resolution — so these triplets express "is_a" relationships between the
+    merged chemical entities without introducing duplicates.
+    """
+    cdno = sources.get("cdno")
+    if cdno is None:
+        return
+
+    edges = cdno["edges"]
+    is_a = edges[edges["edge_type"] == "is_a"].copy()
+    if is_a.empty:
+        logger.info("No CDNO is_a edges to merge.")
+        return
+
+    lookup = explode_external_ids(kg.entities._entities, _SOURCE)
+    if lookup.empty:
+        logger.info("No CDNO entities resolved; skipping CDNO ontology merge.")
+        return
+
+    # Natural is_a direction: head=child, tail=parent.
+    df = is_a.merge(
+        lookup, left_on="head_native_id", right_on="native_id", how="inner"
+    ).drop(columns=["native_id"])
+    df = df.rename(
+        columns={"foodatlas_id": "_head_id", "candidates": "head_candidates"}
+    )
+
+    df = df.merge(
+        lookup, left_on="tail_native_id", right_on="native_id", how="inner"
+    ).drop(columns=["native_id"])
+    df = df.rename(
+        columns={"foodatlas_id": "_tail_id", "candidates": "tail_candidates"}
+    )
+
+    # Drop self-loops that appear after xref-based entity merging (when a CDNO
+    # child and its CDNO parent both map to the same ChEBI entity).
+    df = df[df["_head_id"] != df["_tail_id"]]
+
+    if df.empty:
+        logger.info("No CDNO is_a edges to merge after resolution.")
+        return
+
+    ref = json.dumps({"source": _SOURCE, "edge_type": "is_a"})
+    df["source_type"] = _SOURCE
+    df["reference"] = ref
+    df["source"] = _SOURCE
+    df["head_name_raw"] = df["head_native_id"].astype(str)
+    df["tail_name_raw"] = df["tail_native_id"].astype(str)
+
+    ev_result = kg.evidence.create(df[["source_type", "reference"]])
+    df["evidence_id"] = ev_result.index
+    attestations = kg.attestations.create(df)
+
+    triplet_input = df[["_head_id", "_tail_id"]].copy()
+    triplet_input.columns = pd.Index(["head_id", "tail_id"])
+    triplet_input.index = attestations.index
+    triplet_input["relationship_id"] = _REL_ID
+    triplets = kg.triplets.create(triplet_input)
+
+    logger.info("Created %d CDNO chemical ontology triplets.", len(triplets))

--- a/backend/kgc/src/pipeline/triplets/chemical_chemical/chebi.py
+++ b/backend/kgc/src/pipeline/triplets/chemical_chemical/chebi.py
@@ -38,16 +38,18 @@ def merge_chemical_ontology(
     if lookup.empty:
         return
 
-    # ChEBI is_a semantics: head is_a tail → reversed in KG (head=parent).
+    # Natural is_a direction (matches FoodOn): head=child, tail=parent.
+    # Phase-1 ChEBI edges already use this direction after the adapter
+    # translates ChEBI's raw INIT=parent/FINAL=child convention.
     df = is_a.merge(
-        lookup, left_on="tail_native_id", right_on="native_id", how="inner"
+        lookup, left_on="head_native_id", right_on="native_id", how="inner"
     ).drop(columns=["native_id"])
     df = df.rename(
         columns={"foodatlas_id": "_head_id", "candidates": "head_candidates"}
     )
 
     df = df.merge(
-        lookup, left_on="head_native_id", right_on="native_id", how="inner"
+        lookup, left_on="tail_native_id", right_on="native_id", how="inner"
     ).drop(columns=["native_id"])
     df = df.rename(
         columns={"foodatlas_id": "_tail_id", "candidates": "tail_candidates"}
@@ -61,8 +63,8 @@ def merge_chemical_ontology(
     df["source_type"] = _SOURCE
     df["reference"] = ref
     df["source"] = _SOURCE
-    df["head_name_raw"] = df["tail_native_id"].astype(str)
-    df["tail_name_raw"] = df["head_native_id"].astype(str)
+    df["head_name_raw"] = df["head_native_id"].astype(str)
+    df["tail_name_raw"] = df["tail_native_id"].astype(str)
 
     ev_result = kg.evidence.create(df[["source_type", "reference"]])
     df["evidence_id"] = ev_result.index

--- a/backend/kgc/src/pipeline/triplets/chemical_chemical/dmd.py
+++ b/backend/kgc/src/pipeline/triplets/chemical_chemical/dmd.py
@@ -1,0 +1,137 @@
+"""Build chemical ontology triplets (is_a) from DMD molecule classifications.
+
+DMD provides a ``Molecule Classification`` column that labels each molecule
+as Peptide, Protein, Complex Lipid, Biogenic Amine, etc. ChEBI proper would
+eventually classify these structurally, but most DMD peptides in particular
+have no ChEBI xref and would otherwise sit unclassified. This merger emits
+``is_a`` triplets with ``source=foodatlas`` from each DMD molecule to the
+corresponding ChEBI class entity.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from ..utils import explode_external_ids
+
+if TYPE_CHECKING:
+    from ...knowledge_graph import KnowledgeGraph
+
+logger = logging.getLogger(__name__)
+
+_SOURCE = "foodatlas"
+_REL_ID = "r2"
+
+# DMD classification label → ChEBI native_id of the class entity that the
+# DMD molecule should be declared an is_a of. Only classifications with a
+# real ChEBI class are listed; adding a new row here is all it takes to
+# start emitting triplets for that class.
+_CLASSIFICATION_TO_CHEBI: dict[str, str] = {
+    "Peptide": "16670",  # peptide (CHEBI:16670)
+}
+
+
+def merge_chemical_ontology_dmd(
+    kg: KnowledgeGraph,
+    sources: dict[str, dict[str, pd.DataFrame]],
+) -> None:
+    """Generate is_a triplets from DMD ``Molecule Classification`` labels."""
+    dmd = sources.get("dmd")
+    if dmd is None:
+        return
+
+    nodes = dmd.get("nodes", pd.DataFrame())
+    if nodes.empty:
+        logger.info("No DMD nodes.")
+        return
+
+    dmd_lookup = explode_external_ids(kg.entities._entities, "dmd")
+    if dmd_lookup.empty:
+        logger.info("No DMD entity mappings.")
+        return
+
+    chebi_lookup = explode_external_ids(kg.entities._entities, "chebi")
+    if chebi_lookup.empty:
+        logger.info("No ChEBI entity mappings.")
+        return
+
+    chebi_native_to_fa = dict(
+        zip(chebi_lookup["native_id"], chebi_lookup["foodatlas_id"], strict=False)
+    )
+
+    rows: list[dict[str, object]] = []
+    for label, chebi_native in _CLASSIFICATION_TO_CHEBI.items():
+        parent_fa = chebi_native_to_fa.get(chebi_native)
+        if parent_fa is None:
+            msg = (
+                f"ChEBI class {chebi_native} (for DMD classification {label!r}) "
+                f"not found in entity store — ChEBI ingest may be broken."
+            )
+            raise ValueError(msg)
+
+        matches = nodes[
+            nodes["raw_attrs"].apply(
+                lambda x, lbl=label: (
+                    isinstance(x, dict)
+                    and lbl in (x.get("molecule_classification") or [])
+                )
+            )
+        ]
+        if matches.empty:
+            continue
+
+        merged = matches.merge(
+            dmd_lookup,
+            left_on="native_id",
+            right_on="native_id",
+            how="inner",
+        )
+        if merged.empty:
+            logger.info("DMD %s: no resolved entities.", label)
+            continue
+
+        # Drop child==parent self-loops just in case.
+        merged = merged[merged["foodatlas_id"] != parent_fa]
+
+        for _, row in merged.iterrows():
+            # Natural is_a direction: head=child (DMD molecule), tail=parent.
+            rows.append(
+                {
+                    "_head_id": str(row["foodatlas_id"]),
+                    "_tail_id": parent_fa,
+                    "source_type": _SOURCE,
+                    "reference": json.dumps(
+                        {
+                            "rule": "dmd_molecule_classification",
+                            "value": label,
+                            "chebi_parent": chebi_native,
+                        }
+                    ),
+                    "source": _SOURCE,
+                    "head_name_raw": f"dmd:{row['native_id']}",
+                    "tail_name_raw": f"chebi:{chebi_native}",
+                }
+            )
+
+        logger.info("DMD classification %s: %d triplets queued.", label, len(merged))
+
+    if not rows:
+        logger.info("No DMD chemical-ontology triplets emitted.")
+        return
+
+    df = pd.DataFrame(rows)
+    ev_result = kg.evidence.create(df[["source_type", "reference"]])
+    df["evidence_id"] = ev_result.index
+    attestations = kg.attestations.create(df)
+
+    triplet_input = df[["_head_id", "_tail_id"]].copy()
+    triplet_input.columns = pd.Index(["head_id", "tail_id"])
+    triplet_input.index = attestations.index
+    triplet_input["relationship_id"] = _REL_ID
+    triplets = kg.triplets.create(triplet_input)
+
+    logger.info("Created %d DMD chemical ontology triplets.", len(triplets))

--- a/backend/kgc/src/pipeline/triplets/chemical_chemical/foodatlas.py
+++ b/backend/kgc/src/pipeline/triplets/chemical_chemical/foodatlas.py
@@ -1,0 +1,134 @@
+"""FoodAtlas-curated chemical ontology bridge triplets.
+
+This module is the single home for hand-curated is_a edges between chemical
+entities that no upstream source provides. Each bridge is declared in
+``config/foodatlas_classifications.yaml`` so the code stays data-driven and
+new bridges can be added without touching Python.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pandas as pd
+import yaml
+
+from ..utils import explode_external_ids
+
+if TYPE_CHECKING:
+    from ...knowledge_graph import KnowledgeGraph
+
+logger = logging.getLogger(__name__)
+
+_SOURCE = "foodatlas"
+_REL_ID = "r2"
+
+_CLASSIFICATIONS_PATH = (
+    Path(__file__).resolve().parents[3] / "config" / "foodatlas_classifications.yaml"
+)
+
+
+def _load_bridges(path: Path = _CLASSIFICATIONS_PATH) -> list[dict[str, Any]]:
+    if not path.exists():
+        msg = f"foodatlas_classifications.yaml not found at {path}"
+        raise FileNotFoundError(msg)
+    with path.open() as f:
+        raw = yaml.safe_load(f) or {}
+    return list(raw.get("is_a", []))
+
+
+def _resolve(
+    lookups: dict[str, pd.DataFrame],
+    source: str,
+    native_id: str,
+    kg: KnowledgeGraph,
+) -> str | None:
+    if source not in lookups:
+        lookups[source] = explode_external_ids(kg.entities._entities, source)
+    lookup = lookups[source]
+    match = lookup[lookup["native_id"] == str(native_id)]
+    if match.empty:
+        return None
+    return str(match.iloc[0]["foodatlas_id"])
+
+
+def merge_chemical_ontology_foodatlas(
+    kg: KnowledgeGraph,
+    sources: dict[str, dict[str, pd.DataFrame]],  # noqa: ARG001
+) -> None:
+    """Emit hand-curated is_a triplets declared in the classifications YAML."""
+    bridges = _load_bridges()
+    if not bridges:
+        return
+
+    lookups: dict[str, pd.DataFrame] = {}
+    rows: list[dict[str, Any]] = []
+    for bridge in bridges:
+        child_src = bridge["child"]["source"]
+        child_nid = bridge["child"]["native_id"]
+        parent_src = bridge["parent"]["source"]
+        parent_nid = bridge["parent"]["native_id"]
+        note = bridge.get("note", "")
+
+        child_fa = _resolve(lookups, child_src, child_nid, kg)
+        parent_fa = _resolve(lookups, parent_src, parent_nid, kg)
+        if child_fa is None or parent_fa is None:
+            logger.warning(
+                "FoodAtlas bridge unresolved: %s:%s is_a %s:%s "
+                "(child_fa=%s, parent_fa=%s)",
+                child_src,
+                child_nid,
+                parent_src,
+                parent_nid,
+                child_fa,
+                parent_fa,
+            )
+            continue
+        if child_fa == parent_fa:
+            continue
+
+        # Natural is_a direction: head=child, tail=parent.
+        rows.append(
+            {
+                "_head_id": child_fa,
+                "_tail_id": parent_fa,
+                "source_type": _SOURCE,
+                "reference": json.dumps(
+                    {
+                        "rule": "curated_bridge",
+                        "note": note,
+                        "child": {
+                            "source": child_src,
+                            "native_id": str(child_nid),
+                        },
+                        "parent": {
+                            "source": parent_src,
+                            "native_id": str(parent_nid),
+                        },
+                    }
+                ),
+                "source": _SOURCE,
+                "head_name_raw": f"{child_src}:{child_nid}",
+                "tail_name_raw": f"{parent_src}:{parent_nid}",
+            }
+        )
+
+    if not rows:
+        logger.info("No FoodAtlas bridge triplets emitted.")
+        return
+
+    df = pd.DataFrame(rows)
+    ev_result = kg.evidence.create(df[["source_type", "reference"]])
+    df["evidence_id"] = ev_result.index
+    attestations = kg.attestations.create(df)
+
+    triplet_input = df[["_head_id", "_tail_id"]].copy()
+    triplet_input.columns = pd.Index(["head_id", "tail_id"])
+    triplet_input.index = attestations.index
+    triplet_input["relationship_id"] = _REL_ID
+    triplets = kg.triplets.create(triplet_input)
+
+    logger.info("Created %d FoodAtlas bridge triplets.", len(triplets))

--- a/backend/kgc/src/utils/unclassified.py
+++ b/backend/kgc/src/utils/unclassified.py
@@ -16,22 +16,17 @@ _IS_A_RELATIONSHIP = "r2"
 def find_unclassified(ents: pd.DataFrame, trips: pd.DataFrame) -> pd.DataFrame:
     """Return food/chemical entities with no IS_A parent.
 
-    The two ontologies use opposite IS_A direction conventions:
-
-    - ChEBI (chemicals): ``head=parent, tail=child`` — a chemical has a
-      parent iff it appears as a *tail*.
-    - FoodOn (foods): ``head=child, tail=parent`` — a food has a parent
-      iff it appears as a *head*.
+    All is_a triplets use natural direction: ``head=child, tail=parent``.
+    An entity has a parent iff it appears as a ``head_id``.
     """
     is_a = trips[trips["relationship_id"] == _IS_A_RELATIONSHIP]
-    chem_classified = set(is_a["tail_id"])
-    food_classified = set(is_a["head_id"])
+    classified = set(is_a["head_id"])
 
     chems = ents[ents["entity_type"] == "chemical"]
     foods = ents[ents["entity_type"] == "food"]
 
-    unclassified_chems = chems[~chems.index.isin(chem_classified)]
-    unclassified_foods = foods[~foods.index.isin(food_classified)]
+    unclassified_chems = chems[~chems.index.isin(classified)]
+    unclassified_foods = foods[~foods.index.isin(classified)]
     return pd.concat([unclassified_chems, unclassified_foods])
 
 

--- a/backend/kgc/tests/test_classification.py
+++ b/backend/kgc/tests/test_classification.py
@@ -258,5 +258,5 @@ class TestCategoryConstants:
         eids = list(CHEMICAL_CATEGORIES.values())
         assert len(eids) == len(set(eids))
 
-    def test_twelve_categories(self) -> None:
-        assert len(CHEMICAL_CATEGORIES) == 12
+    def test_category_count(self) -> None:
+        assert len(CHEMICAL_CATEGORIES) == 14

--- a/backend/kgc/tests/test_classification.py
+++ b/backend/kgc/tests/test_classification.py
@@ -26,10 +26,11 @@ def _get_groups(entities: pd.DataFrame, eid: str) -> list[str]:
 
 class TestBuildParentChildMap:
     def test_builds_map(self) -> None:
+        # Natural is_a: head=child, tail=parent. e2 and e3 are children of e1.
         triplets = pd.DataFrame(
             [
-                {IC: "t0", "head_id": "e1", "tail_id": "e2", "relationship_id": "r2"},
-                {IC: "t1", "head_id": "e1", "tail_id": "e3", "relationship_id": "r2"},
+                {IC: "t0", "head_id": "e2", "tail_id": "e1", "relationship_id": "r2"},
+                {IC: "t1", "head_id": "e3", "tail_id": "e1", "relationship_id": "r2"},
                 {IC: "t2", "head_id": "e4", "tail_id": "e5", "relationship_id": "r1"},
             ]
         ).set_index(IC)
@@ -37,6 +38,7 @@ class TestBuildParentChildMap:
         assert result == {"e1": {"e2", "e3"}}
 
     def test_filters_to_chem_ids(self) -> None:
+        # Natural is_a: head=child, tail=parent. e1 is a child of e2.
         triplets = pd.DataFrame(
             [
                 {IC: "t0", "head_id": "e1", "tail_id": "e2", "relationship_id": "r2"},
@@ -129,18 +131,19 @@ class TestClassifyChemicals:
             ]
         ).set_index(IC)
 
+        # Natural is_a: head=child, tail=parent.
         triplets = pd.DataFrame(
             [
                 {
                     IC: "t0",
-                    "head_id": "e65128",
-                    "tail_id": "child1",
+                    "head_id": "child1",
+                    "tail_id": "e65128",
                     "relationship_id": "r2",
                 },
                 {
                     IC: "t1",
-                    "head_id": "e12451",
-                    "tail_id": "child2",
+                    "head_id": "child2",
+                    "tail_id": "e12451",
                     "relationship_id": "r2",
                 },
             ]
@@ -198,18 +201,20 @@ class TestClassifyChemicals:
             ]
         ).set_index(IC)
 
+        # Natural is_a: head=child, tail=parent.
+        # leaf is_a tannin (e13486); tannin is_a polyphenol (e12163).
         triplets = pd.DataFrame(
             [
                 {
                     IC: "t0",
-                    "head_id": "e12163",
-                    "tail_id": "e13486",
+                    "head_id": "e13486",
+                    "tail_id": "e12163",
                     "relationship_id": "r2",
                 },
                 {
                     IC: "t1",
-                    "head_id": "e13486",
-                    "tail_id": "leaf",
+                    "head_id": "leaf",
+                    "tail_id": "e13486",
                     "relationship_id": "r2",
                 },
             ]

--- a/backend/kgc/tests/test_ingest_adapters.py
+++ b/backend/kgc/tests/test_ingest_adapters.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 import pandas as pd
-from src.pipeline.ingest.adapters.cdno import CDNOAdapter
+from src.pipeline.ingest.adapters.cdno import CDNOAdapter, _clean_label
 from src.pipeline.ingest.adapters.chebi import ChEBIAdapter
 from src.pipeline.ingest.adapters.ctd import CTDAdapter
 from src.pipeline.ingest.adapters.dmd import DMDAdapter, _parse_set_field
@@ -167,6 +167,20 @@ def test_foodon_remove_suffix() -> None:
     assert _remove_suffix("apple@en") == "apple"
     assert _remove_suffix("val^^xsd:string") == "val"
     assert _remove_suffix("plain") == "plain"
+
+
+def test_cdno_clean_label() -> None:
+    assert _clean_label("concentration of water in material entity") == "water"
+    assert (
+        _clean_label("concentration of vitamin (molecular entity) in material entity")
+        == "vitamin"
+    )
+    assert (
+        _clean_label("concentration of polysaccharide in material entity")
+        == "polysaccharide"
+    )
+    assert _clean_label("dietary chemical component") == "dietary chemical component"
+    assert _clean_label("") == ""
 
 
 def test_mesh_ensure_list() -> None:

--- a/backend/kgc/tests/test_subtree_filter.py
+++ b/backend/kgc/tests/test_subtree_filter.py
@@ -7,8 +7,18 @@ from src.pipeline.entities.utils.subtree_filter import (
     filter_sources,
 )
 
+_EDGE_COLUMNS = [
+    "source_id",
+    "head_native_id",
+    "tail_native_id",
+    "edge_type",
+    "raw_attrs",
+]
+
 
 def _make_edges(pairs: list[tuple[str, str]], edge_type: str = "is_a") -> pd.DataFrame:
+    if not pairs:
+        return pd.DataFrame(columns=_EDGE_COLUMNS)
     return pd.DataFrame(
         [
             {
@@ -74,29 +84,20 @@ def test_filter_ctd_direct_evidence() -> None:
     assert chemdis.iloc[0]["head_native_id"] == "C1"
 
 
+def _make_cdno_node(native_id: str) -> dict:
+    return {
+        "source_id": "cdno",
+        "native_id": native_id,
+        "name": native_id.lower(),
+        "synonyms": [],
+        "synonym_types": [],
+        "node_type": "class",
+        "raw_attrs": {},
+    }
+
+
 def test_filter_cdno_fdc_nutrient() -> None:
-    nodes = pd.DataFrame(
-        [
-            {
-                "source_id": "cdno",
-                "native_id": "A",
-                "name": "a",
-                "synonyms": [],
-                "synonym_types": [],
-                "node_type": "class",
-                "raw_attrs": {},
-            },
-            {
-                "source_id": "cdno",
-                "native_id": "B",
-                "name": "b",
-                "synonyms": [],
-                "synonym_types": [],
-                "node_type": "class",
-                "raw_attrs": {},
-            },
-        ]
-    )
+    nodes = pd.DataFrame([_make_cdno_node("A"), _make_cdno_node("B")])
     xrefs = pd.DataFrame(
         [
             {
@@ -107,9 +108,48 @@ def test_filter_cdno_fdc_nutrient() -> None:
             },
         ]
     )
+    edges = _make_edges([])
     sources: dict[str, dict[str, pd.DataFrame]] = {
-        "cdno": {"nodes": nodes, "xrefs": xrefs}
+        "cdno": {"nodes": nodes, "edges": edges, "xrefs": xrefs}
     }
     filter_sources(sources, OntologyRoots())
     assert len(sources["cdno"]["nodes"]) == 1
     assert sources["cdno"]["nodes"].iloc[0]["native_id"] == "A"
+
+
+def test_filter_cdno_keeps_whitelisted_subtree() -> None:
+    vitamin_root = "http://purl.obolibrary.org/obo/CDNO_0200179"
+    nodes = pd.DataFrame(
+        [
+            _make_cdno_node(vitamin_root),
+            _make_cdno_node("VIT_C"),  # vitamin subtree, no FDC xref
+            _make_cdno_node("VIT_B"),  # vitamin subtree, no FDC xref
+            _make_cdno_node("UNRELATED"),  # not in subtree, no FDC xref → drop
+            _make_cdno_node("WITH_FDC"),  # unrelated but has FDC xref → keep
+        ]
+    )
+    edges = _make_edges(
+        [
+            ("VIT_C", vitamin_root),
+            ("VIT_B", vitamin_root),
+        ]
+    )
+    xrefs = pd.DataFrame(
+        [
+            {
+                "source_id": "cdno",
+                "native_id": "WITH_FDC",
+                "target_source": "fdc_nutrient",
+                "target_id": "2001",
+            },
+        ]
+    )
+    sources: dict[str, dict[str, pd.DataFrame]] = {
+        "cdno": {"nodes": nodes, "edges": edges, "xrefs": xrefs}
+    }
+    filter_sources(sources, OntologyRoots())
+    kept = set(sources["cdno"]["nodes"]["native_id"])
+    assert kept == {vitamin_root, "VIT_C", "VIT_B", "WITH_FDC"}
+    # Edges must be preserved between kept nodes.
+    kept_edges = sources["cdno"]["edges"]
+    assert len(kept_edges) == 2

--- a/backend/kgc/tests/test_utils_unclassified.py
+++ b/backend/kgc/tests/test_utils_unclassified.py
@@ -34,15 +34,15 @@ def _trips_with_atts(
 
 class TestFindUnclassified:
     def test_chemical_with_parent_is_classified(self) -> None:
-        # ChEBI convention: head=parent, tail=child.
+        # Natural is_a: head=child, tail=parent.
         # c1 (child) has parent c2 -> c1 is classified, c2 is not.
         ents = _ents([("c1", "chemical", "water"), ("c2", "chemical", "compound")])
-        trips = _trips([("c2", "r2", "c1")])
+        trips = _trips([("c1", "r2", "c2")])
         result = find_unclassified(ents, trips)
         assert list(result.index) == ["c2"]
 
     def test_food_with_parent_is_classified(self) -> None:
-        # FoodOn convention: head=child, tail=parent.
+        # Natural is_a: head=child, tail=parent.
         # f1 (child) has parent f2 -> f1 is classified, f2 is not.
         ents = _ents([("f1", "food", "apple"), ("f2", "food", "fruit")])
         trips = _trips([("f1", "r2", "f2")])
@@ -70,8 +70,8 @@ class TestFindUnclassified:
 
 class TestWriteUnclassifiedJsonl:
     def test_writes_jsonl(self, tmp_path: Path) -> None:
-        # c1 is a chemical under parent c2 (ChEBI: head=parent);
-        # f1 is a food under parent f2 (FoodOn: head=child).
+        # Natural is_a (head=child, tail=parent) for both chemicals and foods.
+        # c1 is a chemical under parent c2; f1 is a food under parent f2.
         # Unclassified: c2 (no parent) and f2 (no parent).
         ents = _ents(
             [
@@ -81,7 +81,7 @@ class TestWriteUnclassifiedJsonl:
                 ("f2", "food", "fruit"),
             ]
         )
-        trips = _trips([("c2", "r2", "c1"), ("f1", "r2", "f2")])
+        trips = _trips([("c1", "r2", "c2"), ("f1", "r2", "f2")])
         out = tmp_path / "diagnostics" / "kgc_unclassified.jsonl"
         count = write_unclassified_jsonl(ents, trips, out)
         assert count == 2

--- a/frontend/components/entities/food/FoodCompositionSection.tsx
+++ b/frontend/components/entities/food/FoodCompositionSection.tsx
@@ -61,10 +61,12 @@ const CLASSIFICATION_OPTIONS = [
   "glucosinolate",
   "lignan",
   "nucleotide",
+  "peptide",
   "polyphenol",
   "stilbenoid",
   "tannin",
   "terpenoid",
+  "vitamin",
   "n/a",
 ];
 


### PR DESCRIPTION
Closes #63.

## Summary

DMD peptides (~4,416 `CBL_xxxx` molecules) and CDNO vitamins previously sat unclassified because no \"peptide\" or \"vitamin\" class entity existed with the right upstream edges. This PR wires up both through the existing chemical ontology, using ChEBI's \`peptide\` (CHEBI:16670) for peptides and promoting CDNO's vitamin subtree as a parallel classification that bridges into the ChEBI spine.

> **⚠️ Depends on #111** — this branch is stacked on \`fix/chemical-r2-direction\`. Review #111 first; until it merges, the diff view here includes both sets of changes.

## Implementation

### Peptides (KGC)

DMD molecule.csv has a \`Molecule Classification\` column that labels 4,416 peptides. A new merger reads these labels and emits \`is_a peptide\` triplets to CHEBI:16670:

- **\`backend/kgc/src/pipeline/triplets/chemical_chemical/dmd.py\`** — new merger \`merge_chemical_ontology_dmd\`. \`_CLASSIFICATION_TO_CHEBI\` starts with \`{\"Peptide\": \"16670\"}\`; adding new classes (Protein, Complex Lipid, Biogenic Amine, etc.) is a one-line change. Fails loud if CHEBI:16670 doesn't resolve.

### Vitamins (KGC)

ChEBI only has \`vitamin (role)\` (CHEBI:33229) under the role hierarchy, which is filtered out by the \`molecular entity\` subtree filter. Instead, CDNO's \`CDNO_0200179\` (\"vitamin\") root is promoted as the classification anchor. CDNO vitamin subtree has 47 nodes; 46 have ChEBI equivalents and merge cleanly into existing ChEBI entities via the xref resolver, so the 46 \`is_a\` edges bridge into the ChEBI spine without introducing duplicate entities. The root itself (which has no ChEBI equivalent) is attached to \`molecular entity\` via a curated FoodAtlas bridge.

- **\`backend/kgc/src/pipeline/ingest/adapters/cdno.py\`** — strips \"concentration of X in material entity\" and \"(molecular entity)\" from CDNO labels. Before: \`concentration of vitamin (molecular entity) in material entity\`. After: \`vitamin\`. This affects 1,026 of 2,041 CDNO nodes and is required for entity linking to bind mentions of \"vitamin\" to the root.
- **\`backend/kgc/src/pipeline/entities/utils/subtree_filter.py\`** — new \`cdno_keep_subtrees\` config (in \`corrections.yaml\`) lets classification roots like \`CDNO_0200179\` survive the existing FDC-xref filter even though they have no FDC ID themselves.
- **\`backend/kgc/src/pipeline/triplets/chemical_chemical/cdno.py\`** — new merger \`merge_chemical_ontology_cdno\`. Structural parallel of the ChEBI merger, uses the same \`is_a\` relationship, drops self-loops that arise when a CDNO child and its CDNO parent both xref-merge into the same ChEBI entity.
- **\`backend/kgc/src/pipeline/triplets/chemical_chemical/foodatlas.py\`** + **\`backend/kgc/src/config/foodatlas_classifications.yaml\`** — new YAML-driven merger for hand-curated classification bridges. Currently contains one entry: \`CDNO_0200179 is_a CHEBI:23367\`. Raises \`FileNotFoundError\` if the YAML is missing instead of silently emitting nothing.

### Enrichment

- **\`backend/kgc/src/pipeline/enrichment/classification.py\`** — \`CHEMICAL_CATEGORIES\` adds \`\"peptide\": \"e60858\"\` and \`\"vitamin\": \"e227338\"\` so the enrichment stage labels descendants with \`chemical_groups = [\"peptide\"]\` / \`[\"vitamin\"]\`.

### Search bar fix (pre-existing bug)

- **\`backend/db/src/etl/materializer_search.py\`** — \`_build_exact_tokens\` now lowercases all tokens. The search repository (\`backend/api/src/repositories/search.py\`) already lowercases the query term (\`word = term.lower()\`) and does \`substr_auto LIKE '%term%'\`, but \`substr_auto\` stored tokens in original case. PostgreSQL \`LIKE\` is case-sensitive, so uppercase tokens never matched lowercased queries. This was invisible until DMD peptides landed with uppercase \`CBL_0001\` names. After this fix, searching \"cbl\" surfaces all 4,397 r1-connected peptides (+ cobalamins, which have \"Cbl\" in their synonyms).

### Frontend

- **\`frontend/components/entities/food/FoodCompositionSection.tsx\`** — \`CLASSIFICATION_OPTIONS\` adds \`peptide\` and \`vitamin\` so the composition filter dropdown surfaces the new categories.

## Post-merge deployment

Requires re-running KGC stages 0→4 (re-ingest CDNO for label cleaning, then all downstream stages) and reloading the DB:

\`\`\`
cd backend/kgc
uv run python main.py run --stages 0 --source cdno
uv run python main.py run --stages 1:4

cd ../db
uv run python main.py load
\`\`\`

## Verification (already performed locally)

- \`peptide\` entity has **11,831** \`is_a\` children (ChEBI peptide subtree + 4,416 DMD peptides).
- \`vitamin\` entity exists, has 1 parent (\`molecular entity\` via the FoodAtlas bridge) and its CDNO subtree attached (46 edges, 6 direct children: vitamin A/B/C/D/E/K).
- \`vitamin\` no longer appears in \`outputs/kg/diagnostics/kgc_unclassified.jsonl\`.
- Search for \`cbl\` returns 4,397 DMD peptides alongside cobalamins (which have legitimate \`Cbl\` synonyms from biochemistry literature).
- Ascorbic acid, biotin, alpha-tocopherol label as \`chemical_groups: [\"vitamin\"]\`; DMD peptides label as \`chemical_groups: [\"peptide\"]\`.
- 491 KGC tests + 241 DB tests + 69 API tests pass.

## Test plan

- [ ] Merge #111 first.
- [ ] Rebase this branch onto updated dev: \`git rebase origin/dev && git push --force-with-lease\`.
- [ ] Run the full KGC pipeline end-to-end on real data.
- [ ] Reload DB.
- [ ] Spot-check the vitamin C, biotin, and a random CBL peptide pages in the frontend.
- [ ] Confirm the peptide/vitamin filters in the cow milk food composition page work.