### PR TITLE
refactor(ci): switch CD to OIDC role assumption

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -24,6 +24,7 @@ jobs:
     environment: production
     permissions:
       contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -32,8 +33,7 @@ jobs:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Compute image tag


### PR DESCRIPTION
Replaces static AWS access keys with GitHub OIDC + sts:AssumeRoleWithWebIdentity. Each CD run now exchanges a short-lived JWT for a ~1h AWS session — no long-lived secrets live in GitHub, and nothing needs manual rotation.

Requires: an IAM role trusting the GitHub OIDC provider, its ARN stored as AWS_ROLE_ARN in the production environment.