### PR TITLE
feat(ci): CD pipeline, main-branch guard, and CI rename/matrix split

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,128 @@
+name: CD
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "backend/api/**"
+      - "backend/db/**"
+      - "infra/cdk/**"
+      - "!**/*.md"
+  workflow_dispatch:
+
+concurrency:
+  group: cd-main
+  cancel-in-progress: false
+
+env:
+  AWS_REGION: us-west-1
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Compute image tag
+        id: tag
+        run: echo "image_tag=${GITHUB_SHA::12}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push API image
+        run: ./backend/api/scripts/push-to-ecr.sh "${{ steps.tag.outputs.image_tag }}"
+
+      - name: Build and push DB image
+        run: ./backend/db/scripts/push-to-ecr.sh "${{ steps.tag.outputs.image_tag }}"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install CDK CLI
+        run: npm install -g aws-cdk@2
+
+      - name: Resolve AWS account
+        id: account
+        run: echo "id=$(aws sts get-caller-identity --query Account --output text)" >> "$GITHUB_OUTPUT"
+
+      - name: Sync CDK dependencies
+        run: cd infra/cdk && uv sync
+
+      - name: Deploy non-API stacks (updates JobsStack with new DB image)
+        env:
+          CDK_DEFAULT_ACCOUNT: ${{ steps.account.outputs.id }}
+          CDK_DEFAULT_REGION: ${{ env.AWS_REGION }}
+          TAG: ${{ steps.tag.outputs.image_tag }}
+          API_CERT_ARN: ${{ secrets.API_CERT_ARN }}
+        run: |
+          cd infra/cdk
+          args=(
+            --context "api_image_tag=$TAG"
+            --context "db_image_tag=$TAG"
+            --require-approval never
+          )
+          if [ -n "$API_CERT_ARN" ]; then
+            args+=(--context "api_cert_arn=$API_CERT_ARN")
+          fi
+          uv run cdk deploy \
+            FoodAtlasNetworkStack \
+            FoodAtlasStorageStack \
+            FoodAtlasEcrStack \
+            FoodAtlasDatabaseStack \
+            FoodAtlasJobsStack \
+            "${args[@]}"
+
+      - name: Run Alembic migrations
+        run: ./infra/cdk/scripts/run-migration.sh
+
+      - name: Deploy API stack (rolls out new API image)
+        env:
+          CDK_DEFAULT_ACCOUNT: ${{ steps.account.outputs.id }}
+          CDK_DEFAULT_REGION: ${{ env.AWS_REGION }}
+          TAG: ${{ steps.tag.outputs.image_tag }}
+          API_CERT_ARN: ${{ secrets.API_CERT_ARN }}
+        run: |
+          cd infra/cdk
+          args=(
+            --context "api_image_tag=$TAG"
+            --context "db_image_tag=$TAG"
+            --require-approval never
+          )
+          if [ -n "$API_CERT_ARN" ]; then
+            args+=(--context "api_cert_arn=$API_CERT_ARN")
+          fi
+          uv run cdk deploy FoodAtlasApiStack "${args[@]}"
+
+      - name: Fetch API URL
+        id: api
+        run: |
+          url=$(aws cloudformation describe-stacks \
+            --stack-name FoodAtlasApiStack \
+            --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" \
+            --output text)
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+          echo "API URL: $url"
+
+      - name: Smoke test /health
+        run: curl --fail --show-error --retry 10 --retry-delay 10 --retry-all-errors --max-time 30 "${{ steps.api.outputs.url }}/health"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,6 @@ on:
   pull_request:
     branches:
       - dev
-    paths:
-      - "backend/**"
-      - "frontend/**"
-      - "infra/cdk/**"
-      - "!**/*.md"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -220,3 +215,32 @@ jobs:
 
       - name: Test
         run: cd frontend && npm test
+
+  # Aggregate all CI jobs into a single pass/fail signal. Require only this
+  # check in the protect-dev ruleset: it always runs on PRs to dev (the
+  # workflow has no paths filter), so required checks never deadlock.
+  ci-success:
+    needs:
+      - changes
+      - python-lint
+      - python-security
+      - python-typecheck
+      - backend-test
+      - infra-cdk-test
+      - frontend-lint
+      - frontend-build
+      - frontend-test
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify all needed jobs passed or skipped cleanly
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          failed=$(echo "$NEEDS" | jq -r 'to_entries[] | select(.value.result == "failure" or .value.result == "cancelled") | .key')
+          if [ -n "$failed" ]; then
+            echo "::error::Failed or cancelled jobs:"
+            echo "$failed"
+            exit 1
+          fi
+          echo "All jobs passed or skipped cleanly."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
       kgc: ${{ steps.diff.outputs.kgc }}
       frontend: ${{ steps.diff.outputs.frontend }}
       infra_cdk: ${{ steps.diff.outputs.infra_cdk }}
+      backend_projects: ${{ steps.diff.outputs.backend_projects }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -43,8 +44,15 @@ jobs:
           echo "kgc=$( echo "$CHANGED" | grep -q '^backend/kgc/' && echo true || echo false )" >> "$GITHUB_OUTPUT"
           echo "frontend=$( echo "$CHANGED" | grep -q '^frontend/' && echo true || echo false )" >> "$GITHUB_OUTPUT"
           echo "infra_cdk=$( echo "$CHANGED" | grep -q '^infra/cdk/' && echo true || echo false )" >> "$GITHUB_OUTPUT"
+          projects='[]'
+          for p in api db ie kgc; do
+            if echo "$CHANGED" | grep -q "^backend/$p/"; then
+              projects=$(jq -cn --argjson a "$projects" --arg p "$p" '$a + [$p]')
+            fi
+          done
+          echo "backend_projects=$projects" >> "$GITHUB_OUTPUT"
 
-  backend-lint:
+  python-lint:
     needs: changes
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.db == 'true' || needs.changes.outputs.ie == 'true' || needs.changes.outputs.kgc == 'true' || needs.changes.outputs.infra_cdk == 'true'
     runs-on: ubuntu-latest
@@ -65,7 +73,7 @@ jobs:
           src: backend/ infra/cdk/
           args: format --check
 
-  backend-security:
+  python-security:
     needs: changes
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.db == 'true' || needs.changes.outputs.ie == 'true' || needs.changes.outputs.kgc == 'true' || needs.changes.outputs.infra_cdk == 'true'
     runs-on: ubuntu-latest
@@ -83,7 +91,7 @@ jobs:
       - name: Bandit security scan
         run: bandit -c pyproject.toml -r backend/ infra/cdk/ --exclude "backend/api/tests,backend/db/tests,backend/ie/tests,backend/kgc/tests,backend/api/.venv,backend/db/.venv,backend/ie/.venv,backend/kgc/.venv,infra/cdk/tests,infra/cdk/.venv"
 
-  backend-typecheck:
+  python-typecheck:
     needs: changes
     if: needs.changes.outputs.api == 'true' || needs.changes.outputs.db == 'true' || needs.changes.outputs.ie == 'true' || needs.changes.outputs.kgc == 'true' || needs.changes.outputs.infra_cdk == 'true'
     runs-on: ubuntu-latest
@@ -103,32 +111,23 @@ jobs:
 
   backend-test:
     needs: changes
-    if: needs.changes.outputs.api == 'true' || needs.changes.outputs.db == 'true' || needs.changes.outputs.ie == 'true' || needs.changes.outputs.kgc == 'true'
+    if: needs.changes.outputs.backend_projects != '[]'
+    strategy:
+      fail-fast: false
+      matrix:
+        project: ${{ fromJSON(needs.changes.outputs.backend_projects) }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
+      - uses: astral-sh/setup-uv@v5
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - uses: actions/setup-python@v5
         with:
           python-version: "3.12"
 
-      - name: Run tests for changed projects
-        run: |
-          projects=""
-          [[ "${{ needs.changes.outputs.api }}" == "true" ]] && projects="$projects api"
-          [[ "${{ needs.changes.outputs.db }}" == "true" ]] && projects="$projects db"
-          [[ "${{ needs.changes.outputs.ie }}" == "true" ]] && projects="$projects ie"
-          [[ "${{ needs.changes.outputs.kgc }}" == "true" ]] && projects="$projects kgc"
-          for project in $projects; do
-            echo "::group::test backend/$project"
-            cd backend/$project && uv sync && uv run pytest
-            cd ../..
-            echo "::endgroup::"
-          done
+      - name: Test backend/${{ matrix.project }}
+        run: cd backend/${{ matrix.project }} && uv sync && uv run pytest
 
   infra-cdk-test:
     needs: changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,9 +216,10 @@ jobs:
       - name: Test
         run: cd frontend && npm test
 
-  # Aggregate all CI jobs into a single pass/fail signal. Require only
-  # this check in the protect-dev ruleset — it always runs on PRs to dev
-  # (the workflow has no paths filter), so required checks never deadlock.
+  # Aggregate all CI jobs into a single pass/fail signal. This is the
+  # only check required in the protect-dev ruleset: it always runs on
+  # PRs to dev (no workflow-level paths filter), so required checks
+  # never deadlock.
   ci-success:
     needs:
       - changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -216,9 +216,9 @@ jobs:
       - name: Test
         run: cd frontend && npm test
 
-  # Aggregate all CI jobs into a single pass/fail signal. Require only this
-  # check in the protect-dev ruleset: it always runs on PRs to dev (the
-  # workflow has no paths filter), so required checks never deadlock.
+  # Aggregate all CI jobs into a single pass/fail signal. Require only
+  # this check in the protect-dev ruleset — it always runs on PRs to dev
+  # (the workflow has no paths filter), so required checks never deadlock.
   ci-success:
     needs:
       - changes

--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -1,0 +1,23 @@
+name: guard-main-head-ref
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check:
+    name: guard-main-head-ref
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Validate source branch
+        env:
+          HEAD_REF: ${{ github.head_ref }}
+        run: |
+          if [[ "$HEAD_REF" != "dev" && "$HEAD_REF" != hotfix/* ]]; then
+            echo "::error::PRs to main must come from 'dev' or 'hotfix/*'. Got: '$HEAD_REF'."
+            exit 1
+          fi
+          echo "Head branch '$HEAD_REF' is allowed."


### PR DESCRIPTION
## Summary

Three related CI/CD workflow changes bundled together:

1. **New CD workflow** (`.github/workflows/cd.yml`) — deploys to AWS on push to `main` (or manual dispatch). Triggered by path changes under `backend/api`, `backend/db`, `infra/cdk`. Scoped to a GitHub `production` environment so secrets can be gated on the `main` branch.

2. **New guard workflow** (`.github/workflows/guard-main.yml`) — fails any PR targeting `main` whose head branch isn't `dev` or `hotfix/*`. Intended to be wired as a required status check in the `protect-main` ruleset, since Rulesets can't natively restrict head branches.

3. **CI rename + matrix split** (`.github/workflows/ci.yml`)
   - Renamed `backend-lint`/`backend-security`/`backend-typecheck` → `python-*`. These jobs scan both `backend/` and `infra/cdk/`, so the old name was misleading.
   - Split `backend-test` into a dynamic matrix keyed on the sub-projects that actually changed (via a new `backend_projects` output on the `changes` job). Each sub-project gets its own parallel runner and check run: `backend-test (api)`, `backend-test (db)`, etc.

## CD pipeline shape

On push to `main`:
1. Build and push `foodatlas-api` and `foodatlas-db` images to ECR (via existing `backend/{api,db}/scripts/push-to-ecr.sh`), tagged with git SHA.
2. `cdk deploy` non-API stacks (Network, Storage, Ecr, Database, Jobs) — Jobs stack gets the new DB image ready for migrations.
3. Run Alembic migrations via `infra/cdk/scripts/run-migration.sh`. Pipeline fails if migration exits non-zero.
4. `cdk deploy FoodAtlasApiStack` — rolls out the new API image; CloudFormation waits for ECS service to stabilize.
5. Fetch `ApiUrl` from the ApiStack CFN outputs and `curl --fail` against `/health` with retries.

Ordering ensures migrations run **before** the API rolls out, so new code never hits an old schema. Image tags are pinned per deploy (git SHA) to keep task definitions immutable.

## Required one-time setup before the first CD run

Repo Settings → Environments → create `production` with:
- Secrets: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `API_CERT_ARN`
- Deployment branches: restrict to `main` only

## Known tradeoffs

- **Dynamic test matrix**: PRs that don't touch a backend sub-project won't produce a check run for that matrix instance. Required status checks in the ruleset will deadlock for those missing checks; will address separately via a summary job or the \"do not require unless reported\" toggle.
- **Alembic step** stays in CD for now. Separate issue #120 tracks removing Alembic entirely in favor of SQLAlchemy drop-and-recreate.

## Test plan

- [ ] Merge to `dev`, then dev → main when ready
- [ ] Create `production` environment in GitHub with the three secrets and `main`-only branch restriction
- [ ] First CD run will auto-trigger on dev → main merge (the merge brings backend/api + backend/db changes that match the paths filter)
- [ ] Watch the Actions tab for the CD run; verify ECR image pushed, all stacks deployed, migration ran, smoke test passed
- [ ] Create `protect-main` and `protect-dev` rulesets; require `guard-main-head-ref` on main and the `python-*` / `frontend-*` / `backend-test (*)` / `infra-cdk-test` checks on dev