### PR TITLE
Accessibility fixes (#138)

### DIFF
--- a/frontend/app/(everything-else)/contact/page.tsx
+++ b/frontend/app/(everything-else)/contact/page.tsx
@@ -1,6 +1,14 @@
+import { Metadata } from "next";
+
 import Heading from "@/components/basic/Heading";
 import SubHeading from "@/components/basic/SubHeading";
 import ContactForm from "@/components/contact/ContactForm";
+
+export const metadata: Metadata = {
+  title: "Contact FoodAtlas | Get in Touch with the Research Team",
+  description:
+    "Contact the FoodAtlas team with questions about our research, data, or methodology, or to request API access for your project.",
+};
 
 interface ContactPageProps {
   params: { id: string };

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -19,11 +19,17 @@ const Layout = ({ children }: ClientLayoutProps) => {
     >
       <head />
       <body>
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-2 focus:left-2 focus:z-[100] focus:px-4 focus:py-2 focus:bg-accent-600 focus:text-white focus:rounded focus:shadow-lg"
+        >
+          Skip to main content
+        </a>
         <GoogleAnalytics
           gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? ""}
         />
         <Providers>
-          <main>
+          <main id="main-content">
             {children}
             <Portal>
               <SearchBar />

--- a/frontend/components/about/Person.tsx
+++ b/frontend/components/about/Person.tsx
@@ -25,12 +25,22 @@ const Person = ({ member }: PersonProps) => {
       </p>
       <div className="mt-3 flex justify-center items-center gap-3">
         {member.linkToWebsite && (
-          <a href={member.linkToWebsite} target="_blank" tabIndex={0}>
+          <a
+            href={member.linkToWebsite}
+            target="_blank"
+            tabIndex={0}
+            aria-label={`${member.name}'s personal website`}
+          >
             <MdLanguage className="h-5 w-5 text-light-300" />
           </a>
         )}
         {member.linkToLinkedIn && (
-          <a href={member.linkToLinkedIn} target="_blank" tabIndex={0}>
+          <a
+            href={member.linkToLinkedIn}
+            target="_blank"
+            tabIndex={0}
+            aria-label={`${member.name} on LinkedIn`}
+          >
             <FaLinkedin className="h-5 w-5 text-light-300" />
           </a>
         )}

--- a/frontend/components/basic/Button.tsx
+++ b/frontend/components/basic/Button.tsx
@@ -19,7 +19,7 @@ enum Variants {
 
 const variants = {
   filled:
-    "bg-accent-600 shadow-inner shadow-accent-500/20  hover:from-accent-600 hover:to-accent-600 hover:shadow-accent-700/30",
+    "bg-accent-900 text-light-50 shadow-inner shadow-accent-500/20 hover:bg-accent-800 hover:shadow-accent-700/30",
   outlined:
     "border text-light-300 border-light-300 hover:border-light-200 hover:text-light-200",
   ghost: "px-0 !shadow-none",
@@ -61,6 +61,7 @@ interface ButtonProps {
   isIconOnly?: boolean;
   isSquared?: boolean; // New prop added here
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  "aria-label"?: string;
 }
 
 const Button = forwardRef<HTMLButtonElement, ButtonProps>(
@@ -78,6 +79,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       isIconOnly = false,
       isSquared = false, // Default value for the new prop
       onClick: propagateOnClick = () => {},
+      "aria-label": ariaLabel,
     },
     ref
   ) => {
@@ -142,6 +144,7 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
         type={type}
         onClick={handleClick}
         onKeyUp={handleKeyUp}
+        aria-label={ariaLabel}
       >
         {children}
       </button>

--- a/frontend/components/contact/ContactForm.tsx
+++ b/frontend/components/contact/ContactForm.tsx
@@ -6,6 +6,7 @@ import {
   Fieldset,
   Input,
   Label,
+  Legend,
   Select,
   Textarea,
 } from "@headlessui/react";
@@ -77,6 +78,7 @@ const ContactForm = ({ isApiAccressRequest }: ContactFormProps) => {
     <form className="mx-auto flex gap-4" onSubmit={handleSubmit}>
       <Card>
         <Fieldset className="space-y-6">
+          <Legend className="sr-only">Contact form</Legend>
           {/* name */}
           <Field>
             <Label className="text-sm/6 font-medium text-white">Name</Label>

--- a/frontend/components/landing/HeroSection.tsx
+++ b/frontend/components/landing/HeroSection.tsx
@@ -48,11 +48,11 @@ const HeroSection = () => {
             </Heading>
             {/* separator */}
             <div className="w-32 md:w-48 h-[0.1rem] md:h-1 rounded-full  bg-gradient-to-r from-accent-400/50 via-accent-600/80 to-accent-400/50 border border-accent-500" />
-            {/* secondary heading */}
-            <h2 className="max-w-xl lg:max-w-none text-lg md:text-2xl text-light-300 text-center">
+            {/* tagline */}
+            <p className="max-w-xl lg:max-w-none text-lg md:text-2xl text-light-300 text-center">
               Introducing <i>FoodAtlas</i>, the world&apos;s first
               evidence-based food knowledge base.
-            </h2>
+            </p>
           </div>
         </div>
         <SearchWrapper />

--- a/frontend/components/navigation/Footer.tsx
+++ b/frontend/components/navigation/Footer.tsx
@@ -32,6 +32,7 @@ const Footer = () => {
                 className="w-32 md:w-1/2 my-auto"
                 href="https://aifs.ucdavis.edu"
                 tabIndex={0}
+                aria-label="AI Institute for Next Generation Food Systems (AIFS) website"
               >
                 <AIFSIcon width="100%" height="58" color="#FFFBF7" />
               </a>
@@ -40,15 +41,16 @@ const Footer = () => {
                 className="w-32 md:w-1/2 my-auto"
                 href="https://ucdavis.edu"
                 tabIndex={0}
+                aria-label="University of California, Davis website"
               >
                 <UCDIcon width="100%" height="58" color="#FFFBF7" />
               </a>
             </div>
           </div>
           <div className="md:w-1/3">
-            <h3 className="text-sm lg:text-md italic font-semibold font-mono text-light-50">
+            <h2 className="text-sm lg:text-md italic font-semibold font-mono text-light-50">
               About AIFS
-            </h3>
+            </h2>
             <p className="mt-3 md:mt-5 leading-6 text-sm lg:text-md text-light-300">
               The{" "}
               <Link href={"https://aifs.ucdavis.edu"}>
@@ -63,9 +65,9 @@ const Footer = () => {
             </p>
           </div>
           <div className="md:w-1/3">
-            <h3 className="text-sm lg:text-md italic font-semibold font-mono text-light-50">
+            <h2 className="text-sm lg:text-md italic font-semibold font-mono text-light-50">
               Connect with us
-            </h3>
+            </h2>
             <p className="mt-3 md:mt-5 leading-6 text-sm lg:text-md text-light-300">
               Subscribe to our newsletter to stay up-to-date on AIFS events,
               industry news, and AI research.
@@ -91,6 +93,7 @@ const Footer = () => {
               className="cursor-pointer hover:text-light-50 transition duration-300 ease-in-out"
               href="https://www.threads.net/@aifoodsystems"
               tabIndex={0}
+              aria-label="AIFS on Threads"
             >
               <FaThreads className="h-8 w-8 md:h-9 md:w-9" />
             </a>
@@ -98,6 +101,7 @@ const Footer = () => {
               className="cursor-pointer hover:text-light-50 transition duration-300 ease-in-out"
               href="https://www.instagram.com/aifoodsystems"
               tabIndex={0}
+              aria-label="AIFS on Instagram"
             >
               <FaInstagram className="h-8 w-8 md:h-9 md:w-9" />
             </a>
@@ -105,6 +109,7 @@ const Footer = () => {
               className="cursor-pointer hover:text-light-50 transition duration-300 ease-in-out"
               href="https://www.linkedin.com/company/aifoodsystems/"
               tabIndex={0}
+              aria-label="AIFS on LinkedIn"
             >
               <FaLinkedin className="h-8 w-8 md:h-9 md:w-9" />
             </a>
@@ -112,6 +117,7 @@ const Footer = () => {
               className="cursor-pointer hover:text-light-50 transition duration-300 ease-in-out"
               href="https://www.youtube.com/channel/UCyvVBZ6Qx34ElPB0UmoEF2A"
               tabIndex={0}
+              aria-label="AIFS on YouTube"
             >
               <FaYoutube className="h-8 w-8 md:h-9 md:w-9" />
             </a>

--- a/frontend/components/navigation/Navbar.tsx
+++ b/frontend/components/navigation/Navbar.tsx
@@ -103,6 +103,7 @@ const Navbar = ({ className }: NavbarProps) => {
             isIconOnly
             tabIndex={10}
             onClick={() => router.push("/")}
+            aria-label="FoodAtlas home"
           >
             <FoodAtlasIcon height={45} width={""} color={"#FFFBF7"} />
           </Button>

--- a/frontend/components/search/SearchBar.tsx
+++ b/frontend/components/search/SearchBar.tsx
@@ -177,7 +177,7 @@ const SearchBar = () => {
 
   return (
     isVisible && (
-      <>
+      <div role="search" aria-label="Site search">
         <div
           className={`z-10 w-full absolute ] px-3md:px-12 ${
             isFocused ? "absolute inset-0 top-24 -right-4" : ""
@@ -271,8 +271,9 @@ const SearchBar = () => {
           className={`absolute inset-0 h-screen transition-all duration-300 backdrop-blur-md bg-black/30 saturate-150 pointer-events-none ${
             isFocused ? "opacity-100" : "opacity-0"
           }`}
+          aria-hidden="true"
         />
-      </>
+      </div>
     )
   );
 };


### PR DESCRIPTION
* refactor(ci): switch CD to OIDC role assumption

Replaces static AWS access keys with GitHub OIDC + sts:AssumeRoleWithWebIdentity. Each CD run now exchanges a short-lived JWT for a ~1h AWS session — no long-lived secrets live in GitHub, and nothing needs manual rotation.

Requires: an IAM role trusting the GitHub OIDC provider, its ARN stored as AWS_ROLE_ARN in the production environment.

* fix(ci): smoke-test via custom domain to match ACM cert

The ALB's AWS-assigned *.elb.amazonaws.com hostname doesn't match the ACM cert's SAN (api.foodatlas.ai), so TLS verification was failing even though the API was healthy. Target the custom domain directly.

Drops the now-unneeded 'Fetch API URL' step since the URL is static.

* accessibility improvements

---------