### PR TITLE
fix(downloads): shorten /download fetch TTL from 24h to 5m

### DIFF
--- a/frontend/utils/fetching.ts
+++ b/frontend/utils/fetching.ts
@@ -208,7 +208,7 @@ export async function getDownloadEntries() {
     headers: {
       Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY}`,
     },
-    next: { revalidate: 86400 },
+    next: { revalidate: 300 },
   });
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary

The downloads page's manifest fetch was caching for 86400s (24h). When Vercel rebuilt on the recent dev→main merge, it rendered before the API's new \`/download\` route had fully rolled out via ECS — so it cached a stale "empty manifest" for the full day even though the API soon started returning the real v4.0 entry.

Drop the revalidate window to 300s (5m) so future API-state changes propagate quickly.

## Test plan

- [x] Page is already \`export const dynamic = "force-dynamic"\`, so lowering TTL on the fetch doesn't change steady-state behavior meaningfully — just narrows the stale window after deploys.
- [ ] After merge: Vercel auto-redeploys; confirm v4.0 row renders on https://foodatlas.ai/food-composition-downloads.