### PR TITLE
feat(disambiguation): surface ambiguous attestations end-to-end

### DIFF
--- a/backend/api/src/repositories/chemical.py
+++ b/backend/api/src/repositories/chemical.py
@@ -14,7 +14,8 @@ async def get_metadata(session: AsyncSession, common_name: str) -> dict[str, obj
         text("""
             SELECT common_name, foodatlas_id AS id, entity_type,
                    scientific_name, synonyms, external_ids,
-                   chemical_classification, flavor_descriptors
+                   chemical_classification, flavor_descriptors,
+                   ambiguity_siblings
             FROM mv_chemical_entities WHERE common_name = :name
         """),
         {"name": common_name},
@@ -26,28 +27,58 @@ async def get_metadata(session: AsyncSession, common_name: str) -> dict[str, obj
 
 
 async def get_composition(session: AsyncSession, common_name: str) -> dict[str, object]:
-    """Get foods containing this chemical, split by concentration."""
+    """Get foods containing this chemical, split by concentration.
+
+    Each row's ``ambiguity_siblings`` is scoped to foods that also appear in
+    this chemical's composition. Foods that share a name-cluster globally
+    but have no attestation for this chemical are filtered out so the banner
+    stays consistent with what the page actually shows.
+    """
     with_conc = await session.execute(
         text("""
-            SELECT food_foodatlas_id AS id, food_name AS name,
-                   median_concentration
-            FROM mv_food_chemical_composition
-            WHERE chemical_name = :name AND median_concentration IS NOT NULL
+            WITH chem_foods AS (
+                SELECT food_foodatlas_id AS id
+                FROM mv_food_chemical_composition
+                WHERE chemical_name = :name
+            )
+            SELECT c.food_foodatlas_id AS id, c.food_name AS name,
+                   c.median_concentration,
+                   COALESCE((
+                       SELECT jsonb_agg(s ORDER BY s->>'common_name')
+                       FROM jsonb_array_elements(fe.ambiguity_siblings) s
+                       WHERE s->>'foodatlas_id' IN (SELECT id FROM chem_foods)
+                   ), '[]'::jsonb) AS ambiguity_siblings
+            FROM mv_food_chemical_composition c
+            LEFT JOIN mv_food_entities fe
+                ON fe.foodatlas_id = c.food_foodatlas_id
+            WHERE c.chemical_name = :name AND c.median_concentration IS NOT NULL
         """),
         {"name": common_name},
     )
     without_conc = await session.execute(
         text("""
-            SELECT food_foodatlas_id AS id, food_name AS name,
-                   COALESCE(jsonb_array_length(fdc_evidences), 0)
-                   + COALESCE(jsonb_array_length(foodatlas_evidences), 0)
-                   + COALESCE(jsonb_array_length(dmd_evidences), 0)
-                   AS evidence_count
-            FROM mv_food_chemical_composition
-            WHERE chemical_name = :name AND median_concentration IS NULL
-            ORDER BY COALESCE(jsonb_array_length(fdc_evidences), 0)
-                   + COALESCE(jsonb_array_length(foodatlas_evidences), 0)
-                   + COALESCE(jsonb_array_length(dmd_evidences), 0) DESC
+            WITH chem_foods AS (
+                SELECT food_foodatlas_id AS id
+                FROM mv_food_chemical_composition
+                WHERE chemical_name = :name
+            )
+            SELECT c.food_foodatlas_id AS id, c.food_name AS name,
+                   COALESCE(jsonb_array_length(c.fdc_evidences), 0)
+                   + COALESCE(jsonb_array_length(c.foodatlas_evidences), 0)
+                   + COALESCE(jsonb_array_length(c.dmd_evidences), 0)
+                   AS evidence_count,
+                   COALESCE((
+                       SELECT jsonb_agg(s ORDER BY s->>'common_name')
+                       FROM jsonb_array_elements(fe.ambiguity_siblings) s
+                       WHERE s->>'foodatlas_id' IN (SELECT id FROM chem_foods)
+                   ), '[]'::jsonb) AS ambiguity_siblings
+            FROM mv_food_chemical_composition c
+            LEFT JOIN mv_food_entities fe
+                ON fe.foodatlas_id = c.food_foodatlas_id
+            WHERE c.chemical_name = :name AND c.median_concentration IS NULL
+            ORDER BY COALESCE(jsonb_array_length(c.fdc_evidences), 0)
+                   + COALESCE(jsonb_array_length(c.foodatlas_evidences), 0)
+                   + COALESCE(jsonb_array_length(c.dmd_evidences), 0) DESC
         """),
         {"name": common_name},
     )

--- a/backend/api/src/repositories/disease.py
+++ b/backend/api/src/repositories/disease.py
@@ -13,7 +13,8 @@ async def get_metadata(session: AsyncSession, common_name: str) -> dict[str, obj
     result = await session.execute(
         text("""
             SELECT common_name, foodatlas_id AS id, entity_type,
-                   scientific_name, synonyms, external_ids
+                   scientific_name, synonyms, external_ids,
+                   ambiguity_siblings
             FROM mv_disease_entities WHERE common_name = :name
         """),
         {"name": common_name},
@@ -41,11 +42,23 @@ async def get_correlation(
 
     result = await session.execute(
         text("""
-            SELECT chemical_foodatlas_id AS id, chemical_name AS name,
-                   sources, evidences, evidence_count
-            FROM mv_chemical_disease_correlation
-            WHERE disease_name = :name AND relationship_id = :rel
-            ORDER BY evidence_count DESC
+            WITH disease_chems AS (
+                SELECT chemical_foodatlas_id AS id
+                FROM mv_chemical_disease_correlation
+                WHERE disease_name = :name AND relationship_id = :rel
+            )
+            SELECT c.chemical_foodatlas_id AS id, c.chemical_name AS name,
+                   c.sources, c.evidences, c.evidence_count,
+                   COALESCE((
+                       SELECT jsonb_agg(s ORDER BY s->>'common_name')
+                       FROM jsonb_array_elements(ce.ambiguity_siblings) s
+                       WHERE s->>'foodatlas_id' IN (SELECT id FROM disease_chems)
+                   ), '[]'::jsonb) AS ambiguity_siblings
+            FROM mv_chemical_disease_correlation c
+            LEFT JOIN mv_chemical_entities ce
+                ON ce.foodatlas_id = c.chemical_foodatlas_id
+            WHERE c.disease_name = :name AND c.relationship_id = :rel
+            ORDER BY c.evidence_count DESC
             OFFSET :offset ROWS FETCH FIRST :limit ROWS ONLY
         """),
         {

--- a/backend/api/src/repositories/food.py
+++ b/backend/api/src/repositories/food.py
@@ -33,7 +33,8 @@ async def get_metadata(session: AsyncSession, common_name: str) -> dict[str, obj
     result = await session.execute(
         text("""
             SELECT common_name, foodatlas_id AS id, entity_type,
-                   scientific_name, synonyms, external_ids, food_classification
+                   scientific_name, synonyms, external_ids, food_classification,
+                   ambiguity_siblings
             FROM mv_food_entities WHERE common_name = :name
         """),
         {"name": common_name},

--- a/backend/db/src/etl/materializer.py
+++ b/backend/db/src/etl/materializer.py
@@ -1,6 +1,8 @@
 """Materialize denormalized API tables from base tables."""
 
+import json
 import logging
+from collections import defaultdict
 
 import pandas as pd
 from sqlalchemy import text
@@ -36,6 +38,12 @@ def _materialize_entity_views(conn: Connection) -> None:
     """Compute mv_food_entities, mv_chemical_entities, mv_disease_entities."""
     entities = pd.read_sql(text("SELECT * FROM base_entities"), conn)
     triplets = pd.read_sql(text("SELECT * FROM base_triplets"), conn)
+    attestations = pd.read_sql(
+        text("SELECT head_candidates, tail_candidates FROM base_attestations"), conn
+    )
+
+    sibling_map = _build_sibling_map(attestations)
+    name_map = entities.set_index("foodatlas_id")["common_name"].to_dict()
 
     r1 = triplets[triplets["relationship_id"] == "r1"]
     r3r4 = triplets[triplets["relationship_id"].isin(["r3", "r4"])]
@@ -47,7 +55,12 @@ def _materialize_entity_views(conn: Connection) -> None:
     foods["food_classification"] = foods["attributes"].apply(
         lambda a: a.get("food_groups", []) if isinstance(a, dict) else []
     )
-    _insert_mv_entities(conn, "mv_food_entities", foods, ["food_classification"])
+    foods["ambiguity_siblings"] = _render_siblings_col(
+        foods["foodatlas_id"], sibling_map, name_map
+    )
+    _insert_mv_entities(
+        conn, "mv_food_entities", foods, ["food_classification", "ambiguity_siblings"]
+    )
 
     # Include chemicals from food composition (r1), disease correlations (r3/r4),
     # and their IS_A ancestors (so ancestor pages have metadata).
@@ -65,11 +78,14 @@ def _materialize_entity_views(conn: Connection) -> None:
     chemicals["flavor_descriptors"] = chemicals["attributes"].apply(
         lambda a: a.get("flavor_descriptors", []) if isinstance(a, dict) else []
     )
+    chemicals["ambiguity_siblings"] = _render_siblings_col(
+        chemicals["foodatlas_id"], sibling_map, name_map
+    )
     _insert_mv_entities(
         conn,
         "mv_chemical_entities",
         chemicals,
-        ["chemical_classification", "flavor_descriptors"],
+        ["chemical_classification", "flavor_descriptors", "ambiguity_siblings"],
     )
 
     relevant_disease_ids = set(r3r4["tail_id"])
@@ -77,7 +93,10 @@ def _materialize_entity_views(conn: Connection) -> None:
         (entities["entity_type"] == "disease")
         & (entities["foodatlas_id"].isin(relevant_disease_ids))
     ].copy()
-    _insert_mv_entities(conn, "mv_disease_entities", diseases, [])
+    diseases["ambiguity_siblings"] = _render_siblings_col(
+        diseases["foodatlas_id"], sibling_map, name_map
+    )
+    _insert_mv_entities(conn, "mv_disease_entities", diseases, ["ambiguity_siblings"])
 
     logger.info(
         "Entity views: %d foods, %d chemicals, %d diseases",
@@ -127,3 +146,75 @@ def _insert_mv_entities(
         "external_ids",
     ]
     bulk_copy(conn, table_name, df, base_cols + extra_cols)
+
+
+def _build_sibling_map(attestations: pd.DataFrame) -> dict[str, set[str]]:
+    """Build a unified siblings map from attestation candidates.
+
+    Candidates appear on both head (r1 foods / r3r4 chemicals) and tail
+    (r1 chemicals / r3r4 diseases) positions. The co-occurrence semantics
+    are identical across positions: two entities that resolved from the
+    same raw name are ambiguous. We merge both columns into one adjacency
+    graph, then symmetrize via connected components so every entity in an
+    entangled cluster sees every other. Entity-type invariants hold
+    automatically because the LUT returns same-type candidates per raw
+    name, so clusters never cross entity types.
+    """
+    combined = pd.concat(
+        [attestations["head_candidates"], attestations["tail_candidates"]],
+        ignore_index=True,
+    )
+    return _components_from_candidates(combined)
+
+
+def _components_from_candidates(
+    candidates_col: pd.Series,
+) -> dict[str, set[str]]:
+    """Build adjacency from pairwise co-occurrence, then expand to components."""
+    adjacency: dict[str, set[str]] = defaultdict(set)
+    for cands in candidates_col:
+        if not hasattr(cands, "__len__") or len(cands) <= 1:
+            continue
+        ids = list(cands)
+        for i in ids:
+            adjacency[i].update(x for x in ids if x != i)
+
+    siblings: dict[str, set[str]] = {}
+    seen: set[str] = set()
+    for start in adjacency:
+        if start in seen:
+            continue
+        # BFS over the connected component
+        component: set[str] = set()
+        stack = [start]
+        while stack:
+            node = stack.pop()
+            if node in component:
+                continue
+            component.add(node)
+            stack.extend(adjacency.get(node, set()))
+        for node in component:
+            siblings[node] = component - {node}
+        seen |= component
+    return siblings
+
+
+def _render_siblings_col(
+    foodatlas_ids: pd.Series,
+    sibling_map: dict[str, set[str]],
+    name_map: dict[str, str],
+) -> list[str]:
+    """Render each entity's sibling list as a JSON string ready for bulk_copy.
+
+    Produces JSON strings because bulk_copy routes dicts/lists through a
+    different serializer; pre-stringifying avoids ambiguity at write time.
+    """
+    out: list[str] = []
+    for eid in foodatlas_ids:
+        siblings = sibling_map.get(eid, set())
+        payload = [
+            {"foodatlas_id": sid, "common_name": name_map.get(sid, sid)}
+            for sid in sorted(siblings)
+        ]
+        out.append(json.dumps(payload))
+    return out

--- a/backend/db/src/etl/materializer_composition.py
+++ b/backend/db/src/etl/materializer_composition.py
@@ -73,7 +73,7 @@ def materialize_food_chemical_composition(conn: Connection) -> None:
     )
 
     # Pre-build extraction dicts for all rows at once.
-    merged["_extraction"] = _build_extractions_vectorized(merged)
+    merged["_extraction"] = _build_extractions_vectorized(merged, name_map)
     merged["_ref"] = merged["reference"].apply(
         lambda x: x if isinstance(x, dict) else {}
     )
@@ -134,8 +134,16 @@ def materialize_food_chemical_composition(conn: Connection) -> None:
     logger.info("Food-chemical composition: %d rows", len(result))
 
 
-def _build_extractions_vectorized(df: pd.DataFrame) -> pd.Series:
-    """Pre-build extraction dicts for all rows."""
+def _build_extractions_vectorized(
+    df: pd.DataFrame, name_map: dict[str, str] | None = None
+) -> pd.Series:
+    """Pre-build extraction dicts for all rows.
+
+    ``name_map`` maps foodatlas_id → common_name; when provided and an
+    attestation's ``head_candidates`` / ``tail_candidates`` lists have
+    length > 1, the extraction dict exposes them as readable names under
+    ``food_candidates`` / ``chemical_candidates``.
+    """
     conc_raw = (
         df["conc_value_raw"].fillna("").astype(str)
         + " "
@@ -146,22 +154,21 @@ def _build_extractions_vectorized(df: pd.DataFrame) -> pd.Series:
     conc_vals = [v if pd.notna(v) else None for v in df["conc_value"]]
     conc_units = df["conc_unit"].fillna("")
 
+    head_cands = _candidate_names(df.get("head_candidates"), name_map, len(df))
+    tail_cands = _candidate_names(df.get("tail_candidates"), name_map, len(df))
+
     return pd.Series(
         [
-            {
-                "extracted_food_name": sf,
-                "extracted_chemical_name": sc,
-                "extracted_concentration": cr,
-                "converted_concentration": {"value": cv, "unit": cu},
-                "method": src,
-            }
-            for sf, sc, cr, cv, cu, src in zip(
+            _make_extraction(sf, sc, cr, cv, cu, src, hc, tc)
+            for sf, sc, cr, cv, cu, src, hc, tc in zip(
                 df["show_food"],
                 df["show_chem"],
                 conc_raw,
                 conc_vals,
                 conc_units,
                 df["source"],
+                head_cands,
+                tail_cands,
                 strict=False,
             )
         ],
@@ -169,13 +176,64 @@ def _build_extractions_vectorized(df: pd.DataFrame) -> pd.Series:
     )
 
 
-def _build_evidence_json(group: pd.DataFrame) -> dict[str, list | None]:
+def _make_extraction(
+    sf: str,
+    sc: str,
+    cr: str | None,
+    cv: float | None,
+    cu: str,
+    src: str,
+    head_candidates: list[str] | None,
+    tail_candidates: list[str] | None,
+) -> dict:
+    extraction: dict = {
+        "extracted_food_name": sf,
+        "extracted_chemical_name": sc,
+        "extracted_concentration": cr,
+        "converted_concentration": {"value": cv, "unit": cu},
+        "method": src,
+    }
+    if head_candidates is not None:
+        extraction["food_candidates"] = head_candidates
+    if tail_candidates is not None:
+        extraction["chemical_candidates"] = tail_candidates
+    return extraction
+
+
+def _candidate_names(
+    col: pd.Series | None, name_map: dict[str, str] | None, n_rows: int
+) -> list[list[str] | None]:
+    """Map each row's candidate id list to names; None when not ambiguous.
+
+    A row is ambiguous when its candidate list has more than one entry.
+    Unknown ids (missing from ``name_map``) are kept verbatim so we never
+    silently drop them.
+    """
+    if col is None or name_map is None:
+        return [None] * n_rows
+    out: list[list[str] | None] = []
+    for ids in col:
+        if (
+            ids is None
+            or (isinstance(ids, float) and pd.isna(ids))
+            or not hasattr(ids, "__len__")
+            or len(ids) <= 1
+        ):
+            out.append(None)
+            continue
+        out.append([name_map.get(i, i) for i in ids])
+    return out
+
+
+def _build_evidence_json(
+    group: pd.DataFrame, name_map: dict[str, str] | None = None
+) -> dict[str, list | None]:
     """Build evidence JSON from a raw grouped DataFrame.
 
     Pre-computes extraction dicts and delegates to the optimized path.
     """
     group = group.copy()
-    group["_extraction"] = _build_extractions_vectorized(group)
+    group["_extraction"] = _build_extractions_vectorized(group, name_map)
     group["_ref"] = group["reference"].apply(lambda x: x if isinstance(x, dict) else {})
     return _build_evidence_from_precomputed(group)
 

--- a/backend/db/src/etl/parquet_reader.py
+++ b/backend/db/src/etl/parquet_reader.py
@@ -12,8 +12,16 @@ def _parse_json_col(series: pd.Series) -> pd.Series:
 
 
 def _ensure_list_col(series: pd.Series) -> pd.Series:
-    """Ensure column values are lists (not NaN or strings)."""
-    return series.apply(lambda x: x if isinstance(x, list) else [])
+    """Ensure column values are lists (not NaN, strings, or numpy arrays)."""
+
+    def _to_list(x: object) -> list:
+        if isinstance(x, list):
+            return x
+        if hasattr(x, "tolist"):  # numpy array or pandas-compatible sequence
+            return list(x.tolist())
+        return []
+
+    return series.apply(_to_list)
 
 
 def read_entities(kg_dir: Path) -> pd.DataFrame:

--- a/backend/db/src/models/views.py
+++ b/backend/db/src/models/views.py
@@ -25,6 +25,7 @@ class MVFoodEntity(Base):
     food_classification: Mapped[list[str]] = mapped_column(
         ARRAY(Text), server_default="{}"
     )
+    ambiguity_siblings: Mapped[list] = mapped_column(JSONB, server_default="[]")
 
     __table_args__ = (Index("ix_mv_food_common_name", "common_name"),)
 
@@ -46,6 +47,7 @@ class MVChemicalEntity(Base):
     flavor_descriptors: Mapped[list[str]] = mapped_column(
         ARRAY(Text), server_default="{}"
     )
+    ambiguity_siblings: Mapped[list] = mapped_column(JSONB, server_default="[]")
 
     __table_args__ = (Index("ix_mv_chem_common_name", "common_name"),)
 
@@ -61,6 +63,7 @@ class MVDiseaseEntity(Base):
     scientific_name: Mapped[str] = mapped_column(Text, server_default="")
     synonyms: Mapped[list[str]] = mapped_column(ARRAY(Text), server_default="{}")
     external_ids: Mapped[dict] = mapped_column(JSONB, server_default="{}")
+    ambiguity_siblings: Mapped[list] = mapped_column(JSONB, server_default="[]")
 
     __table_args__ = (Index("ix_mv_disease_common_name", "common_name"),)
 

--- a/backend/db/tests/test_materializer.py
+++ b/backend/db/tests/test_materializer.py
@@ -1,9 +1,15 @@
 """Tests for materializer helper functions."""
 
+import json
 from unittest.mock import MagicMock
 
 import pandas as pd
-from src.etl.materializer import _collect_ancestors, _insert_mv_entities
+from src.etl.materializer import (
+    _build_sibling_map,
+    _collect_ancestors,
+    _insert_mv_entities,
+    _render_siblings_col,
+)
 from src.etl.materializer_composition import (
     _add_foodatlas_evidence,
     _compute_median,
@@ -165,6 +171,102 @@ class TestInsertMvEntities:
             cols = mock_copy.call_args[0][3]
             assert len(cols) == 6
             assert "external_ids" in cols
+
+
+class TestBuildSiblingMap:
+    """Test _build_sibling_map from ambiguous attestation candidates."""
+
+    def test_empty_returns_empty(self):
+        att = pd.DataFrame({"head_candidates": [], "tail_candidates": []})
+        assert _build_sibling_map(att) == {}
+
+    def test_unambiguous_ignored(self):
+        att = pd.DataFrame({"head_candidates": [["a"]], "tail_candidates": [["b"]]})
+        assert _build_sibling_map(att) == {}
+
+    def test_ambiguous_head_builds_pairwise(self):
+        att = pd.DataFrame(
+            {
+                "head_candidates": [["a", "b", "c"]],
+                "tail_candidates": [["t"]],
+            }
+        )
+        s = _build_sibling_map(att)
+        assert s["a"] == {"b", "c"}
+        assert s["b"] == {"a", "c"}
+        assert s["c"] == {"a", "b"}
+
+    def test_ambiguous_tail_builds_pairwise(self):
+        att = pd.DataFrame(
+            {
+                "head_candidates": [["h"]],
+                "tail_candidates": [["x", "y"]],
+            }
+        )
+        s = _build_sibling_map(att)
+        assert s["x"] == {"y"}
+        assert s["y"] == {"x"}
+
+    def test_symmetric_via_connected_components(self):
+        """b and c never co-occur directly but are linked via a -> symmetric."""
+        att = pd.DataFrame(
+            {
+                "head_candidates": [["a", "b"], ["a", "c"]],
+                "tail_candidates": [["t"], ["t"]],
+            }
+        )
+        s = _build_sibling_map(att)
+        # Every entity in the cluster sees every other
+        assert s["a"] == {"b", "c"}
+        assert s["b"] == {"a", "c"}
+        assert s["c"] == {"a", "b"}
+
+    def test_separate_components_stay_isolated(self):
+        att = pd.DataFrame(
+            {
+                "head_candidates": [["a", "b"], ["c", "d"]],
+                "tail_candidates": [["t"], ["t"]],
+            }
+        )
+        s = _build_sibling_map(att)
+        assert s["a"] == {"b"}
+        assert s["c"] == {"d"}
+
+    def test_head_and_tail_merged(self):
+        """Chemical appears as r1 tail and r3r4 head -> unified cluster."""
+        att = pd.DataFrame(
+            {
+                "head_candidates": [["food1"], ["chem1", "chem2"]],
+                "tail_candidates": [["chem1", "chem2"], ["disease1"]],
+            }
+        )
+        s = _build_sibling_map(att)
+        # chem1 and chem2 linked via both positions
+        assert s["chem1"] == {"chem2"}
+        assert s["chem2"] == {"chem1"}
+
+
+class TestRenderSiblingsCol:
+    """Test _render_siblings_col JSON serialization."""
+
+    def test_empty_siblings_yields_empty_list(self):
+        ids = pd.Series(["e1"])
+        result = _render_siblings_col(ids, {}, {"e1": "apple"})
+        assert result == ["[]"]
+
+    def test_siblings_mapped_to_names(self):
+        ids = pd.Series(["e1"])
+        sibling_map = {"e1": {"e2", "e3"}}
+        name_map = {"e1": "apple", "e2": "apricot", "e3": "pear"}
+        result = json.loads(_render_siblings_col(ids, sibling_map, name_map)[0])
+        assert {r["foodatlas_id"] for r in result} == {"e2", "e3"}
+        assert {r["common_name"] for r in result} == {"apricot", "pear"}
+
+    def test_unknown_id_falls_back_to_id(self):
+        ids = pd.Series(["e1"])
+        sibling_map = {"e1": {"e_missing"}}
+        result = json.loads(_render_siblings_col(ids, sibling_map, {})[0])
+        assert result[0]["common_name"] == "e_missing"
 
 
 class TestCollectAncestors:

--- a/backend/db/tests/test_materializer_helpers.py
+++ b/backend/db/tests/test_materializer_helpers.py
@@ -282,6 +282,77 @@ class TestBuildEvidenceJson:
         assert result["foodatlas"][0]["reference"]["url"] == ""
 
 
+class TestAmbiguousCandidates:
+    """Verify that multi-valued head/tail_candidates surface as names."""
+
+    def _make_group(self, head_cands, tail_cands):
+        return pd.DataFrame(
+            [
+                {
+                    "source": "lit2kg",
+                    "reference": {"pmcid": "PMC1", "text": "t"},
+                    "conc_value": 10.0,
+                    "conc_unit": "mg/100g",
+                    "conc_value_raw": "10",
+                    "conc_unit_raw": "mg/100g",
+                    "show_food": "apple",
+                    "show_chem": "quercetin",
+                    "head_candidates": head_cands,
+                    "tail_candidates": tail_cands,
+                }
+            ]
+        )
+
+    def test_ambiguous_head_emits_food_candidates(self):
+        group = self._make_group(["e_apple", "e_apricot"], ["e_quercetin"])
+        name_map = {
+            "e_apple": "apple",
+            "e_apricot": "apricot",
+            "e_quercetin": "quercetin",
+        }
+        result = _build_evidence_json(group, name_map)
+        ext = result["foodatlas"][0]["extraction"][0]
+        assert ext["food_candidates"] == ["apple", "apricot"]
+        assert "chemical_candidates" not in ext
+
+    def test_ambiguous_tail_emits_chemical_candidates(self):
+        group = self._make_group(["e_apple"], ["e_quercetin", "e_quercetin_glucoside"])
+        name_map = {
+            "e_apple": "apple",
+            "e_quercetin": "quercetin",
+            "e_quercetin_glucoside": "quercetin-3-glucoside",
+        }
+        result = _build_evidence_json(group, name_map)
+        ext = result["foodatlas"][0]["extraction"][0]
+        assert ext["chemical_candidates"] == [
+            "quercetin",
+            "quercetin-3-glucoside",
+        ]
+        assert "food_candidates" not in ext
+
+    def test_unambiguous_emits_neither(self):
+        group = self._make_group(["e_apple"], ["e_quercetin"])
+        name_map = {"e_apple": "apple", "e_quercetin": "quercetin"}
+        result = _build_evidence_json(group, name_map)
+        ext = result["foodatlas"][0]["extraction"][0]
+        assert "food_candidates" not in ext
+        assert "chemical_candidates" not in ext
+
+    def test_unknown_id_kept_verbatim(self):
+        group = self._make_group(["e_apple", "e_missing"], ["e_quercetin"])
+        name_map = {"e_apple": "apple", "e_quercetin": "quercetin"}
+        result = _build_evidence_json(group, name_map)
+        ext = result["foodatlas"][0]["extraction"][0]
+        assert ext["food_candidates"] == ["apple", "e_missing"]
+
+    def test_no_name_map_skips_candidates(self):
+        group = self._make_group(["e_apple", "e_apricot"], ["e_quercetin"])
+        result = _build_evidence_json(group)
+        ext = result["foodatlas"][0]["extraction"][0]
+        assert "food_candidates" not in ext
+        assert "chemical_candidates" not in ext
+
+
 class TestMaterializeCompositionEmpty:
     """Test materialize_food_chemical_composition with empty data."""
 

--- a/frontend/components/basic/Ambiguity.tsx
+++ b/frontend/components/basic/Ambiguity.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { MdCallSplit } from "react-icons/md";
+import { twMerge } from "tailwind-merge";
+
+import Tooltip from "@/components/basic/Tooltip";
+
+export const isAmbiguous = (
+  foodCandidates?: string[] | null,
+  chemicalCandidates?: string[] | null
+) =>
+  (foodCandidates?.length ?? 0) > 1 || (chemicalCandidates?.length ?? 0) > 1;
+
+interface AmbiguityTooltipContentProps {
+  foodCandidates?: string[] | null;
+  chemicalCandidates?: string[] | null;
+}
+
+const AmbiguityTooltipContent = ({
+  foodCandidates,
+  chemicalCandidates,
+}: AmbiguityTooltipContentProps) => {
+  const foodAmbiguous = (foodCandidates?.length ?? 0) > 1;
+  const chemicalAmbiguous = (chemicalCandidates?.length ?? 0) > 1;
+  return (
+    <div className="flex flex-col gap-1.5 max-w-xs whitespace-normal">
+      {foodAmbiguous && (
+        <div>
+          <span className="text-amber-400 font-semibold">Ambiguous food</span>
+          <span className="text-light-300">
+            {" "}— could also refer to:{" "}
+          </span>
+          <span className="capitalize">{foodCandidates!.join(", ")}</span>
+        </div>
+      )}
+      {chemicalAmbiguous && (
+        <div>
+          <span className="text-amber-400 font-semibold">
+            Ambiguous chemical
+          </span>
+          <span className="text-light-300">{" "}— could also be:{" "}</span>
+          <span className="capitalize">{chemicalCandidates!.join(", ")}</span>
+        </div>
+      )}
+    </div>
+  );
+};
+
+interface AmbiguityIconProps {
+  foodCandidates?: string[] | null;
+  chemicalCandidates?: string[] | null;
+  className?: string;
+}
+
+export const AmbiguityIcon = ({
+  foodCandidates,
+  chemicalCandidates,
+  className,
+}: AmbiguityIconProps) => {
+  if (!isAmbiguous(foodCandidates, chemicalCandidates)) return null;
+  return (
+    <Tooltip
+      content={
+        <AmbiguityTooltipContent
+          foodCandidates={foodCandidates}
+          chemicalCandidates={chemicalCandidates}
+        />
+      }
+    >
+      <MdCallSplit
+        aria-label="Ambiguous data point"
+        className={twMerge("text-amber-500 size-4 rotate-90", className)}
+      />
+    </Tooltip>
+  );
+};
+
+interface AmbiguityBadgeProps {
+  ambiguousCount: number;
+  totalCount: number;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  className?: string;
+}
+
+export const AmbiguityBadge = ({
+  ambiguousCount,
+  totalCount,
+  onClick,
+  className,
+}: AmbiguityBadgeProps) => {
+  if (ambiguousCount <= 0) return null;
+  const fullyAmbiguous = ambiguousCount === totalCount;
+  return (
+    <Tooltip
+      content={
+        <span className="whitespace-normal">
+          {fullyAmbiguous
+            ? `All ${totalCount} data point${totalCount === 1 ? " is" : "s are"} ambiguous.`
+            : `${ambiguousCount} of ${totalCount} data points ${ambiguousCount === 1 ? "is" : "are"} ambiguous.`}{" "}
+          Click to review.
+        </span>
+      }
+    >
+      <button
+        type="button"
+        onClick={onClick}
+        className={twMerge(
+          "inline-flex items-center gap-1 rounded-full border px-1.5 py-[0.1rem] text-[0.6rem] font-mono font-medium transition-colors",
+          fullyAmbiguous
+            ? "text-amber-400 border-amber-500 bg-amber-500/15 hover:bg-amber-500/25"
+            : "text-amber-400/90 border-amber-500/60 bg-amber-500/10 hover:bg-amber-500/20",
+          className
+        )}
+      >
+        <MdCallSplit className="size-3 rotate-90" />
+        {ambiguousCount}
+      </button>
+    </Tooltip>
+  );
+};
+
+AmbiguityIcon.displayName = "AmbiguityIcon";
+AmbiguityBadge.displayName = "AmbiguityBadge";

--- a/frontend/components/basic/EntitySiblingIcon.tsx
+++ b/frontend/components/basic/EntitySiblingIcon.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { MdCallSplit } from "react-icons/md";
+import { twMerge } from "tailwind-merge";
+
+import Tooltip from "@/components/basic/Tooltip";
+import { AmbiguitySibling } from "@/types/Metadata";
+
+interface EntitySiblingIconProps {
+  siblings: AmbiguitySibling[] | null | undefined;
+  entityKind: "food" | "chemical";
+  className?: string;
+}
+
+const EntitySiblingIcon = ({
+  siblings,
+  entityKind,
+  className,
+}: EntitySiblingIconProps) => {
+  if (!Array.isArray(siblings) || siblings.length === 0) return null;
+  const names = siblings.map((s) => s.common_name).join(", ");
+  return (
+    <Tooltip
+      content={
+        <span className="whitespace-normal max-w-xs block">
+          <span className="text-amber-400 font-semibold">
+            Ambiguous {entityKind}
+          </span>
+          <span className="text-light-300">{" "}— this name also refers to:{" "}</span>
+          <span className="capitalize">{names}</span>
+        </span>
+      }
+    >
+      <MdCallSplit
+        aria-label={`Ambiguous ${entityKind}`}
+        className={twMerge("text-amber-500 size-4 rotate-90", className)}
+      />
+    </Tooltip>
+  );
+};
+
+EntitySiblingIcon.displayName = "EntitySiblingIcon";
+
+export default EntitySiblingIcon;

--- a/frontend/components/entities/CorrelationTable.tsx
+++ b/frontend/components/entities/CorrelationTable.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { MdAdd, MdErrorOutline, MdInfoOutline, MdRemove } from "react-icons/md";
 
 import Button from "@/components/basic/Button";
+import EntitySiblingIcon from "@/components/basic/EntitySiblingIcon";
 import Link from "@/components/basic/Link";
 import LoadingCard from "@/components/basic/LoadingCard";
 import Pagination from "@/components/basic/Pagination";
@@ -171,6 +172,12 @@ const CorrelationTable = ({
                         >
                           {row.name}
                         </Link>
+                        {tableLocation !== "chemical" && (
+                          <EntitySiblingIcon
+                            siblings={row.ambiguity_siblings}
+                            entityKind="chemical"
+                          />
+                        )}
                       </div>
                     </td>
                     {/* evidence */}

--- a/frontend/components/entities/EntityAmbiguityBanner.tsx
+++ b/frontend/components/entities/EntityAmbiguityBanner.tsx
@@ -1,0 +1,51 @@
+import { MdInfoOutline } from "react-icons/md";
+import { Fragment } from "react";
+
+import Link from "@/components/basic/Link";
+import { AmbiguitySibling } from "@/types/Metadata";
+import { encodeSpace } from "@/utils/utils";
+
+interface EntityAmbiguityBannerProps {
+  entityType: "food" | "chemical" | "disease";
+  siblings: AmbiguitySibling[] | undefined | null;
+}
+
+const EntityAmbiguityBanner = ({
+  entityType,
+  siblings,
+}: EntityAmbiguityBannerProps) => {
+  if (!Array.isArray(siblings) || siblings.length === 0) return null;
+  return (
+    <div
+      role="note"
+      className="mt-4 flex gap-2 items-start rounded-md border border-amber-500/40 bg-amber-500/10 px-3 py-2 text-sm text-amber-100"
+    >
+      <MdInfoOutline className="size-4 mt-0.5 text-amber-400 flex-shrink-0" />
+      <p className="leading-snug">
+        This name is also used for{" "}
+        {siblings.map((s, i) => (
+          <Fragment key={s.foodatlas_id}>
+            <Link
+              href={`/${entityType}/${encodeURIComponent(
+                encodeSpace(s.common_name)
+              )}`}
+              isExternal={false}
+            >
+              <span className="capitalize">{s.common_name}</span>
+            </Link>
+            {i < siblings.length - 2
+              ? ", "
+              : i === siblings.length - 2
+              ? ", and "
+              : ""}
+          </Fragment>
+        ))}
+        . You may be looking for one of those.
+      </p>
+    </div>
+  );
+};
+
+EntityAmbiguityBanner.displayName = "EntityAmbiguityBanner";
+
+export default EntityAmbiguityBanner;

--- a/frontend/components/entities/HeaderSection.tsx
+++ b/frontend/components/entities/HeaderSection.tsx
@@ -3,6 +3,7 @@ import FoodIcon from "@/components/icons/FoodIcon";
 import ChemicalIcon from "@/components/icons/ChemicalIcon";
 import DiseaseIcon from "@/components/icons/DiseaseIcon";
 import Heading from "@/components/basic/Heading";
+import EntityAmbiguityBanner from "@/components/entities/EntityAmbiguityBanner";
 import { getMetaData } from "@/utils/fetching";
 
 const colorScheme = {
@@ -54,6 +55,11 @@ const HeaderSection = async ({
           {commonName}
         </Heading>
       </div>
+      {/* ambiguity banner */}
+      <EntityAmbiguityBanner
+        entityType={entityType}
+        siblings={data?.ambiguity_siblings}
+      />
     </div>
   );
 };

--- a/frontend/components/entities/chemical/ConcentrationCompositionPlot.tsx
+++ b/frontend/components/entities/chemical/ConcentrationCompositionPlot.tsx
@@ -6,6 +6,7 @@ import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
 import {
   MdArrowDownward,
   MdArrowUpward,
+  MdCallSplit,
   MdInfo,
   MdInfoOutline,
   MdKeyboardArrowDown,
@@ -27,6 +28,8 @@ import {
   NameType,
 } from "recharts/types/component/DefaultTooltipContent";
 import Card from "@/components/basic/Card";
+import EntitySiblingIcon from "@/components/basic/EntitySiblingIcon";
+import { AmbiguitySibling } from "@/types/Metadata";
 import { encodeSpace, formatConcentrationValueAlt } from "@/utils/utils";
 
 const BAR_HEIGHT = 28;
@@ -37,13 +40,19 @@ interface DotPlotProps {
         id: string;
         name: string;
         median_concentration: { value: number; unit: string };
+        ambiguity_siblings?: AmbiguitySibling[];
       }[]
     | undefined
     | null;
   chemicalName?: string;
 }
 
-type SortedData = { food: string; value: any; id: string };
+type SortedData = {
+  food: string;
+  value: any;
+  id: string;
+  ambiguity_siblings?: AmbiguitySibling[];
+};
 
 const ConcentrationCompositionPlot = ({ data, chemicalName }: DotPlotProps) => {
   const router = useRouter();
@@ -61,6 +70,7 @@ const ConcentrationCompositionPlot = ({ data, chemicalName }: DotPlotProps) => {
         food: row.name,
         value: row.median_concentration?.value ?? 0,
         id: row.id,
+        ambiguity_siblings: row.ambiguity_siblings,
       }));
 
     const sortedData = [...d].sort((a, b) => {
@@ -89,13 +99,26 @@ const ConcentrationCompositionPlot = ({ data, chemicalName }: DotPlotProps) => {
     label,
   }: TooltipProps<ValueType, NameType>) => {
     if (active) {
+      const siblings = (payload?.[0]?.payload?.ambiguity_siblings ??
+        []) as AmbiguitySibling[];
       return (
-        <div className="border border-light-50/5 bg-light-800 p-3 rounded-lg text-xs flex flex-col text-light-50">
+        <div className="border border-light-50/5 bg-light-800 p-3 rounded-lg text-xs flex flex-col gap-1 text-light-50 max-w-xs">
           <span className="capitalize font-bold">{label}</span>
           <span>
             {formatConcentrationValueAlt(payload?.[0]?.value as number)}{" "}
             {payload?.[0]?.unit}
           </span>
+          {siblings.length > 0 && (
+            <span className="text-amber-400 leading-snug whitespace-normal">
+              <span className="font-semibold">Ambiguous food</span>
+              <span className="text-light-300">
+                {" "}— also refers to:{" "}
+              </span>
+              <span className="capitalize">
+                {siblings.map((s) => s.common_name).join(", ")}
+              </span>
+            </span>
+          )}
         </div>
       );
     }
@@ -103,10 +126,14 @@ const ConcentrationCompositionPlot = ({ data, chemicalName }: DotPlotProps) => {
 
   // custom label on bars
   const CustomLabel = (props: any) => {
-    const { x, y, width, height, value } = props;
+    const { x, y, width, height, value, index } = props;
+    const isAmbiguous =
+      (sortedData[index]?.ambiguity_siblings?.length ?? 0) > 0;
 
     const fontSize = 16;
     const offset = 4;
+    const iconSize = 16;
+    const textOffset = isAmbiguous ? offset + iconSize + 2 : offset;
     // empirical correction so the thing looks like it's in the middle (not caring about the baseline)
     const baselineCorrection = 2.1;
 
@@ -124,8 +151,18 @@ const ConcentrationCompositionPlot = ({ data, chemicalName }: DotPlotProps) => {
           </filter>
         </defs>
         <g>
+          {isAmbiguous && (
+            <MdCallSplit
+              x={x + offset}
+              y={y + (height - iconSize) / 2}
+              width={iconSize}
+              height={iconSize}
+              color="#f59e0b"
+              style={{ transform: "rotate(90deg)", transformOrigin: `${x + offset + iconSize / 2}px ${y + height / 2}px` }}
+            />
+          )}
           <text
-            x={x + offset}
+            x={x + textOffset}
             y={y + height / 2 + fontSize / 2 - baselineCorrection}
             width={width}
             height={height}

--- a/frontend/components/entities/chemical/NoConcentrationComposition.tsx
+++ b/frontend/components/entities/chemical/NoConcentrationComposition.tsx
@@ -5,12 +5,15 @@ import { MdInfoOutline, MdKeyboardArrowDown } from "react-icons/md";
 
 import Link from "@/components/basic/Link";
 import Card from "@/components/basic/Card";
+import EntitySiblingIcon from "@/components/basic/EntitySiblingIcon";
+import { AmbiguitySibling } from "@/types/Metadata";
 import { encodeSpace } from "@/utils/utils";
 
 interface NoConcentrationRow {
   id: string;
   name: string;
   evidence_count: number;
+  ambiguity_siblings?: AmbiguitySibling[];
 }
 
 interface NoConcentrationCompositionProps {
@@ -60,6 +63,10 @@ const NoConcentrationComposition = ({
                   >
                     {row.name}
                   </Link>
+                  <EntitySiblingIcon
+                    siblings={row.ambiguity_siblings}
+                    entityKind="food"
+                  />
                   {row.evidence_count > 0 && (
                     <span className="text-xs text-light-500">
                       ({row.evidence_count})

--- a/frontend/components/entities/food/DmdEvidence.tsx
+++ b/frontend/components/entities/food/DmdEvidence.tsx
@@ -1,6 +1,7 @@
 import Badge from "@/components/basic/Badge";
 import Link from "@/components/basic/Link";
 import Card from "@/components/basic/Card";
+import { AmbiguityIcon } from "@/components/basic/Ambiguity";
 import { FoodEvidence } from "@/types/Evidence";
 import { formatConcentrationValueAlt } from "@/utils/utils";
 
@@ -59,7 +60,12 @@ const DmdEvidence = ({ evidence }: DmdEvidenceProps) => {
                   {extraction.extracted_food_name}
                 </td>
                 <td className="py-2 px-2 break-all">
-                  {extraction.extracted_chemical_name}
+                  <span className="inline-flex items-center gap-1 align-middle">
+                    {extraction.extracted_chemical_name}
+                    <AmbiguityIcon
+                      chemicalCandidates={extraction.chemical_candidates}
+                    />
+                  </span>
                 </td>
                 <td className="py-2 px-2 text-right whitespace-nowrap">
                   {extraction.extracted_concentration ?? "-"}

--- a/frontend/components/entities/food/FdcEvidence.tsx
+++ b/frontend/components/entities/food/FdcEvidence.tsx
@@ -1,6 +1,7 @@
 import Badge from "@/components/basic/Badge";
 import Link from "@/components/basic/Link";
 import Card from "@/components/basic/Card";
+import { AmbiguityIcon } from "@/components/basic/Ambiguity";
 import { FoodEvidence } from "@/types/Evidence";
 import { formatConcentrationValueAlt } from "@/utils/utils";
 
@@ -59,7 +60,12 @@ const FdcEvidence = ({ evidence }: FdcEvidenceProps) => {
                   {extraction.extracted_food_name}
                 </td>
                 <td className="py-2 px-2 break-all">
-                  {extraction.extracted_chemical_name}
+                  <span className="inline-flex items-center gap-1 align-middle">
+                    {extraction.extracted_chemical_name}
+                    <AmbiguityIcon
+                      chemicalCandidates={extraction.chemical_candidates}
+                    />
+                  </span>
                 </td>
                 <td className="py-2 px-2 text-right whitespace-nowrap">
                   {extraction.extracted_concentration ?? "—"}

--- a/frontend/components/entities/food/FoodAtlasEvidence.tsx
+++ b/frontend/components/entities/food/FoodAtlasEvidence.tsx
@@ -1,6 +1,7 @@
 import Link from "@/components/basic/Link";
 import Badge from "@/components/basic/Badge";
 import Card from "@/components/basic/Card";
+import { AmbiguityIcon } from "@/components/basic/Ambiguity";
 import { FoodEvidence } from "@/types/Evidence";
 import { formatConcentrationValueAlt } from "@/utils/utils";
 import { greekVariants, matchesWithGreek } from "@/utils/greekLetters";
@@ -110,7 +111,12 @@ const FoodAtlasEvidence = ({ evidence }: FoodAtlasEvidenceProps) => {
                   {extraction.extracted_food_name}
                 </td>
                 <td className="py-2 px-2 break-all">
-                  {extraction.extracted_chemical_name}
+                  <span className="inline-flex items-center gap-1 align-middle">
+                    {extraction.extracted_chemical_name}
+                    <AmbiguityIcon
+                      chemicalCandidates={extraction.chemical_candidates}
+                    />
+                  </span>
                 </td>
                 <td className="py-2 px-2 text-right whitespace-nowrap">
                   {extraction.extracted_concentration ?? "-"}

--- a/frontend/components/entities/food/FoodCompositionEvidenceModal.tsx
+++ b/frontend/components/entities/food/FoodCompositionEvidenceModal.tsx
@@ -1,8 +1,21 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { MdCallSplit } from "react-icons/md";
+import { twMerge } from "tailwind-merge";
+
 import FoodAtlasEvidence from "@/components/entities/food/FoodAtlasEvidence";
 import FdcEvidence from "@/components/entities/food/FdcEvidence";
 import DmdEvidence from "@/components/entities/food/DmdEvidence";
 import Modal from "@/components/basic/Modal";
-import { FoodEvidence } from "@/types/Evidence";
+import { FoodEvidence, FoodEvidenceExtraction } from "@/types/Evidence";
+
+// On the food page the head (food) side of ambiguity is owned by the entity
+// banner; the modal only surfaces ambiguity on the counterpart (chemical) side.
+const isCounterpartAmbiguous = (ex: FoodEvidenceExtraction): boolean =>
+  (ex.chemical_candidates?.length ?? 0) > 1;
+
+type AmbiguityFilter = "all" | "ambiguous" | "not-ambiguous";
 
 interface FoodCompositionEvidenceModalProps {
   foodName: string;
@@ -10,7 +23,10 @@ interface FoodCompositionEvidenceModalProps {
   evidences: FoodEvidence[] | undefined;
   isOpen: boolean;
   onClose: () => void;
+  initialFilter?: AmbiguityFilter;
 }
+
+const FILTER_ORDER: AmbiguityFilter[] = ["all", "ambiguous", "not-ambiguous"];
 
 const FoodCompositionEvidenceModal = ({
   foodName,
@@ -18,7 +34,21 @@ const FoodCompositionEvidenceModal = ({
   evidences,
   isOpen,
   onClose,
+  initialFilter = "all",
 }: FoodCompositionEvidenceModalProps) => {
+  const [filter, setFilter] = useState<AmbiguityFilter>(initialFilter);
+
+  useEffect(() => {
+    if (isOpen) setFilter(initialFilter);
+  }, [isOpen, initialFilter]);
+
+  const cycleFilter = () => {
+    setFilter((f) => {
+      const idx = FILTER_ORDER.indexOf(f);
+      return FILTER_ORDER[(idx + 1) % FILTER_ORDER.length];
+    });
+  };
+
   // sort all evidences by their highest converted concentration value
   const sortedEvidences = evidences?.slice().sort((a, b) => {
     const maxValueA = Math.max(
@@ -30,6 +60,32 @@ const FoodCompositionEvidenceModal = ({
     return maxValueB - maxValueA; // sort in descending order
   });
 
+  // counts at the evidence ("data point") level — matches the row badge count
+  const totalCount = sortedEvidences?.length ?? 0;
+  const ambiguousCount =
+    sortedEvidences?.filter((ev) =>
+      ev.extraction.some(isCounterpartAmbiguous)
+    ).length ?? 0;
+  const notAmbiguousCount = totalCount - ambiguousCount;
+
+  const displayedEvidences =
+    filter === "ambiguous"
+      ? sortedEvidences?.filter((ev) =>
+          ev.extraction.some(isCounterpartAmbiguous)
+        )
+      : filter === "not-ambiguous"
+      ? sortedEvidences?.filter(
+          (ev) => !ev.extraction.some(isCounterpartAmbiguous)
+        )
+      : sortedEvidences;
+
+  const filterLabel =
+    filter === "all"
+      ? `All (${totalCount})`
+      : filter === "ambiguous"
+      ? `Only ambiguous (${ambiguousCount})`
+      : `Not ambiguous (${notAmbiguousCount})`;
+
   const handleModalClose = () => {
     onClose();
   };
@@ -38,17 +94,38 @@ const FoodCompositionEvidenceModal = ({
     <Modal
       title="Data Points"
       description={
-        <p>
-          The following data points indicate that{" "}
-          <span className="capitalize font-semibold">{foodName}</span> contains{" "}
-          <span className="capitalize font-semibold">{chemicalName}</span>
-        </p>
+        <div className="flex flex-col gap-3">
+          <p>
+            The following data points indicate that{" "}
+            <span className="capitalize font-semibold">{foodName}</span>{" "}
+            contains{" "}
+            <span className="capitalize font-semibold">{chemicalName}</span>
+          </p>
+          {ambiguousCount > 0 && (
+            <button
+              type="button"
+              onClick={cycleFilter}
+              className={twMerge(
+                "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium w-fit transition-colors",
+                filter === "all"
+                  ? "text-light-300 border-light-500 bg-light-500/10 hover:bg-light-500/20"
+                  : filter === "ambiguous"
+                  ? "text-amber-300 border-amber-400 bg-amber-500/20 hover:bg-amber-500/30"
+                  : "text-light-300 border-light-400 bg-light-400/15 hover:bg-light-400/25"
+              )}
+              aria-label="Cycle ambiguity filter"
+            >
+              <MdCallSplit className="size-3.5 rotate-90" />
+              {filterLabel}
+            </button>
+          )}
+        </div>
       }
       isOpen={isOpen}
       onClose={handleModalClose}
     >
       <div className="flex flex-col gap-4">
-        {sortedEvidences?.map((evidence, id) =>
+        {displayedEvidences?.map((evidence, id) =>
           evidence.reference.source_name === "FoodAtlas" ? (
             <FoodAtlasEvidence key={id} evidence={evidence} />
           ) : evidence.reference.source_name === "FDC" ? (

--- a/frontend/components/entities/food/FoodCompositionSection.tsx
+++ b/frontend/components/entities/food/FoodCompositionSection.tsx
@@ -30,6 +30,7 @@ import Link from "@/components/basic/Link";
 import Pagination from "@/components/basic/Pagination";
 import LoadingCard from "@/components/basic/LoadingCard";
 import Heading from "@/components/basic/Heading";
+import { AmbiguityBadge } from "@/components/basic/Ambiguity";
 import FoodCompositionEvidenceModal from "@/components/entities/food/FoodCompositionEvidenceModal";
 import { usePaginations } from "@/context/paginationsContext";
 import { encodeSpace, formatConcentrationValueAlt } from "@/utils/utils";
@@ -106,6 +107,9 @@ const FoodCompositionSection = ({
   });
   const [showAllConcentrations, setShowAllConcentrations] = useState(true);
   const [selectedEvidenceName, setSelectedEvidenceName] = useState("");
+  const [ambiguousFilter, setAmbiguousFilter] = useState<
+    "all" | "ambiguous" | "not-ambiguous"
+  >("all");
   const [sourceCounts, setSourceCounts] = useState<Record<string, number>>({});
   const [classificationFilter, setClassificationFilter] = useState<
     string[]
@@ -214,7 +218,33 @@ const FoodCompositionSection = ({
   ) => {
     event.preventDefault();
     event.stopPropagation();
+    setAmbiguousFilter("all");
     setSelectedEvidenceName(name);
+  };
+
+  // handle ambiguity badge click (opens modal pre-filtered to ambiguous)
+  const handleAmbiguityBadgeClick = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    name: string
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setAmbiguousFilter("ambiguous");
+    setSelectedEvidenceName(name);
+  };
+
+  // count evidences (= "data points") that contain ≥1 chemical-ambiguous
+  // extraction. Food-side ambiguity is surfaced by the page banner instead,
+  // so we intentionally exclude it from the row-level count.
+  const getRowAmbiguousCount = (row: FoodCompositionData) => {
+    const all = [
+      ...(row.foodatlas_evidences ?? []),
+      ...(row.fdc_evidences ?? []),
+      ...(row.dmd_evidences ?? []),
+    ];
+    return all.filter((ev) =>
+      ev.extraction.some((ex) => (ex.chemical_candidates?.length ?? 0) > 1)
+    ).length;
   };
 
   // handle search
@@ -552,7 +582,7 @@ const FoodCompositionSection = ({
                     <tr key={row.id}>
                       {/* name */}
                       <td className="py-3 pr-4">
-                        <div className="flex min-h-12 capitalize items-center">
+                        <div className="flex min-h-12 capitalize items-center gap-2">
                           <Link
                             href={`/chemical/${encodeURIComponent(
                               encodeSpace(row.name)
@@ -561,6 +591,13 @@ const FoodCompositionSection = ({
                           >
                             {row.name}
                           </Link>
+                          <AmbiguityBadge
+                            ambiguousCount={getRowAmbiguousCount(row)}
+                            totalCount={getRowEvidenceCount(row)}
+                            onClick={(e) =>
+                              handleAmbiguityBadgeClick(e, row.name)
+                            }
+                          />
                         </div>
                       </td>
                       {/* classification */}
@@ -667,6 +704,7 @@ const FoodCompositionSection = ({
           })()}
           isOpen={selectedEvidenceName !== ""}
           onClose={() => setSelectedEvidenceName("")}
+          initialFilter={ambiguousFilter}
         />
       </Portal>
     </>

--- a/frontend/types/ChemicalCorrelation.ts
+++ b/frontend/types/ChemicalCorrelation.ts
@@ -1,4 +1,5 @@
 import { Evidence } from "@/types";
+import { AmbiguitySibling } from "@/types/Metadata";
 
 export type ChemicalCorrelation = {
   id: string;
@@ -7,4 +8,5 @@ export type ChemicalCorrelation = {
   source_chemical_foodatlas_id?: string;
   sources: string[];
   evidences: Evidence[];
+  ambiguity_siblings?: AmbiguitySibling[];
 };

--- a/frontend/types/Evidence.ts
+++ b/frontend/types/Evidence.ts
@@ -25,15 +25,19 @@ export type Evidence = {
 //   extracted_chemical: string;
 // };
 
+export type FoodEvidenceExtraction = {
+  extracted_food_name: string | null;
+  extracted_chemical_name: string | null;
+  extracted_concentration: string | null;
+  converted_concentration: Concentration;
+  method: string;
+  food_candidates?: string[] | null;
+  chemical_candidates?: string[] | null;
+};
+
 export type FoodEvidence = {
   premise: string;
-  extraction: {
-    extracted_food_name: string | null;
-    extracted_chemical_name: string | null;
-    extracted_concentration: string | null;
-    converted_concentration: Concentration;
-    method: string;
-  }[];
+  extraction: FoodEvidenceExtraction[];
   reference: {
     id: string;
     source_name: "FoodAtlas" | "FDC" | "DMD";

--- a/frontend/types/Metadata.ts
+++ b/frontend/types/Metadata.ts
@@ -1,5 +1,10 @@
 import { ExternalIds } from "@/types/ExternalIds";
 
+export type AmbiguitySibling = {
+  foodatlas_id: string;
+  common_name: string;
+};
+
 export type Metadata = {
   id: string;
   entity_type: "food" | "chemical" | "disease";
@@ -10,4 +15,5 @@ export type Metadata = {
   chemical_classification?: string[];
   flavor_descriptors?: string[];
   external_ids: ExternalIds;
+  ambiguity_siblings?: AmbiguitySibling[];
 };


### PR DESCRIPTION
## Summary

Surface entity-resolution ambiguity from the KGC pipeline all the way to the UI. Previously, ambiguous attestations (raw names that resolved to multiple entities) were filtered into a sibling parquet and silently dropped on DB load. Now they flow through to the UI with three layers of signal:

- **Page-level banner** under each entity title (Wikipedia-style disambiguation), listing entities that share a name-cluster with the one you're viewing.
- **Row-level ambiguity icons** next to chemical/food/disease listings on cross-entity pages, scoped to the current page's composition/correlation context (no leaks across chemicals).
- **Data-point level icons + badge + 3-state filter** in the food-page evidence modal, showing the specific candidate alternatives per attestation.

## Key changes

### Data pipeline fix
- `parquet_reader._ensure_list_col` was silently replacing every numpy-array candidate column with `[]`, so `base_attestations.head_candidates` / `tail_candidates` were 100% empty. Fixed to convert via `.tolist()`.

### Materializer
- `materializer_composition.py`: emits `food_candidates` / `chemical_candidates` (as readable names) on each extraction dict when the attestation has >1 candidates.
- `materializer.py`: new `_build_sibling_map` + `_components_from_candidates` — unified over head and tail candidates, symmetrized via connected-components BFS so every entity in an entangled cluster sees every other. Output column `ambiguity_siblings` (JSONB) on `mv_food_entities`, `mv_chemical_entities`, `mv_disease_entities`.

### API
- `food/chemical/disease` meta endpoints expose `ambiguity_siblings`.
- `chemical.get_composition` and `disease.get_correlation` use a CTE + `jsonb_agg` to filter each row's siblings to entities also present in this page's listings — prevents cross-chemical leaks in the banner/icons.

### Frontend
- `EntityAmbiguityBanner` — Wikipedia-style disambiguation note under `HeaderSection`.
- `Ambiguity.tsx` — shared icon + tooltip + badge primitives for per-extraction ambiguity on the food page.
- `EntitySiblingIcon` — shared icon for entity-level sibling indication on chemical/disease pages.
- Food page row badge counts only counterpart-side (chemical) ambiguity; head-side is owned by the banner. Modal filter is 3-state (All / Only ambiguous / Not ambiguous).
- Chemical page plot label uses `MdCallSplit` to match list icons; hover tooltip names siblings.
- Disease page correlation table shows sibling icon next to ambiguous chemicals.

### Tests
- `TestBuildSiblingMap` (6 cases): empty, unambiguous, pairwise, symmetric-via-components, separate-components, head+tail merged.
- `TestRenderSiblingsCol` (3 cases): empty → `[]`, id→name mapping, unknown-id fallback.
- `TestAmbiguousCandidates` (5 cases) in `test_materializer_helpers.py`.

## Test plan

- [ ] Run `cd backend/db && uv run python main.py load` to rebuild the DB with the fixed parquet reader and new mv columns.
- [ ] Visit a food page with known ambiguous chemical synonyms (e.g., one with `(R)`/`(S)` isomer siblings) → verify row badge + data-point icons.
- [ ] Visit `/food/milk` and `/food/cow milk (liquid)` → verify the banner shows the other cluster members symmetrically.
- [ ] Visit a chemical page with known ambiguous food candidates → verify list badges and plot label icons; confirm siblings shown are only foods present in that chemical's composition.
- [ ] Visit a disease page → verify no banner (expected: MeSH disease IDs are unique); verify chemical correlation rows show icons when the linked chemical has siblings.