### PR TITLE
chore: funnel hotfixes through dev; drop hotfix → main path

### DIFF
--- a/.github/workflows/guard-main.yml
+++ b/.github/workflows/guard-main.yml
@@ -16,8 +16,8 @@ jobs:
         env:
           HEAD_REF: ${{ github.head_ref }}
         run: |
-          if [[ "$HEAD_REF" != "dev" && "$HEAD_REF" != hotfix/* ]]; then
-            echo "::error::PRs to main must come from 'dev' or 'hotfix/*'. Got: '$HEAD_REF'."
+          if [[ "$HEAD_REF" != "dev" ]]; then
+            echo "::error::PRs to main must come from 'dev'. Got: '$HEAD_REF'. Hotfixes flow feat|fix|hotfix/* → dev → main."
             exit 1
           fi
           echo "Head branch '$HEAD_REF' is allowed."

--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -91,16 +91,17 @@ In production, `DB_USER`/`DB_PASSWORD` come from AWS Secrets Manager, `API_DEBUG
 ## Branching strategy
 
 ```
-main           ← protected, production-ready
-  ├── hotfix/  ← urgent fixes, PR directly to main
-  └── dev      ← integration branch, PR target for features
-       └── feat/your-name/description
-       └── fix/your-name/description
+main           ← protected, production-ready (CD deploys from here)
+  └── dev      ← integration branch, only branch allowed to PR into main
+       ├── feat/<name>/<description>
+       ├── fix/<name>/<description>
+       └── hotfix/<description>          ← high priority, but still flows through dev
 ```
 
 - **Never push directly to `main` or `dev`.**
-- Create feature/fix branches off `dev`. PRs target `dev`.
-- For urgent production fixes, branch `hotfix/<description>` off `main` and PR into `main`.
+- Every change — feature, fix, or hotfix — branches off `dev` and PRs into `dev`.
+- `main` is updated only via `dev → main` PRs. The `guard-main.yml` workflow enforces this and will fail any PR to `main` whose source isn't `dev`.
+- The `hotfix/<description>` name is purely a signal to reviewers that a change is high-priority and should be expedited through dev → main. There's no different mechanical path: it still goes feat-style through dev, gets the same CI, and rides the next dev → main rollup (which can be opened immediately for an urgent fix).
 - Naming: `feat/<name>/<description>`, `fix/<name>/<description>`, `hotfix/<description>`.
 
 ## Development workflow
@@ -120,25 +121,36 @@ Each merge target has a fixed strategy — pick the right one in the GitHub PR U
 
 | PR direction | Strategy | Why |
 |---|---|---|
-| `feat/*` or `fix/*` → `dev` | **Squash and merge** | Collapses a noisy review history into one logical commit on `dev`. |
-| `dev` → `main` | **Create a merge commit** | Preserves the individual feature commits already on `dev` so production history reflects exactly what shipped. |
-| `hotfix/*` → `main` | **Create a merge commit** | Same reason — keep the hotfix commits intact on `main`. |
+| `feat/*`, `fix/*`, or `hotfix/*` → `dev` | **Squash and merge** | Collapses a noisy review history into one logical commit on `dev`. |
+| `dev` → `main` | **Create a merge commit** | Preserves the individual squashed-feature commits already on `dev` so production history reflects exactly what shipped. |
 
-### Keeping `dev` in sync with `main`
+### Drift between `dev` and `main`
 
-When a `hotfix/*` lands on `main`, `dev` is now missing those commits. Pull them back so the next `dev → main` PR doesn't reintroduce stale code:
+Because everything reaches `main` only via `dev → main`, `dev` is always a content-superset of `main`: every patch on `main` is also on `dev`. There is no scenario in normal operation where `dev` falls behind `main`.
+
+**Don't be fooled by `git log dev..main`.** Each `dev → main` merge creates a merge-commit shell on `main` only (that's what merge commits *are*). After many rollups, `git log origin/dev..origin/main` will report a growing count of commits that exist on `main` but not on `dev`. **This is not drift.** Those commits are merge-shells whose tree content is already in `dev` via the squashed feature commits they wrap.
+
+The only meaningful drift check is at the file level:
+
+```bash
+git fetch origin
+git diff origin/dev origin/main             # empty = no drift
+git cherry origin/dev origin/main | grep '^+'   # any '+' line = real new content on main
+```
+
+If either of these shows real content on `main` that isn't on `dev`, **something bypassed the dev → main rule** — investigate before doing anything else (likely cause: someone disabled the `guard-main` workflow or used admin override). Once you understand what landed, sync it back into `dev` with the recipe below; otherwise leave `dev` alone.
+
+#### Emergency sync-back recipe (should never be needed)
 
 ```bash
 git checkout main && git pull
 git checkout dev && git pull
 git checkout -b chore/sync-main-into-dev
-git merge main          # standard merge, keep main's commits
+git merge main
 git push -u origin chore/sync-main-into-dev
 ```
 
-Open a PR targeting `dev`. It still uses the dev-side strategy (**squash and merge**) — the granular commits are already preserved on `main`, so collapsing the sync to a single `chore: sync main into dev` commit on `dev` is fine. Recent example: [PR #133](https://github.com/AI-Institute-Food-Systems/foodatlas/pull/133).
-
-When `dev` itself merges to `main`, no sync is needed — the merge commit on `main` brings everything in `dev` over, and `dev` is unchanged.
+Then open a PR targeting `dev` and squash-merge it. Past example: [PR #133](https://github.com/AI-Institute-Food-Systems/foodatlas/pull/133).
 
 ## Code quality
 


### PR DESCRIPTION
## Summary

Removes the "hotfix can PR directly to `main`" exception. From now on, **`dev` is the only allowed source for PRs into `main`** — every change (feature, fix, hotfix) flows `feat|fix|hotfix → dev → main`. The `hotfix/*` name remains as a *priority signal* for reviewers, not a different mechanical path.

## Why

The dual-path setup created two specific problems:

1. **Real drift.** Any time a `hotfix/*` landed on `main`, `dev` was structurally behind until someone remembered to open a `chore: sync main into dev` PR. We've already shipped one of those (PR #133) and almost forgot another time.
2. **False alarms even when there was no real drift.** The asymmetric merge strategies (squash on `dev`, merge commit on `main`) make `git log dev..main` show a non-zero count permanently — the merge-commit shells on `main` are by design not on `dev`. That noise made it hard to tell when `dev` was *actually* behind vs. just topologically lagging.

With one path, `dev` is structurally always a content-superset of `main`. `git diff dev main` becomes the meaningful drift check (and is reliably empty after each rollup), and the `git log` count becomes pure noise that we can ignore by policy.

## Changes

- **`.github/workflows/guard-main.yml`** — source-branch check now requires `dev`. Any PR targeting `main` from a non-`dev` branch fails CI with a message that points to the new flow. This is the enforcement mechanism — no GitHub Settings / branch-protection changes needed.
- **`DEVELOPER.md`**:
  - Branching tree redrawn with `hotfix/<description>` under `dev`, not under `main`. Footnote spells out the guard-main enforcement.
  - Naming bullet clarifies that `hotfix/<description>` is now purely a priority signal for reviewers — same mechanical path as `feat/*` and `fix/*`.
  - Merge-strategy table collapsed: `feat|fix|hotfix → dev` (squash) and `dev → main` (merge commit). The old `hotfix/* → main` row is gone.
  - The "Keeping `dev` in sync with `main`" section was rewritten as **"Drift between `dev` and `main`"** — leads with the structural invariant ("never needed in normal operation"), explicitly explains the `git log` false-alarm and recommends `git diff` / `git cherry` instead, and demotes the sync-PR recipe to an emergency-only fallback (with a note that needing it implies `guard-main` was bypassed and is itself a bug to investigate).

No code or product behavior changes. Pure policy + docs + one CI guard tweak.

## Test plan

- [ ] Confirm `guard-main` workflow still passes for the next legitimate `dev → main` PR.
- [ ] (Manual smoke) Try opening a PR from this branch directly to `main` (don't merge it) — `guard-main` should fail with the new error message ("PRs to main must come from 'dev'…"). Close the test PR after confirming.
- [ ] Skim DEVELOPER.md and confirm the branching tree, merge-strategy table, and drift section read coherently.

## Follow-ups (out of scope here)

- If we ever want `git log dev..main` to actually be zero (rather than just structurally noisy), we'd need to switch `dev → main` to fast-forward — either via GitHub's merge queue with a "linear history" rule, or by merging via CLI. Discussed but not adopted; the current setup is fine if we accept "use `git diff dev main`, ignore `git log`."