### PR TITLE
feat(downloads): add "How to Cite" citation block (#137)

### DIFF
--- a/frontend/app/(everything-else)/food-composition-downloads/page.tsx
+++ b/frontend/app/(everything-else)/food-composition-downloads/page.tsx
@@ -60,6 +60,25 @@ const Downloads = async () => {
       </div>
       <Divider />
       <div className="mt-14">
+        <Heading type="h2" className="text-3xl">
+          How to Cite
+        </Heading>
+        <SubHeading>
+          If you use <i>FoodAtlas</i> in your research, please cite:
+        </SubHeading>
+        <Card className="mt-6">
+          <p className="leading-relaxed text-light-200">
+            Li, F., Youn, J., Xie, K. et al. A unified knowledge graph linking
+            foodomics to chemical-disease networks and flavor profiles.{" "}
+            <i>npj Sci Food</i> <strong>10</strong>, 33 (2026).{" "}
+            <Link href="https://doi.org/10.1038/s41538-025-00680-9">
+              https://doi.org/10.1038/s41538-025-00680-9
+            </Link>
+          </p>
+        </Card>
+      </div>
+      <Divider />
+      <div className="mt-14">
         <Card>
           <DownloadsTable data={data} />
         </Card>


### PR DESCRIPTION
## Summary

- Adds a **How to Cite** section to `/food-composition-downloads`, placed *above* the downloads table so users see the citation before grabbing a bundle.
- Surfaces the reference paper:
  > Li, F., Youn, J., Xie, K. et al. *A unified knowledge graph linking foodomics to chemical-disease networks and flavor profiles.* npj Sci Food **10**, 33 (2026). https://doi.org/10.1038/s41538-025-00680-9

Closes #137.

## Implementation

- Single edit to `frontend/app/(everything-else)/food-composition-downloads/page.tsx`.
- Reuses existing `Heading` (h2, `text-3xl` per `technical-background` page convention), `SubHeading`, `Card`, and `Link` primitives — no new components or styles introduced.
- Layout order: intro → divider → **How to Cite** → divider → downloads table → "retired versions" note.

## Test plan

- [ ] Visit `http://localhost:3001/food-composition-downloads` and confirm the **How to Cite** card renders above the downloads table.
- [ ] DOI link opens `https://doi.org/10.1038/s41538-025-00680-9` in a new tab.
- [ ] Layout still looks right on mobile (single-column stack).