### PR TITLE
feat(about): add Publications section and unify paper references

### DIFF
--- a/frontend/app/(everything-else)/about/page.tsx
+++ b/frontend/app/(everything-else)/about/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from "next";
 
 import Person from "@/components/about/Person";
+import Card from "@/components/basic/Card";
 import Divider from "@/components/basic/Divider";
 import Heading from "@/components/basic/Heading";
 import SubHeading from "@/components/basic/SubHeading";
@@ -95,9 +96,7 @@ const About = () => {
           </Link>{" "}
           page or to the full{" "}
           <Link
-            href={
-              "https://drive.google.com/file/d/1e9hfCT3Og-Mvsch5Rse0oNq_V4ua_mKo/view?usp=sharing"
-            }
+            href="https://doi.org/10.1038/s41538-025-00680-9"
             isExternal={true}
           >
             publication
@@ -141,6 +140,45 @@ const About = () => {
               )
             )}
           </div>
+        </div>
+        {/* publications */}
+        <div>
+          <Heading type="h2" variant="boxed">
+            Publications
+          </Heading>
+          <Card className="mt-10">
+            <ol className="flex flex-col gap-4 list-decimal list-inside leading-relaxed text-light-200 marker:text-light-400">
+              <li>
+                Li, F., Youn, J., Xie, K., Chan, T., Gupta, P., Yoo, A., ... &
+                Tagkopoulos, I. (2026). A unified knowledge graph linking
+                foodomics to chemical-disease networks and flavor profiles.{" "}
+                <i>npj Science of Food</i>.{" "}
+                <Link href="https://doi.org/10.1038/s41538-025-00680-9">
+                  https://doi.org/10.1038/s41538-025-00680-9
+                </Link>
+              </li>
+              <li>
+                Youn, J., Li, F., Simmons, G., Kim, S., & Tagkopoulos, I.
+                (2024). FoodAtlas: automated knowledge extraction of food and
+                chemicals from literature.{" "}
+                <i>Computers in Biology and Medicine</i>, <i>181</i>, 109072.{" "}
+                <Link href="https://doi.org/10.1016/j.compbiomed.2024.109072">
+                  https://doi.org/10.1016/j.compbiomed.2024.109072
+                </Link>
+              </li>
+              <li>
+                Youn, J., Li, F., & Tagkopoulos, I. (2023). Semi-automated
+                construction of food composition knowledge base. In{" "}
+                <i>
+                  2nd AAAI Workshop on AI for Agriculture and Food Systems
+                </i>
+                .{" "}
+                <Link href="https://doi.org/10.48550/arXiv.2301.11322">
+                  https://doi.org/10.48550/arXiv.2301.11322
+                </Link>
+              </li>
+            </ol>
+          </Card>
         </div>
       </div>
     </div>

--- a/frontend/app/(everything-else)/food-composition-downloads/page.tsx
+++ b/frontend/app/(everything-else)/food-composition-downloads/page.tsx
@@ -68,9 +68,10 @@ const Downloads = async () => {
         </SubHeading>
         <Card className="mt-6">
           <p className="leading-relaxed text-light-200">
-            Li, F., Youn, J., Xie, K. et al. A unified knowledge graph linking
-            foodomics to chemical-disease networks and flavor profiles.{" "}
-            <i>npj Sci Food</i> <strong>10</strong>, 33 (2026).{" "}
+            Li, F., Youn, J., Xie, K., Chan, T., Gupta, P., Yoo, A., ... &
+            Tagkopoulos, I. (2026). A unified knowledge graph linking foodomics
+            to chemical-disease networks and flavor profiles.{" "}
+            <i>npj Science of Food</i>.{" "}
             <Link href="https://doi.org/10.1038/s41538-025-00680-9">
               https://doi.org/10.1038/s41538-025-00680-9
             </Link>

--- a/frontend/app/(everything-else)/technical-background/page.tsx
+++ b/frontend/app/(everything-else)/technical-background/page.tsx
@@ -88,13 +88,10 @@ const TechnicalBackground = () => {
         </p>
         <p className="mt-2.5 text-lg leading-loose text-light-200">
           The following provides a brief overview of some of the methods and
-          technologies used. For a detailed look behind the scenes, refer to our
-          first{" "}
+          technologies used. For a detailed look behind the scenes, refer to our{" "}
           <Link
             className="whitespace-nowrap"
-            href={
-              "https://drive.google.com/file/d/1e9hfCT3Og-Mvsch5Rse0oNq_V4ua_mKo/view?usp=sharing"
-            }
+            href="https://doi.org/10.1038/s41538-025-00680-9"
           >
             publication
           </Link>


### PR DESCRIPTION
## Summary

Builds on #152 to make publication references consistent across the site.

- **New Publications section** on `/about`, placed under Software Engineering Team — a numbered list (1, 2, 3) of the three FoodAtlas-related papers, each with a DOI link.
- **Repointed inline 'publication' link** on `/about` and `/technical-background` from the legacy Google Drive PDF to the canonical npj Science of Food (2026) DOI.
- **Harmonized 'How to Cite' format** on `/food-composition-downloads` to match the APA-style used in the new Publications list (full author list with `... &`, parenthetical year, full journal name "npj Science of Food", DOI link).

## Implementation

- Single React change in `frontend/app/(everything-else)/about/page.tsx` for the Publications block — uses `<ol class="list-decimal list-inside ...">` so numbering is browser-rendered, and reuses existing `Heading` (boxed h2), `Card`, and `Link` primitives.
- Two small edits to repoint the prior Google Drive link to `https://doi.org/10.1038/s41538-025-00680-9`.
- One edit to `food-composition-downloads/page.tsx` reformatting the "How to Cite" entry.

## Papers listed

1. Li et al. (2026) — *npj Science of Food* — https://doi.org/10.1038/s41538-025-00680-9
2. Youn et al. (2024) — *Computers in Biology and Medicine* — https://doi.org/10.1016/j.compbiomed.2024.109072
3. Youn et al. (2023) — *AAAI Workshop on AI for Agriculture and Food Systems* — https://doi.org/10.48550/arXiv.2301.11322

## Test plan

- [ ] `/about` shows a new "Publications" section under Software Engineering Team with three numbered entries and clickable DOIs.
- [ ] `/about` and `/technical-background` inline "publication" links open the npj DOI (not the old Google Drive PDF).
- [ ] `/food-composition-downloads` "How to Cite" card uses the new APA-style format and matches entry #1 on `/about` exactly (minus the leading "1.").