### PR TITLE
fix(downloads): shorten /download fetch TTL from 24h to 5m (#134)

### DIFF
--- a/frontend/utils/fetching.ts
+++ b/frontend/utils/fetching.ts
@@ -208,7 +208,7 @@ export async function getDownloadEntries() {
     headers: {
       Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY}`,
     },
-    next: { revalidate: 86400 },
+    next: { revalidate: 300 },
   });
 
   if (!response.ok) {


### PR DESCRIPTION
The downloads page's fetch of the bundle manifest was caching for 86400s. Combined with a deploy sequence where Vercel rebuilt before the API's new /download route was live, this left a stale "empty manifest" response in Vercel's cache for a full day even though the API had since started returning real data.

Drop the revalidate window to 300s so any future API-state change (new release published, region changed, etc.) heals in minutes instead of a day.