### PR TITLE
fix(ci): smoke-test via custom domain to match ACM cert

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -114,15 +114,5 @@ jobs:
           fi
           uv run cdk deploy FoodAtlasApiStack "${args[@]}"
 
-      - name: Fetch API URL
-        id: api
-        run: |
-          url=$(aws cloudformation describe-stacks \
-            --stack-name FoodAtlasApiStack \
-            --query "Stacks[0].Outputs[?OutputKey=='ApiUrl'].OutputValue" \
-            --output text)
-          echo "url=$url" >> "$GITHUB_OUTPUT"
-          echo "API URL: $url"
-
       - name: Smoke test /health
-        run: curl --fail --show-error --retry 10 --retry-delay 10 --retry-all-errors --max-time 30 "${{ steps.api.outputs.url }}/health"
+        run: curl --fail --show-error --retry 10 --retry-delay 10 --retry-all-errors --max-time 30 "https://api.foodatlas.ai/health"


### PR DESCRIPTION
The ALB's AWS-assigned *.elb.amazonaws.com hostname doesn't match the ACM cert's SAN (api.foodatlas.ai), so TLS verification was failing even though the API was healthy. Target the custom domain directly.

Drops the now-unneeded 'Fetch API URL' step since the URL is static.