### PR TITLE
feat: per-attestation trustworthiness signals (LLM plausibility v1) (…

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This is a polyglot monorepo with independent sub-projects:
   - `api/` — FastAPI REST service (uvicorn, port 8000). Routes, repositories, config, auth.
   - `db/` — PostgreSQL schema (SQLAlchemy models, drop-and-recreate on each load), ETL pipeline (parquet → Postgres).
   - `ie/` — Information extraction pipeline (Click CLI, four stages: corpus → search → filtering → extraction). PubMed/PMC search + BioBERT filter + OpenAI batch extraction.
-  - `kgc/` — Knowledge graph construction pipeline (Click CLI, five stages: ingest → entities → triplets → ie → enrichment).
+  - `kgc/` — Knowledge graph construction pipeline (Click CLI, six stages: ingest → entities → triplets → ie → enrichment → trust). The `trust` stage emits per-attestation trustworthiness signals (v1: Gemini-based LLM plausibility judge) and writes `trust_signals.parquet`; the `db` loader upserts these onto a separate `TrustBase` so signals survive `db load` rebuilds.
 - **`frontend/`** — Next.js 14 app (React 18, TypeScript, Tailwind, App Router). Dev server runs on port 3001.
 - **`infra/`** — Local dev infrastructure (`infra/local/`, Docker Compose Postgres 16) and AWS CDK (`infra/aws/`).
 - **`docs/`** — Architecture and planning documents.

--- a/backend/api/src/config.py
+++ b/backend/api/src/config.py
@@ -15,3 +15,10 @@ class APISettings(BaseSettings):
     debug: bool = True
     downloads_bucket: str = ""
     downloads_region: str = "us-west-1"
+    # Per-attestation LLM-plausibility score at-or-below this is "low trust"
+    # (the comparison is inclusive — score <= threshold counts as low).
+    # The composition / data-points endpoints filter on this when the
+    # `trust` query param is "default" (hide low-trust) or "low_only"
+    # (show only low-trust). Threshold lives here so it can be tuned
+    # without redeploying the frontend or rerunning the trust stage.
+    trust_low_threshold: float = 0.4

--- a/backend/api/src/repositories/food.py
+++ b/backend/api/src/repositories/food.py
@@ -3,7 +3,10 @@
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from src.config import APISettings
+
 from .formatting import format_external_ids
+from .trust_filter import TrustMode, apply_trust_filter
 
 ROWS_PER_PAGE = 25
 
@@ -132,8 +135,19 @@ async def get_composition(
     show_all_rows: bool = True,
     filter_classification: str = "",
     rows_per_page: int = ROWS_PER_PAGE,
+    trust: TrustMode = "default",
 ) -> dict[str, object]:
-    """Get paginated food chemical composition with filtering/sorting."""
+    """Get paginated food chemical composition with filtering/sorting.
+
+    The ``trust`` param controls per-attestation visibility:
+    ``default`` hides extractions whose llm_plausibility score is below
+    :attr:`APISettings.trust_low_threshold`; ``show_all`` returns everything
+    so the UI can render low-trust items with a warning icon; ``low_only``
+    returns only the low-trust items. Filtering happens after pagination
+    today, so page sizes for the non-default modes may be slightly under
+    ``rows_per_page`` — acceptable trade-off for v1; revisit if pagination
+    accuracy becomes a real UX issue.
+    """
     sources = [s for s in filter_source.split("+") if s] if filter_source else []
     if filter_source and not sources:
         return _empty_composition(rows_per_page)
@@ -157,18 +171,29 @@ async def get_composition(
 
     where = " AND ".join(where_parts)
     offset = rows_per_page * (page - 1)
-    params["offset"] = offset
-    params["limit"] = rows_per_page
 
-    sql = _compose_sql(select_cols, where, sort_col, direction, paginated=True)
+    # Fetch every matching row (no LIMIT/OFFSET in SQL). The trust filter
+    # rewrites medians and drops rows, so SQL-level pagination would be
+    # wrong for trust != show_all (rows can move pages once their median
+    # changes). Total rows in tomato-scale foods is in the hundreds; the
+    # cost of fetching all in one query is well below the cost of an
+    # incorrect page count or the wrong rows on the page.
+    sql = _compose_sql(select_cols, where, sort_col, direction, paginated=False)
     result = await session.execute(text(sql), params)
-    data = [dict(row._mapping) for row in result]
+    all_rows = [dict(row._mapping) for row in result]
 
-    count_params = {k: v for k, v in params.items() if k not in ("offset", "limit")}
-    count_sql = _compose_sql(select_cols, where, sort_col, direction, count_only=True)
-    count_result = await session.execute(text(count_sql), count_params)
-    total_rows = count_result.scalar() or 0
+    threshold = APISettings().trust_low_threshold
+    all_rows = await apply_trust_filter(
+        session, all_rows, mode=trust, threshold=threshold
+    )
+    # Re-sort using the recomputed median (default / low_only) — show_all
+    # keeps the stored median so SQL order is already correct.
+    if trust != "show_all":
+        all_rows = _resort_after_filter(all_rows, sort_by, direction)
+
+    total_rows = len(all_rows)
     total_pages = (total_rows + rows_per_page - 1) // rows_per_page if total_rows else 0
+    data = all_rows[offset : offset + rows_per_page]
 
     return {
         "data": data,
@@ -257,6 +282,32 @@ def _compose_sql(
         + " NULLS LAST"
         + pagination
     )
+
+
+def _resort_after_filter(data: list[dict], sort_by: str, direction: str) -> list[dict]:
+    """Re-sort the page using the post-filter (recomputed) median.
+
+    Pagination is unchanged — we operate on whatever rows the SQL page
+    returned. This restores within-page ordering after the trust filter
+    rewrites medians; cross-page ordering can still be approximate.
+    """
+    descending = direction.upper() == "DESC"
+    if sort_by == "median_concentration":
+        with_val: list[dict] = []
+        without_val: list[dict] = []
+        for row in data:
+            mc = row.get("median_concentration")
+            val = mc.get("value") if isinstance(mc, dict) else None
+            (with_val if val is not None else without_val).append(row)
+        with_val.sort(
+            key=lambda r: r["median_concentration"]["value"], reverse=descending
+        )
+        return with_val + without_val  # NULLS LAST
+    if sort_by == "common_name":
+        return sorted(
+            data, key=lambda r: (r.get("name") or "").lower(), reverse=descending
+        )
+    return data
 
 
 def _empty_composition(rows_per_page: int) -> dict[str, object]:

--- a/backend/api/src/repositories/trust_filter.py
+++ b/backend/api/src/repositories/trust_filter.py
@@ -1,0 +1,264 @@
+"""Per-attestation trust-score filtering applied to composition responses.
+
+Each evidence dict in the materialised composition view (``fdc_evidences``,
+``foodatlas_evidences``, ``dmd_evidences``) carries a list of ``extraction``
+objects, each annotated with an ``attestation_id``. Trust signals live in
+``base_trust_signals`` and are joined at request time by attestation_id. The
+threshold is configurable via :class:`APISettings.trust_low_threshold`.
+
+Modes:
+
+- ``default`` — drop extractions whose latest llm_plausibility score is below
+  the threshold; if a row's evidences end up entirely empty, drop the row.
+- ``show_all`` — return every extraction; annotate each with ``trust_low``
+  (``True`` when the extraction has a score and that score is below the
+  threshold; ``False`` otherwise — including for unscored attestations like
+  FDC/DMD which we treat as trusted). The frontend uses ``trust_low`` to
+  render a warning badge on rows with at least one low-trust extraction.
+- ``low_only`` — keep only extractions whose score is below the threshold;
+  drop rows that end up with no evidences. Used when the user clicks the
+  warning badge to filter to suspicious data points (mirrors the
+  "ambiguous" pattern).
+
+Attestations without a trust signal default to ``score = 1.0`` (trusted).
+This means FDC and DMD-derived attestations — which the trust stage doesn't
+judge today — pass through ``default`` and are correctly excluded from
+``low_only``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal
+
+from sqlalchemy import text
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+TrustMode = Literal["default", "show_all", "low_only"]
+_EVIDENCE_KEYS = ("fdc_evidences", "foodatlas_evidences", "dmd_evidences")
+_NO_SIGNAL_DEFAULT_SCORE = 1.0
+
+
+async def apply_trust_filter(
+    session: AsyncSession,
+    rows: list[dict],
+    *,
+    mode: TrustMode,
+    threshold: float,
+) -> list[dict]:
+    """Filter or annotate ``rows`` according to ``mode``; returns new list.
+
+    ``rows`` is a list of MV-shaped dicts (each may contain
+    ``fdc_evidences`` / ``foodatlas_evidences`` / ``dmd_evidences`` keys
+    with list-or-None values). Every extraction must already carry
+    ``attestation_id`` (added in the materializer).
+    """
+    if not rows:
+        return rows
+
+    att_ids = _collect_attestation_ids(rows)
+
+    if mode == "show_all":
+        if not att_ids:
+            return rows
+        scores = await _fetch_trust_scores(session, att_ids)
+        return _annotate_rows(rows, scores=scores, threshold=threshold)
+
+    if not att_ids:
+        # Nothing to score; default mode keeps everything (treats as
+        # high-trust); low_only mode drops everything since no row has
+        # any low-trust evidence.
+        return rows if mode == "default" else []
+
+    scores = await _fetch_trust_scores(session, att_ids)
+    return _filter_rows(rows, scores=scores, mode=mode, threshold=threshold)
+
+
+def _annotate_rows(
+    rows: list[dict],
+    *,
+    scores: dict[str, float],
+    threshold: float,
+) -> list[dict]:
+    """Add ``trust_low`` to every extraction without dropping anything."""
+    out: list[dict] = []
+    for row in rows:
+        new_row = dict(row)
+        for key in _EVIDENCE_KEYS:
+            evs = row.get(key)
+            if not evs:
+                continue
+            new_row[key] = [
+                {
+                    **ev,
+                    "extraction": [
+                        {**ext, "trust_low": _is_low(ext, scores, threshold)}
+                        for ext in (ev.get("extraction") or [])
+                    ],
+                }
+                for ev in evs
+            ]
+        out.append(new_row)
+    return out
+
+
+def _is_low(ext: dict, scores: dict[str, float], threshold: float) -> bool:
+    """``True`` only when the extraction has a score AND it's at-or-below threshold.
+
+    Threshold is inclusive on the low side (``<=``): a score of exactly the
+    threshold counts as low-trust. The model often anchors on round numbers
+    (e.g. judges "suspicious-but-not-impossible" cases as exactly 0.3); using
+    ``<=`` catches those instead of letting them slip through.
+
+    Unscored attestations (FDC / DMD / un-judged lit2kg) are *not* flagged —
+    we don't know their plausibility and shouldn't visually penalize them.
+    """
+    aid = ext.get("attestation_id", "")
+    if aid not in scores:
+        return False
+    return scores[aid] <= threshold
+
+
+def _collect_attestation_ids(rows: list[dict]) -> list[str]:
+    seen: set[str] = set()
+    for row in rows:
+        for key in _EVIDENCE_KEYS:
+            for ev in row.get(key) or []:
+                for ext in ev.get("extraction") or []:
+                    aid = ext.get("attestation_id")
+                    if aid:
+                        seen.add(aid)
+    return list(seen)
+
+
+async def _fetch_trust_scores(
+    session: AsyncSession, att_ids: list[str]
+) -> dict[str, float]:
+    """Latest valid llm_plausibility score per attestation; -1 errors excluded.
+
+    "Latest" = highest ``created_at`` for the attestation. Re-judging an
+    attestation with a new prompt (different ``config_hash``) appends a new
+    row to ``base_trust_signals`` rather than overwriting the old one, so
+    old judgments are preserved for audit. The API picks the most recent
+    one — without this, a prompt change wouldn't take visual effect for
+    attestations whose old score was higher than the new score.
+    """
+    result = await session.execute(
+        text("""
+            WITH ranked AS (
+                SELECT
+                    attestation_id,
+                    score,
+                    ROW_NUMBER() OVER (
+                        PARTITION BY attestation_id
+                        ORDER BY created_at DESC
+                    ) AS rn
+                FROM base_trust_signals
+                WHERE attestation_id = ANY(:ids)
+                  AND signal_kind = 'llm_plausibility'
+                  AND score >= 0
+            )
+            SELECT attestation_id, score FROM ranked WHERE rn = 1
+        """),
+        {"ids": att_ids},
+    )
+    return {row.attestation_id: float(row.score) for row in result}
+
+
+def _filter_rows(
+    rows: list[dict],
+    *,
+    scores: dict[str, float],
+    mode: TrustMode,
+    threshold: float,
+) -> list[dict]:
+    out: list[dict] = []
+    for row in rows:
+        new_row = dict(row)
+        any_kept = False
+        for key in _EVIDENCE_KEYS:
+            new_evs = _filter_evidences(
+                row.get(key) or [], scores=scores, mode=mode, threshold=threshold
+            )
+            new_row[key] = new_evs or None
+            if new_evs:
+                any_kept = True
+        if not any_kept:
+            continue
+        # The MV's median_concentration is computed at materialize time across
+        # every extraction; once we drop low-trust ones it can become stale
+        # (e.g. "tomato linoleic acid 52410 mg/100g" still showing as the
+        # median after the offending rows are filtered). Recompute from what
+        # actually survived the filter so the UI's median matches its rows.
+        new_row["median_concentration"] = _recompute_median(new_row)
+        out.append(new_row)
+    return out
+
+
+def _recompute_median(row: dict) -> dict | None:
+    """Median of mg/100g values across surviving extractions; None if empty."""
+    vals: list[float] = []
+    for key in _EVIDENCE_KEYS:
+        for ev in row.get(key) or []:
+            for ext in ev.get("extraction") or []:
+                conc = ext.get("converted_concentration") or {}
+                val = conc.get("value")
+                unit = conc.get("unit") or ""
+                if val is None or unit != "mg/100g":
+                    continue
+                try:
+                    f = float(val)
+                except (TypeError, ValueError):
+                    continue
+                if f == 0:
+                    continue
+                vals.append(f)
+    if not vals:
+        return None
+    vals.sort()
+    n = len(vals)
+    median = vals[n // 2] if n % 2 else (vals[n // 2 - 1] + vals[n // 2]) / 2
+    return {"unit": "mg/100g", "value": median}
+
+
+def _filter_evidences(
+    evidences: list[dict],
+    *,
+    scores: dict[str, float],
+    mode: TrustMode,
+    threshold: float,
+) -> list[dict]:
+    kept: list[dict] = []
+    for ev in evidences:
+        new_extractions = _filter_extractions(
+            ev.get("extraction") or [],
+            scores=scores,
+            mode=mode,
+            threshold=threshold,
+        )
+        if new_extractions:
+            kept_ev = dict(ev)
+            kept_ev["extraction"] = new_extractions
+            kept.append(kept_ev)
+    return kept
+
+
+def _filter_extractions(
+    extractions: list[dict],
+    *,
+    scores: dict[str, float],
+    mode: TrustMode,
+    threshold: float,
+) -> list[dict]:
+    out: list[dict] = []
+    for ext in extractions:
+        score = scores.get(ext.get("attestation_id", ""), _NO_SIGNAL_DEFAULT_SCORE)
+        # Threshold is inclusive on the low side: score <= threshold counts as
+        # low-trust. The model often lands on round numbers (e.g. 0.3 for
+        # "suspicious but not impossible") — strict `<` would let those slip.
+        if (mode == "default" and score > threshold) or (
+            mode == "low_only" and score <= threshold
+        ):
+            out.append(ext)
+    return out

--- a/backend/api/src/routes/food.py
+++ b/backend/api/src/routes/food.py
@@ -1,12 +1,19 @@
 """Food entity API routes."""
 
+from typing import TYPE_CHECKING, cast
+
 from fastapi import APIRouter, Depends, Query
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.dependencies import get_db, verify_api_key
 from src.repositories import food, taxonomy
 
+if TYPE_CHECKING:
+    from src.repositories.trust_filter import TrustMode
+
 router = APIRouter(prefix="/food", dependencies=[Depends(verify_api_key)])
+
+_VALID_TRUST_MODES = ("default", "show_all", "low_only")
 
 
 @router.get("/metadata")
@@ -51,9 +58,18 @@ async def food_composition(
     sort_dir: str = Query("desc"),
     show_all_rows: str = Query("true"),
     filter_classification: str = Query(""),
+    trust: str = Query(
+        "default",
+        description=(
+            "Per-attestation trust filter. 'default' hides low-trust "
+            "extractions; 'show_all' returns everything; 'low_only' returns "
+            "only low-trust extractions."
+        ),
+    ),
     db: AsyncSession = Depends(get_db),
 ):
     show_all = show_all_rows.lower() != "false"
+    trust_mode = cast("TrustMode", trust if trust in _VALID_TRUST_MODES else "default")
     return await food.get_composition(
         db,
         common_name,
@@ -64,4 +80,5 @@ async def food_composition(
         sort_dir,
         show_all,
         filter_classification,
+        trust=trust_mode,
     )

--- a/backend/api/tests/test_repo_trust_filter.py
+++ b/backend/api/tests/test_repo_trust_filter.py
@@ -1,0 +1,226 @@
+"""Tests for the per-attestation trust-score filter applied to compositions."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from src.repositories.trust_filter import apply_trust_filter
+
+
+def _ext(att_id: str, **kwargs: object) -> dict:
+    base = {
+        "attestation_id": att_id,
+        "extracted_food_name": "tomato",
+        "extracted_chemical_name": "lycopene",
+        "extracted_concentration": "5 mg/100g",
+        "converted_concentration": {"value": 5.0, "unit": "mg/100g"},
+        "method": "lit2kg:gpt-5.2",
+    }
+    base.update(kwargs)
+    return base
+
+
+def _ev(extractions: list[dict]) -> dict:
+    return {
+        "premise": "tomato contains lycopene",
+        "reference": {"id": "PMC1", "url": "u", "source_name": "FoodAtlas"},
+        "extraction": extractions,
+    }
+
+
+def _row(**evidences: object) -> dict:
+    return {
+        "name": "lycopene",
+        "id": "echem",
+        "median_concentration": {"unit": "mg/100g", "value": 99.0},
+        "fdc_evidences": evidences.get("fdc"),
+        "foodatlas_evidences": evidences.get("foodatlas"),
+        "dmd_evidences": evidences.get("dmd"),
+    }
+
+
+def _ext_with_conc(att_id: str, value: float) -> dict:
+    return _ext(att_id, converted_concentration={"value": value, "unit": "mg/100g"})
+
+
+def _mock_session_with_scores(scores: dict[str, float]) -> AsyncMock:
+    session = AsyncMock()
+    result = MagicMock()
+    rows = [MagicMock(attestation_id=aid, score=s) for aid, s in scores.items()]
+    result.__iter__.return_value = iter(rows)
+    session.execute.return_value = result
+    return session
+
+
+class TestShowAllMode:
+    @pytest.mark.asyncio
+    async def test_annotates_every_extraction(self):
+        rows = [
+            _row(
+                foodatlas=[_ev([_ext("at_low"), _ext("at_high"), _ext("at_unscored")])]
+            )
+        ]
+        session = _mock_session_with_scores({"at_low": 0.1, "at_high": 0.9})
+        out = await apply_trust_filter(session, rows, mode="show_all", threshold=0.3)
+        kept = out[0]["foodatlas_evidences"][0]["extraction"]
+        flags = {e["attestation_id"]: e["trust_low"] for e in kept}
+        assert flags == {
+            "at_low": True,
+            "at_high": False,
+            "at_unscored": False,  # no score → not flagged
+        }
+        # show_all keeps every extraction; just annotates.
+        assert len(kept) == 3
+
+    @pytest.mark.asyncio
+    async def test_no_db_call_when_no_attestations(self):
+        # Empty evidence arrays: nothing to annotate; no DB call.
+        rows = [_row()]
+        session = AsyncMock()
+        out = await apply_trust_filter(session, rows, mode="show_all", threshold=0.3)
+        assert out == rows
+        session.execute.assert_not_called()
+
+
+class TestDefaultMode:
+    @pytest.mark.asyncio
+    async def test_drops_low_trust_extractions(self):
+        rows = [
+            _row(
+                foodatlas=[
+                    _ev([_ext("at_low"), _ext("at_high")]),
+                ]
+            )
+        ]
+        session = _mock_session_with_scores({"at_low": 0.1, "at_high": 0.9})
+        out = await apply_trust_filter(session, rows, mode="default", threshold=0.3)
+        kept = out[0]["foodatlas_evidences"][0]["extraction"]
+        assert [e["attestation_id"] for e in kept] == ["at_high"]
+
+    @pytest.mark.asyncio
+    async def test_drops_row_when_all_evidences_filtered_out(self):
+        rows = [_row(foodatlas=[_ev([_ext("at_low")])])]
+        session = _mock_session_with_scores({"at_low": 0.1})
+        out = await apply_trust_filter(session, rows, mode="default", threshold=0.3)
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_keeps_row_when_other_evidences_remain(self):
+        # foodatlas filtered out, but fdc has no trust signal so passes.
+        rows = [
+            _row(
+                fdc=[_ev([_ext("at_fdc")])],
+                foodatlas=[_ev([_ext("at_low")])],
+            )
+        ]
+        session = _mock_session_with_scores({"at_low": 0.1})
+        out = await apply_trust_filter(session, rows, mode="default", threshold=0.3)
+        assert len(out) == 1
+        assert out[0]["foodatlas_evidences"] is None
+        assert out[0]["fdc_evidences"] is not None  # fdc default 1.0 ≥ 0.3
+
+    @pytest.mark.asyncio
+    async def test_attestations_without_signal_treated_as_high_trust(self):
+        rows = [_row(foodatlas=[_ev([_ext("at_unscored")])])]
+        session = _mock_session_with_scores({})  # no scores returned
+        out = await apply_trust_filter(session, rows, mode="default", threshold=0.3)
+        # default 1.0 ≥ 0.3 → kept
+        assert len(out) == 1
+
+
+class TestLowOnlyMode:
+    @pytest.mark.asyncio
+    async def test_keeps_only_low_trust_extractions(self):
+        rows = [
+            _row(
+                foodatlas=[_ev([_ext("at_low"), _ext("at_high")])],
+            )
+        ]
+        session = _mock_session_with_scores({"at_low": 0.1, "at_high": 0.9})
+        out = await apply_trust_filter(session, rows, mode="low_only", threshold=0.3)
+        kept = out[0]["foodatlas_evidences"][0]["extraction"]
+        assert [e["attestation_id"] for e in kept] == ["at_low"]
+
+    @pytest.mark.asyncio
+    async def test_drops_unscored_attestations(self):
+        # Unscored default to 1.0; under low_only those don't qualify.
+        rows = [_row(foodatlas=[_ev([_ext("at_unscored")])])]
+        session = _mock_session_with_scores({})
+        out = await apply_trust_filter(session, rows, mode="low_only", threshold=0.3)
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_drops_row_when_no_low_trust_evidence(self):
+        rows = [_row(foodatlas=[_ev([_ext("at_high")])])]
+        session = _mock_session_with_scores({"at_high": 0.9})
+        out = await apply_trust_filter(session, rows, mode="low_only", threshold=0.3)
+        assert out == []
+
+
+class TestMedianRecompute:
+    @pytest.mark.asyncio
+    async def test_default_recomputes_median_from_surviving(self):
+        # 5 + 50000 high-trust pair; the 50000 outlier is low-trust.
+        # Pre-filter median (across 3 values) = 5; surviving median = 5.
+        # The point: after filtering we recompute, dropping the bad value.
+        rows = [
+            _row(
+                foodatlas=[
+                    _ev(
+                        [
+                            _ext_with_conc("at_a", 4.0),
+                            _ext_with_conc("at_b", 5.0),
+                            _ext_with_conc("at_low", 50000.0),
+                        ]
+                    )
+                ]
+            )
+        ]
+        rows[0]["median_concentration"] = {"unit": "mg/100g", "value": 99.0}
+        session = _mock_session_with_scores({"at_a": 0.9, "at_b": 0.9, "at_low": 0.05})
+        out = await apply_trust_filter(session, rows, mode="default", threshold=0.3)
+        assert out[0]["median_concentration"]["value"] == 4.5  # median of [4, 5]
+
+    @pytest.mark.asyncio
+    async def test_low_only_recomputes_median_from_low(self):
+        rows = [
+            _row(
+                foodatlas=[
+                    _ev(
+                        [
+                            _ext_with_conc("at_high", 5.0),
+                            _ext_with_conc("at_low", 50000.0),
+                        ]
+                    )
+                ]
+            )
+        ]
+        session = _mock_session_with_scores({"at_high": 0.9, "at_low": 0.05})
+        out = await apply_trust_filter(session, rows, mode="low_only", threshold=0.3)
+        assert out[0]["median_concentration"]["value"] == 50000.0
+
+
+class TestThreshold:
+    @pytest.mark.asyncio
+    async def test_score_at_threshold_is_low_trust(self):
+        # Boundary inclusive on the LOW side: score == threshold is "low trust".
+        # Default mode drops it; low_only mode keeps it.
+        rows = [_row(foodatlas=[_ev([_ext("at_edge")])])]
+        session = _mock_session_with_scores({"at_edge": 0.3})
+        out = await apply_trust_filter(session, rows, mode="default", threshold=0.3)
+        assert out == []
+
+    @pytest.mark.asyncio
+    async def test_score_just_above_threshold_kept_default(self):
+        rows = [_row(foodatlas=[_ev([_ext("at_edge")])])]
+        session = _mock_session_with_scores({"at_edge": 0.301})
+        out = await apply_trust_filter(session, rows, mode="default", threshold=0.3)
+        assert len(out) == 1
+
+    @pytest.mark.asyncio
+    async def test_low_only_includes_threshold_value(self):
+        rows = [_row(foodatlas=[_ev([_ext("at_edge")])])]
+        session = _mock_session_with_scores({"at_edge": 0.3})
+        out = await apply_trust_filter(session, rows, mode="low_only", threshold=0.3)
+        assert len(out) == 1

--- a/backend/db/main.py
+++ b/backend/db/main.py
@@ -7,8 +7,10 @@ from pathlib import Path
 import click
 from src.config import DBSettings
 from src.engine import create_sync_engine
-from src.etl.loader import load_kg, refresh_materialized_views
+from src.etl.loader import load_kg, load_trust_only, refresh_materialized_views
 from src.etl.s3_sync import download_s3_prefix, is_s3_uri
+
+_LOAD_SCOPES = ["trust"]
 
 logging.basicConfig(
     level=logging.INFO,
@@ -35,24 +37,36 @@ def cli() -> None:
         "downloaded to a temporary directory first."
     ),
 )
-def load(parquet_dir: str) -> None:
+@click.option(
+    "--only",
+    type=click.Choice(_LOAD_SCOPES),
+    default=None,
+    help=(
+        "Load only the named subset, skipping the full ETL "
+        "(no schema drop, no base bulk-inserts, no MV refresh). "
+        "Currently supported: 'trust' — upserts trust_signals.parquet "
+        "into base_trust_signals (TrustBase, separate metadata)."
+    ),
+)
+def load(parquet_dir: str, only: str | None) -> None:
     """Load KGC parquet output into PostgreSQL."""
     settings = DBSettings()
     engine = create_sync_engine(settings)
+    loader = load_trust_only if only == "trust" else load_kg
 
     if is_s3_uri(parquet_dir):
         with tempfile.TemporaryDirectory(prefix="foodatlas-s3-") as tmp:
             local_dir = Path(tmp)
             download_s3_prefix(parquet_dir, local_dir)
             with engine.connect() as conn:
-                load_kg(conn, local_dir)
+                loader(conn, local_dir)
     else:
         local_path = Path(parquet_dir)
         if not local_path.exists():
             msg = f"Parquet directory does not exist: {local_path}"
             raise click.BadParameter(msg, param_hint="--parquet-dir")
         with engine.connect() as conn:
-            load_kg(conn, local_path)
+            loader(conn, local_path)
 
     click.echo("Done.")
 

--- a/backend/db/scripts/inspect_trust.py
+++ b/backend/db/scripts/inspect_trust.py
@@ -1,0 +1,94 @@
+"""Ad-hoc diagnostic: dump trust scores for a (food, chemical) pair.
+
+Filters by **canonical** food and chemical names — matching the values
+shown in the UI (`mv_food_chemical_composition.food_name` /
+`chemical_name`) — not by the raw IE-extracted strings. So
+`inspect_trust.py "tomato (raw)" "linoleic acid"` returns every
+attestation that resolves to those entities, regardless of whether IE
+extracted "tomato", "tomato fruit", "Tomato, raw", etc. The raw names
+remain in the output for inspection.
+
+Usage::
+
+    cd backend/db
+    uv run python scripts/inspect_trust.py "tomato (raw)" "linoleic acid"
+    uv run python scripts/inspect_trust.py tomato carbohydrate
+"""
+
+from __future__ import annotations
+
+import sys
+
+from sqlalchemy import text
+from src.config import DBSettings
+from src.engine import create_sync_engine
+
+
+def main(food: str, chemical: str) -> None:
+    settings = DBSettings()
+    engine = create_sync_engine(settings)
+
+    sql = text("""
+        WITH food AS (
+            SELECT foodatlas_id FROM base_entities WHERE common_name = :food
+        ),
+        chem AS (
+            SELECT foodatlas_id FROM base_entities WHERE common_name = :chemical
+        ),
+        atts AS (
+            SELECT DISTINCT unnest(bt.attestation_ids) AS attestation_id
+            FROM base_triplets bt, food, chem
+            WHERE bt.head_id = food.foodatlas_id
+              AND bt.tail_id = chem.foodatlas_id
+              AND bt.relationship_id = 'r1'
+        )
+        SELECT
+            a.attestation_id,
+            a.source,
+            a.head_name_raw,
+            a.tail_name_raw,
+            a.conc_value,
+            a.conc_value_raw || ' ' || a.conc_unit_raw AS original,
+            ts.score,
+            ts.reason
+        FROM atts
+        JOIN base_attestations a USING (attestation_id)
+        LEFT JOIN base_trust_signals ts
+               ON ts.attestation_id = a.attestation_id
+              AND ts.signal_kind = 'llm_plausibility'
+              AND ts.score >= 0
+        ORDER BY ts.score NULLS LAST, a.attestation_id
+    """)
+
+    with engine.connect() as conn:
+        rows = list(conn.execute(sql, {"food": food, "chemical": chemical}))
+
+    if not rows:
+        print(
+            f"No attestations found for canonical (food={food!r}, "
+            f"chemical={chemical!r}). Check the names against the UI."
+        )
+        return
+
+    print(f"{len(rows)} attestations for ({food!r}, {chemical!r}):")
+    print()
+    for r in rows:
+        m = r._mapping
+        score_str = f"{m['score']:.3f}" if m["score"] is not None else "(no signal)"
+        reason = (m["reason"] or "")[:80]
+        raw_food = (m["head_name_raw"] or "")[:18]
+        raw_chem = (m["tail_name_raw"] or "")[:20]
+        print(
+            f"  {m['attestation_id']:<16} "
+            f"src={m['source']:<25} "
+            f"raw=({raw_food} / {raw_chem}) "
+            f"orig={(m['original'] or '').strip():<22} "
+            f"score={score_str:<14} "
+            f"reason={reason}"
+        )
+
+
+if __name__ == "__main__":
+    food_arg = sys.argv[1] if len(sys.argv) > 1 else "tomato (raw)"
+    chem_arg = sys.argv[2] if len(sys.argv) > 2 else "linoleic acid"
+    main(food_arg, chem_arg)

--- a/backend/db/scripts/trust_distribution.py
+++ b/backend/db/scripts/trust_distribution.py
@@ -1,0 +1,120 @@
+"""Print the score distribution from base_trust_signals.
+
+Default: latest signals across all attestations. Optionally filter by
+signal_kind / version / source-prefix on the attestation.
+
+Usage::
+
+    cd backend/db
+    uv run python scripts/trust_distribution.py
+    uv run python scripts/trust_distribution.py --source lit2kg:gpt-4
+"""
+
+from __future__ import annotations
+
+import argparse
+
+from sqlalchemy import text
+from src.config import DBSettings
+from src.engine import create_sync_engine
+
+_BINS = [0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0001]
+_BIN_LABELS = [
+    "  0.0",
+    "≤ 0.1",
+    "≤ 0.2",
+    "≤ 0.3",
+    "≤ 0.4",
+    "≤ 0.5",
+    "≤ 0.6",
+    "≤ 0.7",
+    "≤ 0.8",
+    "≤ 0.9",
+    "≤ 1.0",
+]
+
+
+def main(signal_kind: str, version: str | None, source_prefix: str | None) -> None:
+    settings = DBSettings()
+    engine = create_sync_engine(settings)
+
+    where = ["ts.signal_kind = :kind"]
+    params: dict[str, str] = {"kind": signal_kind}
+    if version:
+        where.append("ts.version = :ver")
+        params["ver"] = version
+    if source_prefix:
+        where.append("a.source LIKE :src_prefix")
+        params["src_prefix"] = source_prefix + "%"
+
+    where_sql = " AND ".join(where)
+    sql = text(f"""
+        SELECT ts.score
+        FROM base_trust_signals ts
+        JOIN base_attestations a USING (attestation_id)
+        WHERE {where_sql}
+    """)
+
+    with engine.connect() as conn:
+        rows = list(conn.execute(sql, params))
+
+    scores = [float(r._mapping["score"]) for r in rows]
+    if not scores:
+        print(f"No trust signals match (kind={signal_kind}, version={version}).")
+        return
+
+    valid = [s for s in scores if s >= 0]
+    errors = len(scores) - len(valid)
+    print(f"Total signals: {len(scores)}  (errors / score=-1: {errors})")
+    print(f"Valid scores : {len(valid)}")
+    if not valid:
+        return
+
+    valid_sorted = sorted(valid)
+    n = len(valid_sorted)
+    mean = sum(valid_sorted) / n
+    median = (
+        valid_sorted[n // 2]
+        if n % 2
+        else (valid_sorted[n // 2 - 1] + valid_sorted[n // 2]) / 2
+    )
+    print(
+        f"Min / Median / Mean / Max : "
+        f"{valid_sorted[0]:.3f} / {median:.3f} / "
+        f"{mean:.3f} / {valid_sorted[-1]:.3f}"
+    )
+    print()
+
+    print("Below threshold:")
+    for t in (0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7):
+        below = sum(1 for s in valid if s <= t)
+        print(f"  score ≤ {t:.1f}  {below:>6}  {100 * below / n:5.1f}%")
+    print()
+
+    counts = [0] * (len(_BINS) - 1)
+    for s in valid:
+        for i in range(len(_BINS) - 1):
+            if _BINS[i] <= s < _BINS[i + 1]:
+                counts[i] += 1
+                break
+
+    width = max(counts) or 1
+    print(f"Histogram (bin: count, {width} = full bar)")
+    for label, c in zip(_BIN_LABELS[1:], counts, strict=True):
+        bar = "█" * int(40 * c / width)
+        pct = 100 * c / n
+        print(f"  {label:>6}  {c:>6}  {pct:5.1f}%  {bar}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--signal-kind", default="llm_plausibility")
+    parser.add_argument("--version", default=None)
+    parser.add_argument(
+        "--source",
+        default=None,
+        help="Filter to attestations whose `source` starts with this prefix "
+        "(e.g. 'lit2kg:gpt-4').",
+    )
+    args = parser.parse_args()
+    main(args.signal_kind, args.version, args.source)

--- a/backend/db/scripts/wipe_trust.py
+++ b/backend/db/scripts/wipe_trust.py
@@ -1,0 +1,33 @@
+"""Wipe all rows from base_trust_signals (keeps the table).
+
+Use when iterating on the trust prompt before shipping — re-judging produces
+new ``signal_id``s with different ``config_hash``, so old rows accumulate
+unless deleted. The API now picks the latest score per attestation, so this
+isn't strictly required, but it's nice for a clean snapshot.
+
+Usage::
+
+    cd backend/db
+    uv run python scripts/wipe_trust.py
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import text
+from src.config import DBSettings
+from src.engine import create_sync_engine
+
+
+def main() -> None:
+    settings = DBSettings()
+    engine = create_sync_engine(settings)
+    with engine.connect() as conn:
+        before = conn.execute(text("SELECT COUNT(*) FROM base_trust_signals")).scalar()
+        conn.execute(text("DELETE FROM base_trust_signals"))
+        conn.commit()
+        after = conn.execute(text("SELECT COUNT(*) FROM base_trust_signals")).scalar()
+    print(f"Deleted {before} rows, table now has {after} rows.")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/db/src/etl/loader.py
+++ b/backend/db/src/etl/loader.py
@@ -4,15 +4,21 @@ import logging
 from pathlib import Path
 
 from sqlalchemy import text
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.engine import Connection
 
-from ..models import Base
+from ..models import Base, BaseTrustSignal, TrustBase
 from . import parquet_reader
 from .bulk_insert import bulk_copy
 from .materializer import refresh_all
 from .materializer_search import refresh_search
 
 logger = logging.getLogger(__name__)
+
+# Postgres caps a single statement at 65535 bind parameters (16-bit). With
+# ~10 columns per trust-signal row, batches of 5000 stay well under the cap
+# (50000 params) with safety margin for any future column additions.
+_UPSERT_BATCH_SIZE = 5000
 
 
 def _recreate_schema(conn: Connection) -> None:
@@ -22,6 +28,40 @@ def _recreate_schema(conn: Connection) -> None:
     conn.execute(text("CREATE EXTENSION IF NOT EXISTS pg_trgm"))
     Base.metadata.create_all(bind=conn)
     conn.commit()
+
+
+def _load_trust_signals(conn: Connection, kg_dir: Path) -> None:
+    """Idempotently create base_trust_signals (separate Base) and upsert rows.
+
+    Trust signals live on :class:`TrustBase`, distinct from :class:`Base`, so
+    ``_recreate_schema``'s ``Base.metadata.drop_all`` does not wipe them.
+    Re-running ``db load`` upserts (last-write-wins on signal_id) so a
+    successful retry from KGC overwrites a prior error row.
+    """
+    TrustBase.metadata.create_all(bind=conn)
+    df = parquet_reader.read_trust_signals(kg_dir)
+    if df is None or df.empty:
+        logger.info("No trust_signals.parquet to load (skipping).")
+        return
+
+    rows = df.to_dict(orient="records")
+    # Chunk to stay under Postgres' 65535-bind-parameter cap per statement.
+    for start in range(0, len(rows), _UPSERT_BATCH_SIZE):
+        chunk = rows[start : start + _UPSERT_BATCH_SIZE]
+        stmt = pg_insert(BaseTrustSignal).values(chunk)
+        stmt = stmt.on_conflict_do_update(
+            index_elements=[BaseTrustSignal.signal_id],
+            set_={
+                "score": stmt.excluded.score,
+                "reason": stmt.excluded.reason,
+                "error_text": stmt.excluded.error_text,
+                "model": stmt.excluded.model,
+                "created_at": stmt.excluded.created_at,
+            },
+        )
+        conn.execute(stmt)
+    conn.commit()
+    logger.info("Upserted %d trust-signal rows.", len(rows))
 
 
 def load_kg(conn: Connection, parquet_dir: Path) -> None:
@@ -120,9 +160,25 @@ def load_kg(conn: Connection, parquet_dir: Path) -> None:
     )
     conn.commit()
 
-    # 4. Materialize API tables
+    # 4. Trust signals (optional, opt-in via KGC trust stage)
+    _load_trust_signals(conn, kg_dir)
+
+    # 5. Materialize API tables
     refresh_materialized_views(conn)
     logger.info("ETL complete.")
+
+
+def load_trust_only(conn: Connection, parquet_dir: Path) -> None:
+    """Upsert only ``trust_signals.parquet`` into ``base_trust_signals``.
+
+    Skips the full ETL — no schema drop, no base bulk-inserts, no MV refresh.
+    Trust signals are already isolated on :class:`TrustBase` and the API does
+    a query-time JOIN against them, so neither step is needed when iterating
+    on KGC's trust stage outputs alone.
+    """
+    kg_dir = parquet_dir.resolve()
+    logger.info("Loading trust signals only from %s", kg_dir)
+    _load_trust_signals(conn, kg_dir)
 
 
 def refresh_materialized_views(conn: Connection) -> None:

--- a/backend/db/src/etl/materializer_composition.py
+++ b/backend/db/src/etl/materializer_composition.py
@@ -159,8 +159,9 @@ def _build_extractions_vectorized(
 
     return pd.Series(
         [
-            _make_extraction(sf, sc, cr, cv, cu, src, hc, tc)
-            for sf, sc, cr, cv, cu, src, hc, tc in zip(
+            _make_extraction(att_id, sf, sc, cr, cv, cu, src, hc, tc)
+            for att_id, sf, sc, cr, cv, cu, src, hc, tc in zip(
+                df["attestation_id"],
                 df["show_food"],
                 df["show_chem"],
                 conc_raw,
@@ -177,6 +178,7 @@ def _build_extractions_vectorized(
 
 
 def _make_extraction(
+    attestation_id: str,
     sf: str,
     sc: str,
     cr: str | None,
@@ -186,7 +188,12 @@ def _make_extraction(
     head_candidates: list[str] | None,
     tail_candidates: list[str] | None,
 ) -> dict:
+    # `attestation_id` is exposed on every evidence dict (fdc/foodatlas/dmd)
+    # so the API can JOIN against base_trust_signals at request time without
+    # re-aggregating from base tables. FDC and DMD attestations don't carry
+    # trust signals today; they're surfaced for symmetry and future use.
     extraction: dict = {
+        "attestation_id": attestation_id,
         "extracted_food_name": sf,
         "extracted_chemical_name": sc,
         "extracted_concentration": cr,

--- a/backend/db/src/etl/parquet_reader.py
+++ b/backend/db/src/etl/parquet_reader.py
@@ -59,6 +59,22 @@ def read_evidence(kg_dir: Path) -> pd.DataFrame:
     return df
 
 
+def read_trust_signals(kg_dir: Path) -> pd.DataFrame | None:
+    """Read trust_signals.parquet if present; return None when missing.
+
+    Distinct from the other readers because trust signals are optional (the
+    KGC trust stage is opt-in) and accumulate across runs rather than being
+    rebuilt from scratch each ``db load``.
+    """
+    path = kg_dir / "trust_signals.parquet"
+    if not path.exists() or path.stat().st_size == 0:
+        return None
+    df = pd.read_parquet(path)
+    df["reason"] = df["reason"].fillna("")
+    df["error_text"] = df["error_text"].fillna("")
+    return df
+
+
 def read_attestations(kg_dir: Path) -> pd.DataFrame:
     df = pd.read_parquet(kg_dir / "attestations.parquet")
     for col in (

--- a/backend/db/src/models/__init__.py
+++ b/backend/db/src/models/__init__.py
@@ -6,6 +6,8 @@ from .entities import BaseEntity
 from .evidence import BaseEvidence
 from .relationships import Relationship
 from .triplets import BaseTriplet
+from .trust_base import TrustBase
+from .trust_signals import BaseTrustSignal
 from .views import (
     MVChemicalDiseaseCorrelation,
     MVChemicalEntity,
@@ -22,6 +24,7 @@ __all__ = [
     "BaseEntity",
     "BaseEvidence",
     "BaseTriplet",
+    "BaseTrustSignal",
     "MVChemicalDiseaseCorrelation",
     "MVChemicalEntity",
     "MVDiseaseEntity",
@@ -30,4 +33,5 @@ __all__ = [
     "MVMetadataStatistics",
     "MVSearchAutoComplete",
     "Relationship",
+    "TrustBase",
 ]

--- a/backend/db/src/models/trust_base.py
+++ b/backend/db/src/models/trust_base.py
@@ -1,0 +1,13 @@
+"""Separate SQLAlchemy declarative base for trust-signal tables.
+
+`base_trust_signals` is registered here rather than on :class:`Base` so the KG
+loader's ``Base.metadata.drop_all()`` (loader.py) does not wipe accumulated
+trust signals on each ``db load``. The trust loader calls
+``TrustBase.metadata.create_all(bind=conn)`` idempotently and upserts rows.
+"""
+
+from sqlalchemy.orm import DeclarativeBase
+
+
+class TrustBase(DeclarativeBase):
+    """Base class for trust-signal ORM models."""

--- a/backend/db/src/models/trust_signals.py
+++ b/backend/db/src/models/trust_signals.py
@@ -1,0 +1,51 @@
+"""Base trust-signal ORM model — from KGC trust_signals.parquet."""
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Double, Index, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from .trust_base import TrustBase
+
+
+class BaseTrustSignal(TrustBase):
+    """One score from one signal version for one attestation.
+
+    `signal_id` is `sha256(attestation_id + signal_kind + version + config_hash)` so
+    re-running an unchanged version is a no-op (handled via upsert in the loader).
+
+    No FK to `base_attestations` — `attestation_id` is content-addressed and
+    stable across KG rebuilds, but `base_attestations` is dropped/recreated on
+    every `db load`. Skipping the FK lets trust signals outlive base rebuilds.
+    """
+
+    __tablename__ = "base_trust_signals"
+
+    signal_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    attestation_id: Mapped[str] = mapped_column(String(30), nullable=False)
+    signal_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    version: Mapped[str] = mapped_column(Text, nullable=False)
+    config_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    model: Mapped[str] = mapped_column(Text, nullable=False)
+    # score in [0, 1] for valid judgments; -1 sentinel marks an LLM/transport
+    # error and is paired with non-empty `error_text`. Rows with score < 0 are
+    # selected for retry on the next trust-stage run.
+    score: Mapped[float] = mapped_column(Double, nullable=False)
+    reason: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    error_text: Mapped[str] = mapped_column(Text, nullable=False, server_default="")
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+    )
+
+    __table_args__ = (
+        Index("ix_base_trust_signals_attestation", "attestation_id"),
+        Index(
+            "ix_base_trust_signals_run",
+            "signal_kind",
+            "version",
+            "config_hash",
+        ),
+        Index("ix_base_trust_signals_kind_score", "signal_kind", "score"),
+    )

--- a/backend/db/tests/test_materializer_helpers.py
+++ b/backend/db/tests/test_materializer_helpers.py
@@ -95,6 +95,7 @@ class TestBuildEvidenceJson:
         return pd.DataFrame(
             [
                 {
+                    "attestation_id": "at_test",
                     "source": source,
                     "reference": {
                         "url": "https://example.com",
@@ -154,6 +155,7 @@ class TestBuildEvidenceJson:
         group = pd.DataFrame(
             [
                 {
+                    "attestation_id": "at_test",
                     "source": "fdc",
                     "reference": {"fdc_id": "12345", "url": "https://fdc.example.com"},
                     "conc_value": 10.0,
@@ -173,6 +175,7 @@ class TestBuildEvidenceJson:
         group = pd.DataFrame(
             [
                 {
+                    "attestation_id": "at_test",
                     "source": "dmd",
                     "reference": {
                         "dmd_concentration_id": "dmd99",
@@ -195,6 +198,7 @@ class TestBuildEvidenceJson:
         group = pd.DataFrame(
             [
                 {
+                    "attestation_id": "at_a",
                     "source": "lit2kg",
                     "reference": {"pmcid": "PMC1", "text": "same premise"},
                     "conc_value": 5.0,
@@ -205,6 +209,7 @@ class TestBuildEvidenceJson:
                     "show_chem": "vit c",
                 },
                 {
+                    "attestation_id": "at_b",
                     "source": "lit2kg",
                     "reference": {"pmcid": "PMC1", "text": "same premise"},
                     "conc_value": 10.0,
@@ -225,6 +230,7 @@ class TestBuildEvidenceJson:
         group = pd.DataFrame(
             [
                 {
+                    "attestation_id": "at_test",
                     "source": "fdc",
                     "reference": "not_a_dict",
                     "conc_value": 10.0,
@@ -242,6 +248,7 @@ class TestBuildEvidenceJson:
     def test_empty_group_returns_all_none(self):
         group = pd.DataFrame(
             columns=[
+                "attestation_id",
                 "source",
                 "reference",
                 "conc_value",
@@ -267,6 +274,7 @@ class TestBuildEvidenceJson:
         group = pd.DataFrame(
             [
                 {
+                    "attestation_id": "at_test",
                     "source": "lit2kg",
                     "reference": {"pmcid": "", "text": "premise"},
                     "conc_value": 5.0,
@@ -289,6 +297,7 @@ class TestAmbiguousCandidates:
         return pd.DataFrame(
             [
                 {
+                    "attestation_id": "at_test",
                     "source": "lit2kg",
                     "reference": {"pmcid": "PMC1", "text": "t"},
                     "conc_value": 10.0,

--- a/backend/db/tests/test_trust_signals_load.py
+++ b/backend/db/tests/test_trust_signals_load.py
@@ -1,0 +1,125 @@
+"""Tests for trust-signal loader behaviour and TrustBase isolation."""
+
+from datetime import UTC, datetime
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+from src.etl.loader import _UPSERT_BATCH_SIZE, _load_trust_signals, load_trust_only
+from src.models import Base, BaseTrustSignal, TrustBase
+
+
+class TestTrustBaseIsolation:
+    """`base_trust_signals` must live on TrustBase, not Base."""
+
+    def test_trust_table_not_in_base_metadata(self):
+        # If it were in Base.metadata, drop_all() in _recreate_schema would
+        # wipe accumulated trust signals on every db load.
+        assert "base_trust_signals" not in Base.metadata.tables
+
+    def test_trust_table_in_trust_metadata(self):
+        assert "base_trust_signals" in TrustBase.metadata.tables
+
+    def test_no_fk_to_base_attestations(self):
+        # No FK because base_attestations is dropped/recreated each db load,
+        # but trust signals must outlive that cycle. attestation_id is
+        # content-addressed and stable across rebuilds.
+        fks = list(BaseTrustSignal.__table__.foreign_keys)
+        assert fks == []
+
+
+class TestLoadTrustSignals:
+    """Skips cleanly when parquet is missing; upserts when rows are present."""
+
+    @patch("src.etl.loader.parquet_reader")
+    def test_skips_when_parquet_missing(self, mock_reader: MagicMock):
+        mock_reader.read_trust_signals.return_value = None
+        conn = MagicMock()
+        _load_trust_signals(conn, Path("/nonexistent"))
+        # create_all is called on TrustBase (idempotent), but no execute() for
+        # the upsert because there's nothing to load.
+        conn.execute.assert_not_called()
+
+    @patch("src.etl.loader.parquet_reader")
+    def test_skips_when_dataframe_empty(self, mock_reader: MagicMock):
+        mock_reader.read_trust_signals.return_value = pd.DataFrame()
+        conn = MagicMock()
+        _load_trust_signals(conn, Path("/nonexistent"))
+        conn.execute.assert_not_called()
+
+    @patch("src.etl.loader.parquet_reader")
+    def test_chunks_large_inputs_under_postgres_param_cap(self, mock_reader: MagicMock):
+        # Postgres caps statements at 65535 bind params; the loader must
+        # chunk rather than send one giant INSERT. 12_000 rows by 10 cols
+        # would be 120k params in one shot - chunking should split it.
+        n_rows = 2 * _UPSERT_BATCH_SIZE + 100  # forces 3 chunks
+        rows = [
+            {
+                "signal_id": f"{i:064x}",
+                "attestation_id": f"at{i:028x}"[:30],
+                "signal_kind": "llm_plausibility",
+                "version": "v1",
+                "config_hash": "h" * 64,
+                "model": "gemini:gemini-2.5-flash-lite",
+                "score": 0.5,
+                "reason": "",
+                "error_text": "",
+                "created_at": datetime.now(UTC),
+            }
+            for i in range(n_rows)
+        ]
+        mock_reader.read_trust_signals.return_value = pd.DataFrame(rows)
+        conn = MagicMock()
+        _load_trust_signals(conn, Path("/nonexistent"))
+        assert conn.execute.call_count == 3  # 5000 + 5000 + 100
+        conn.commit.assert_called_once()  # one commit at the end, not per chunk
+
+    @patch("src.etl.loader.parquet_reader")
+    def test_upserts_when_rows_present(self, mock_reader: MagicMock):
+        df = pd.DataFrame(
+            [
+                {
+                    "signal_id": "s" * 64,
+                    "attestation_id": "atabc",
+                    "signal_kind": "llm_plausibility",
+                    "version": "v1",
+                    "config_hash": "h" * 64,
+                    "model": "gemini:gemini-2.5-flash-lite",
+                    "score": 0.9,
+                    "reason": "ok",
+                    "error_text": "",
+                    "created_at": datetime.now(UTC),
+                }
+            ]
+        )
+        mock_reader.read_trust_signals.return_value = df
+        conn = MagicMock()
+        _load_trust_signals(conn, Path("/nonexistent"))
+        # execute is called with the upsert; commit happens after.
+        assert conn.execute.call_count == 1
+        conn.commit.assert_called_once()
+
+
+class TestLoadTrustOnly:
+    """`load_trust_only` is the public CLI entry point — should NOT touch the
+    full-ETL helpers (no _recreate_schema, no bulk_copy, no MV refresh)."""
+
+    @patch("src.etl.loader.refresh_materialized_views")
+    @patch("src.etl.loader.bulk_copy")
+    @patch("src.etl.loader._recreate_schema")
+    @patch("src.etl.loader.parquet_reader")
+    def test_skips_full_etl_helpers(
+        self,
+        mock_reader: MagicMock,
+        mock_recreate: MagicMock,
+        mock_bulk: MagicMock,
+        mock_refresh: MagicMock,
+    ):
+        mock_reader.read_trust_signals.return_value = None
+        conn = MagicMock()
+        load_trust_only(conn, Path("/nonexistent"))
+        mock_recreate.assert_not_called()
+        mock_bulk.assert_not_called()
+        mock_refresh.assert_not_called()
+        # but it DOES read the trust parquet
+        mock_reader.read_trust_signals.assert_called_once()

--- a/backend/kgc/README.md
+++ b/backend/kgc/README.md
@@ -53,6 +53,8 @@ Settings use Pydantic with env prefix `KGC_` (e.g. `KGC_DATA_DIR`). Key fields:
 
 Override via environment variables, config JSON, or CLI flags.
 
+The `trust` stage additionally needs `GOOGLE_API_KEY` set in the **root** `.env` (`<repo-root>/.env`, loaded by `KGCSettings`) for its v1 Gemini provider — see [#162](https://github.com/AI-Institute-Food-Systems/foodatlas/issues/162) for the open question of consolidating per-sub-project `.env` handling.
+
 ## Pipeline Stages
 
 | # | Stage | Description |
@@ -62,17 +64,19 @@ Override via environment variables, config JSON, or CLI flags.
 | 2 | `triplets` | Build ontology `is_a` (food/chemical/disease) + composition (`food → chemical`) + chemical–disease correlation triplets from ingest edges |
 | 3 | `ie` | Fold IE TSV output (from `backend/ie/`) into the KG: parse concentrations, resolve raw food/chemical names, attach attestations |
 | 4 | `enrichment` | Chemical/food classification (ChEBI/FoodOn-driven), grouping, common names, synonym display, flavor descriptions |
+| 5 | `trust` | Per-attestation trustworthiness signals (e.g. LLM plausibility judge). Reads attestations + evidence, runs the configured judge, writes `trust_signals.parquet`. Requires `GOOGLE_API_KEY` for the v1 Gemini provider. Configured via `pipeline.stages.trust` in the config JSON. |
 
 ### Architecture in two phases
 
 **Phase 1 — Ingest** (`src/pipeline/ingest/`): Source adapters parse raw data files into a standardized parquet format with `nodes`, `edges`, and `xrefs` per source. Each adapter implements the `SourceAdapter` protocol. Output lives under `outputs/ingest/<source>/`.
 
-**Phase 2 — Construct** (the `entities`, `triplets`, `ie`, and `enrichment` stages): Builds the KG from Phase 1 output, writing checkpoints between stages so each stage can be re-run independently.
+**Phase 2 — Construct** (the `entities`, `triplets`, `ie`, `enrichment`, and `trust` stages): Builds the KG from Phase 1 output, writing checkpoints between stages so each stage can be re-run independently.
 
 - **EntityRunner**: Loads ingest sources → filters ontology subtrees → multi-pass resolution (primary from authoritative sources; secondary linked via xrefs; unlinked entities created) → saves entities + lookup tables.
 - **TripletRunner**: Loads ingest sources → walks ingest edges to build typed triplets (`food_food`, `food_chemical`, `chemical_chemical`, `chemical_disease`, `disease_disease`) → writes `triplets.parquet` + per-triplet `evidence.parquet` and `attestations.parquet`.
 - **IERunner**: Reads `backend/ie/outputs/extraction/<date>/extraction_predicted.tsv`, parses concentrations, resolves food/chemical names against the entity LUTs, and folds new triplets + attestations into the KG. Ambiguous resolutions are written separately to `attestations_ambiguous.parquet`.
 - **Enrichment**: Adds derived attributes (chemical classification, food classification, synonym display, flavors) and grouping artifacts. Writes outputs into `outputs/kg/intermediate/` and back-fills entity rows.
+- **TrustRunner**: Per-attestation trustworthiness signals (v1 LLM-plausibility judge using Gemini 2.5 Flash-Lite; future: faithfulness, range checks). Reads attestations + evidence, runs the configured judge, writes `trust_signals.parquet`. Configured under `pipeline.stages.trust` in the config JSON; needs `GOOGLE_API_KEY` for the v1 Gemini provider. The DB loader upserts these into a separate `TrustBase` table so signals survive `db load` rebuilds. See `scripts/spot_check_food.py` for ad-hoc per-food calibration runs that bypass the persistent parquet.
 
 Manual corrections live in `src/config/corrections.yaml` and are loaded by `EntityRunner` during Phase 2. **Phase 1 ingest stays faithful** to the source data (no IDs dropped, no xrefs remapped) — corrections only kick in once construct starts. This separation keeps ingest reproducible and makes corrections auditable in one place.
 
@@ -110,6 +114,7 @@ The pipeline writes parquet files to `outputs/kg/` (the loadable knowledge graph
 | `evidence.parquet` | Per-triplet evidence rows |
 | `attestations.parquet` | Per-triplet attestation/provenance |
 | `attestations_ambiguous.parquet` | Attestations whose entity resolution was ambiguous |
+| `trust_signals.parquet` | Per-attestation trust scores from the `trust` stage (one row per `(attestation, signal_kind, version, config_hash)`) |
 | `CHANGELOG.md` | Auto-generated diff vs. the previous run (consumed by `publish-bundle.sh`) |
 | `SUMMARY.md` | Human-readable summary of the run (entity/triplet counts, source coverage) |
 
@@ -166,7 +171,13 @@ kgc/
 │       │   ├── flavor.py
 │       │   ├── common_name.py
 │       │   ├── synonyms_display.py
-│       │   └── grouping/          # Chemical / food / MeSH grouping
+│       │   └── grouping/          # Chemical / food / MeSH grouping (currently dormant)
+│       ├── trust/                 # Stage 5: per-attestation trust signals
+│       │   ├── runner.py          # TrustRunner — selection + dispatch + parquet write
+│       │   ├── versions.py        # Version-bundle yaml loader + canonical config_hash
+│       │   ├── labels.py          # Score → label thresholds (config-tunable)
+│       │   ├── llm/               # Pluggable provider clients (gemini, bedrock stub, openai stub)
+│       │   └── versions/          # Per-(signal_kind, version) yml bundles (e.g. llm_plausibility/v1.yml)
 │       └── report/                # Diff against previous KG (CHANGELOG.md generator)
 ├── data/                          # Reference data sources (see data/README.md)
 ├── outputs/                       # Generated output directory

--- a/backend/kgc/pyproject.toml
+++ b/backend/kgc/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "pyarrow>=15.0.0",
     "python-dotenv>=1.2.2",
     "pyyaml>=6.0.0",
+    "google-genai>=1.0.0",
 ]
 
 [tool.uv]

--- a/backend/kgc/scripts/spot_check_food.py
+++ b/backend/kgc/scripts/spot_check_food.py
@@ -1,0 +1,144 @@
+"""Ad-hoc trust-judge spot check for a specific food.
+
+Runs the configured `llm_plausibility v1` prompt against every lit2kg
+attestation whose ``head_name_raw`` exactly matches the given food, prints a
+sorted summary, and DOES NOT write to ``trust_signals.parquet`` — pure
+diagnostic.
+
+Usage::
+
+    cd backend/kgc
+    uv run python scripts/spot_check_food.py tomato
+    uv run python scripts/spot_check_food.py "cherry tomato"
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pandas as pd
+
+# Importing settings triggers the module-level load_dotenv on the root .env
+# (where GOOGLE_API_KEY lives, plus any proxy overrides). Without this, a
+# SOCKS proxy from the shell environment leaks into httpx and breaks Gemini.
+from src.models import settings as _settings  # noqa: F401
+from src.models.trust_signal import LLMPlausibilityResponse
+from src.pipeline.trust.llm import create_client
+from src.pipeline.trust.llm.base import TrustLLMRequest
+from src.pipeline.trust.versions import load_version
+
+KG_DIR = Path("outputs/kg")
+
+
+def main(food: str) -> None:
+    att = pd.read_parquet(KG_DIR / "attestations.parquet")
+    ev = pd.read_parquet(KG_DIR / "evidence.parquet").set_index("evidence_id")
+
+    mask = (
+        att["source"].str.startswith("lit2kg:")
+        & att["conc_value"].notna()
+        & (att["head_name_raw"] == food)
+    )
+    matched = att[mask].set_index("attestation_id")
+    print(f"Found {len(matched)} lit2kg attestations for food={food!r}")
+    if matched.empty:
+        return
+
+    bundle, config_hash = load_version("llm_plausibility", "v1")
+    print(f"Using {bundle.signal_kind} v1 (config_hash={config_hash[:12]})")
+
+    requests: list[TrustLLMRequest] = []
+    for att_id, row in matched.iterrows():
+        raw = ev.loc[row["evidence_id"], "reference"]
+        try:
+            ref = json.loads(raw)
+        except (TypeError, ValueError):
+            continue
+        sentence = ref.get("text") or ""
+        if not sentence:
+            continue
+        user_prompt = bundle.prompts.user.format(
+            food=row["head_name_raw"],
+            chemical=row["tail_name_raw"],
+            conc_value=row["conc_value"],
+            conc_value_raw=row.get("conc_value_raw", ""),
+            conc_unit_raw=row.get("conc_unit_raw", ""),
+            sentence=sentence,
+        )
+        requests.append(TrustLLMRequest(key=str(att_id), user_prompt=user_prompt))
+
+    print(f"Built {len(requests)} requests; running sync (16 workers)…")
+    client = create_client(bundle.provider)
+    responses = client.submit_batch(bundle, requests, batch_mode=False)
+
+    rows: list[dict] = []
+    for resp in responses:
+        if resp.error or resp.raw_text is None:
+            rows.append(
+                {
+                    "attestation_id": resp.key,
+                    "score": -1.0,
+                    "reason": "",
+                    "error": resp.error or "no response",
+                }
+            )
+            continue
+        try:
+            parsed = LLMPlausibilityResponse.model_validate_json(resp.raw_text)
+            rows.append(
+                {
+                    "attestation_id": resp.key,
+                    "score": parsed.score,
+                    "reason": parsed.reason,
+                    "error": "",
+                }
+            )
+        except Exception as exc:
+            rows.append(
+                {
+                    "attestation_id": resp.key,
+                    "score": -1.0,
+                    "reason": "",
+                    "error": str(exc)[:120],
+                }
+            )
+
+    df = pd.DataFrame(rows)
+    extras = matched[
+        ["tail_name_raw", "conc_value", "conc_value_raw", "conc_unit_raw"]
+    ].reset_index()
+    df = df.merge(extras, on="attestation_id", how="left")
+    # Display: show the original (raw) value+unit AND the standardised mg/100g
+    # value side by side, so the unit label is always unambiguous.
+    df["original"] = (
+        df["conc_value_raw"].astype(str).str.strip()
+        + " "
+        + df["conc_unit_raw"].astype(str).str.strip()
+    ).str.strip()
+    df = df.rename(columns={"conc_value": "mg_per_100g"})
+    df = df.sort_values("score")
+
+    pd.set_option("display.max_colwidth", 100)
+    pd.set_option("display.width", 220)
+    print()
+    print(f"=== {food} judgments (sorted by score) ===")
+    print(
+        df[["tail_name_raw", "original", "mg_per_100g", "score", "reason"]].to_string(
+            index=False
+        )
+    )
+    print()
+    valid = df[df["score"] >= 0]
+    print(f"Score distribution ({len(valid)}/{len(df)} valid):")
+    print(valid["score"].describe().round(3))
+    n_err = int((df["score"] < 0).sum())
+    if n_err:
+        print(f"\n{n_err} error rows:")
+        print(df[df["score"] < 0][["tail_name_raw", "error"]].to_string(index=False))
+
+
+if __name__ == "__main__":
+    food_arg = sys.argv[1] if len(sys.argv) > 1 else "tomato"
+    main(food_arg)

--- a/backend/kgc/src/config/defaults.json
+++ b/backend/kgc/src/config/defaults.json
@@ -11,6 +11,14 @@
       },
       "kg_init": {
         "previous_kg_entities": "data/PreviousFAKG/v3.3/entities.tsv"
+      },
+      "trust": {
+        "signal": "llm_plausibility",
+        "version": "v1",
+        "source_filter": ["lit2kg:"],
+        "limit": null,
+        "batch_size": 50000,
+        "batch_mode": false
       }
     }
   }

--- a/backend/kgc/src/models/settings.py
+++ b/backend/kgc/src/models/settings.py
@@ -30,9 +30,35 @@ class KgInitStageConfig(BaseModel):
     previous_kg_entities: str = ""
 
 
+class TrustStageConfig(BaseModel):
+    """Config for the TRUST stage (per-attestation trustworthiness scoring).
+
+    All knobs live here — the trust stage takes no per-stage CLI flags. These
+    are operational concerns (where/how to run); semantic concerns (what to
+    ask the model) live in the version yml under
+    ``backend/kgc/src/pipeline/trust/versions/<signal>/<version>.yml``.
+    """
+
+    signal: str = "llm_plausibility"
+    version: str = "v1"
+    # List of attestation-source prefixes to include; None / [] = all sources.
+    # E.g. ["lit2kg:"] judges all literature-extracted attestations across
+    # IE-model variants; ["lit2kg:", "foodatlas"] also includes internal
+    # corrections. Skip-by-default sources like "fdc" (curated USDA) and
+    # ontology edges (chebi/foodon/...) are excluded by leaving them out.
+    source_filter: list[str] | None = None
+    limit: int | None = None  # None = all unjudged attestations
+    batch_size: int = 50000
+    # batch_mode toggles provider Batch API (cheap, slow) vs sync calls (full
+    # price, fast). Operational knob — does not change `config_hash`, so
+    # flipping does not force a re-judge.
+    batch_mode: bool = True
+
+
 class StagesConfig(BaseModel):
     data_cleaning: DataCleaningStageConfig = DataCleaningStageConfig()
     kg_init: KgInitStageConfig = KgInitStageConfig()
+    trust: TrustStageConfig = TrustStageConfig()
 
 
 class PipelineConfig(BaseModel):

--- a/backend/kgc/src/models/trust_signal.py
+++ b/backend/kgc/src/models/trust_signal.py
@@ -1,0 +1,52 @@
+"""Trust-signal models — pydantic schema for the KGC trust pipeline output.
+
+The KGC trust stage produces one :class:`TrustSignal` per (attestation, signal
+version) and writes them to ``kg_dir/trust_signals.parquet``. The DB loader
+upserts those rows into ``base_trust_signals``.
+
+`signal_id` is content-addressed:
+``sha256(attestation_id + "|" + signal_kind + "|" + version + "|" + config_hash)``
+where ``config_hash`` is the canonicalized hash of the version yml that produced
+the score. Re-running an unchanged version is a no-op; editing the yml — even a
+single prompt word — produces a new ``config_hash`` and writes new rows
+alongside the old, enabling A/B comparison without losing history.
+"""
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class TrustSignal(BaseModel):
+    """One trust-signal row, as written to ``trust_signals.parquet``.
+
+    ``score`` is in ``[0, 1]`` for valid judgments. ``-1`` is a sentinel for
+    rows where the LLM/transport errored; those rows carry a non-empty
+    ``error_text`` and are picked up for retry by the next trust-stage run.
+    """
+
+    signal_id: str
+    attestation_id: str
+    signal_kind: str
+    version: str
+    config_hash: str
+    model: str
+    score: float = Field(ge=-1.0, le=1.0)
+    reason: str = ""
+    error_text: str = ""
+    created_at: datetime
+
+
+class LLMPlausibilityResponse(BaseModel):
+    """Validated JSON shape returned by an LLM judge for plausibility.
+
+    Strict ``[0, 1]`` — the LLM never produces the ``-1`` error sentinel; that
+    is set by the runner when it has to write a row for an errored request.
+
+    The prompt asks for ≤ 200-char reasons but we accept up to 500 here so a
+    minor overrun does not throw away the (still-valid) score. Treat this as
+    soft-rejection: the prompt tightens, the validator forgives.
+    """
+
+    score: float = Field(ge=0.0, le=1.0)
+    reason: str = Field(default="", max_length=500)

--- a/backend/kgc/src/pipeline/runner.py
+++ b/backend/kgc/src/pipeline/runner.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from ..utils.timing import log_duration
-from .checkpoint import load_checkpoint
+from .checkpoint import load_checkpoint, save_checkpoint
 from .enrichment.classification import classify_chemicals
 from .enrichment.flavor import apply_flavor_descriptions
 from .enrichment.food_classification import classify_foods
@@ -18,6 +18,7 @@ from .knowledge_graph import KnowledgeGraph
 from .load_sources import load_sources
 from .stages import ALL_STAGES, PipelineStage
 from .triplets.runner import TripletRunner
+from .trust.runner import TrustRunner
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -86,6 +87,11 @@ class PipelineRunner:
         classify_foods(kg.entities, kg.triplets)
         apply_flavor_descriptions(kg, sources)
         kg.save()
+        save_checkpoint(kg_dir, "enrichment")
+
+    def _run_trust(self) -> None:
+        runner = TrustRunner(self._settings)
+        runner.run()
 
 
 _STAGE_HANDLERS: dict[PipelineStage, Callable[[PipelineRunner], None]] = {
@@ -94,4 +100,5 @@ _STAGE_HANDLERS: dict[PipelineStage, Callable[[PipelineRunner], None]] = {
     PipelineStage.TRIPLETS: PipelineRunner._run_triplets,
     PipelineStage.IE: PipelineRunner._run_ie,
     PipelineStage.ENRICHMENT: PipelineRunner._run_enrichment,
+    PipelineStage.TRUST: PipelineRunner._run_trust,
 }

--- a/backend/kgc/src/pipeline/stages.py
+++ b/backend/kgc/src/pipeline/stages.py
@@ -15,6 +15,7 @@ class PipelineStage(Enum):
     TRIPLETS = 2
     IE = 3
     ENRICHMENT = 4
+    TRUST = 5
 
 
 ALL_STAGES: list[PipelineStage] = sorted(PipelineStage, key=lambda s: s.value)

--- a/backend/kgc/src/pipeline/trust/__init__.py
+++ b/backend/kgc/src/pipeline/trust/__init__.py
@@ -1,0 +1,1 @@
+"""Trust-signal pipeline stage — per-attestation trustworthiness scoring."""

--- a/backend/kgc/src/pipeline/trust/labels.py
+++ b/backend/kgc/src/pipeline/trust/labels.py
@@ -1,0 +1,31 @@
+"""Score → label mapping for trust signals.
+
+Labels are *derived*, never stored. The DB only holds the float score; query
+sites map to a label via this helper. Thresholds are caller-tunable so the
+API layer (or a SQL view) can experiment without rewriting data.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+TrustLabel = Literal["implausible", "suspicious", "plausible"]
+
+
+def label_from_score(
+    score: float,
+    *,
+    suspicious_at: float = 0.33,
+    plausible_at: float = 0.67,
+) -> TrustLabel:
+    """Map a 0..1 score to one of three labels.
+
+    Boundaries are inclusive on the lower bound: ``score == suspicious_at``
+    counts as ``"suspicious"`` (not ``"implausible"``); ``score == plausible_at``
+    counts as ``"plausible"``.
+    """
+    if score < suspicious_at:
+        return "implausible"
+    if score < plausible_at:
+        return "suspicious"
+    return "plausible"

--- a/backend/kgc/src/pipeline/trust/llm/__init__.py
+++ b/backend/kgc/src/pipeline/trust/llm/__init__.py
@@ -1,0 +1,35 @@
+"""LLM clients for trust signals; pluggable via VersionBundle.provider."""
+
+from __future__ import annotations
+
+from .base import TrustLLMClient, TrustLLMRequest, TrustLLMResponse
+from .bedrock import BedrockClient
+from .gemini import GeminiClient
+from .openai import OpenAIClient
+
+__all__ = [
+    "BedrockClient",
+    "GeminiClient",
+    "OpenAIClient",
+    "TrustLLMClient",
+    "TrustLLMRequest",
+    "TrustLLMResponse",
+    "create_client",
+]
+
+
+def create_client(provider: str) -> TrustLLMClient:
+    """Factory: ``provider`` value from a version yml → live client.
+
+    Raises ``ValueError`` on unknown providers and ``NotImplementedError``
+    for stubbed providers — both fail at runner startup before any LLM
+    spend happens.
+    """
+    if provider == "gemini":
+        return GeminiClient()
+    if provider == "bedrock":
+        return BedrockClient()
+    if provider == "openai":
+        return OpenAIClient()
+    msg = f"Unknown trust LLM provider: {provider!r}"
+    raise ValueError(msg)

--- a/backend/kgc/src/pipeline/trust/llm/base.py
+++ b/backend/kgc/src/pipeline/trust/llm/base.py
@@ -1,0 +1,60 @@
+"""Abstract LLM client for trust signals.
+
+The runner builds one :class:`TrustLLMRequest` per attestation, hands the
+collection to a provider-specific :class:`TrustLLMClient`, and writes one
+``base_trust_signals`` row per :class:`TrustLLMResponse`. Clients are
+responsible for batching, polling, and translating the version-bundle
+generation params + response schema into the provider's call shape.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ..versions import VersionBundle
+
+
+@dataclass(frozen=True)
+class TrustLLMRequest:
+    """One judge request, identified by a stable key for response join."""
+
+    key: str
+    user_prompt: str
+
+
+@dataclass(frozen=True)
+class TrustLLMResponse:
+    """One judge response. Exactly one of ``raw_text`` / ``error`` is set."""
+
+    key: str
+    raw_text: str | None
+    error: str | None
+
+
+class TrustLLMClient(ABC):
+    """Provider-agnostic LLM client used by the trust pipeline."""
+
+    @abstractmethod
+    def submit_batch(
+        self,
+        bundle: VersionBundle,
+        requests: list[TrustLLMRequest],
+        *,
+        batch_mode: bool = True,
+    ) -> list[TrustLLMResponse]:
+        """Run ``requests`` through the configured model, in input order.
+
+        ``batch_mode`` is operational: ``True`` prefers the provider's Batch
+        API (cheap, ~minutes-to-hours latency); ``False`` issues sync calls
+        (full price, immediate). Implementations may ignore the flag if a
+        provider doesn't support both modes.
+
+        Returns one response per request; the i-th response corresponds to
+        the i-th request, matched by ``key``. A row the provider failed to
+        process should appear as a :class:`TrustLLMResponse` with
+        ``raw_text=None`` and a non-empty ``error`` string — the runner
+        records it as a ``score=-1`` row so a future re-run can retry.
+        """

--- a/backend/kgc/src/pipeline/trust/llm/bedrock.py
+++ b/backend/kgc/src/pipeline/trust/llm/bedrock.py
@@ -1,0 +1,25 @@
+"""Bedrock client stub. Not implemented for v1 — fail fast at config time."""
+
+from __future__ import annotations
+
+from .base import TrustLLMClient, TrustLLMRequest, TrustLLMResponse
+
+
+class BedrockClient(TrustLLMClient):
+    """Stub. v1 ships Gemini only; switch via ``provider:`` in version yml."""
+
+    def __init__(self) -> None:
+        msg = (
+            "BedrockClient is not implemented yet. v1 ships with provider=gemini; "
+            "set provider: gemini in the version yml or implement BedrockClient."
+        )
+        raise NotImplementedError(msg)
+
+    def submit_batch(  # pragma: no cover - unreachable; __init__ raises
+        self,
+        bundle,
+        requests: list[TrustLLMRequest],
+        *,
+        batch_mode: bool = True,
+    ) -> list[TrustLLMResponse]:
+        raise NotImplementedError

--- a/backend/kgc/src/pipeline/trust/llm/gemini.py
+++ b/backend/kgc/src/pipeline/trust/llm/gemini.py
@@ -1,0 +1,340 @@
+"""Gemini Batch API client.
+
+Uses the ``google-genai`` SDK. Auth via ``GOOGLE_API_KEY`` env var. Batch flow:
+
+1. Write per-request lines to a JSONL file (one record = one prompt).
+2. Upload via the Files API.
+3. Submit a Batch job referencing the uploaded file id.
+4. Poll until terminal state.
+5. Download the result file (also JSONL) and join responses back by ``key``.
+
+Same pattern the IE pipeline uses for OpenAI batch in
+``backend/ie/src/pipeline/extraction/runner.py`` — adapted for Gemini's
+``contents`` / ``system_instruction`` shape.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import tempfile
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, cast
+
+from google import genai
+from google.genai import types
+from google.genai.errors import APIError
+from tenacity import (
+    before_sleep_log,
+    retry,
+    retry_if_exception,
+    stop_after_attempt,
+    wait_exponential_jitter,
+)
+from tqdm import tqdm
+from tqdm.contrib.logging import logging_redirect_tqdm
+
+from .base import TrustLLMClient, TrustLLMRequest, TrustLLMResponse
+
+if TYPE_CHECKING:
+    from ..versions import VersionBundle
+
+logger = logging.getLogger(__name__)
+
+# google-genai uses httpx which logs every request at INFO; the SDK itself
+# also logs an "AFC is enabled with max remote calls: 10" line per call
+# (Automatic Function Calling — irrelevant for us because we pass no tools).
+# Both fire once per request and drown the tqdm progress bar; bump to WARNING.
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("google_genai.models").setLevel(logging.WARNING)
+
+_COMPLETED_STATES = frozenset(
+    {
+        "JOB_STATE_SUCCEEDED",
+        "JOB_STATE_FAILED",
+        "JOB_STATE_CANCELLED",
+        "JOB_STATE_EXPIRED",
+    }
+)
+_POLL_INTERVAL_S = 30
+_SYNC_MAX_WORKERS = 16
+
+# HTTP codes that indicate a transient server / quota condition. Anything
+# else (400 INVALID_ARGUMENT, 401/403 auth) is a real error and not retried.
+_TRANSIENT_CODES = frozenset({429, 500, 502, 503, 504})
+
+
+def _is_transient_api_error(exc: BaseException) -> bool:
+    if not isinstance(exc, APIError):
+        return False
+    return getattr(exc, "code", None) in _TRANSIENT_CODES
+
+
+def _job_state_name(job: Any) -> str:
+    """Extract `state.name` from a batch job, raising if either is missing.
+
+    The SDK types both ``state`` and ``state.name`` as Optional, but in
+    practice they're always populated for a job that just round-tripped
+    through ``batches.get``. Raise if not, so we fail loudly rather than
+    silently treating a None as a non-terminal state.
+    """
+    state = job.state
+    if state is None or state.name is None:
+        msg = f"Gemini batch {getattr(job, 'name', '?')!r} returned without state"
+        raise RuntimeError(msg)
+    return cast("str", state.name)
+
+
+@retry(
+    stop=stop_after_attempt(5),
+    wait=wait_exponential_jitter(initial=1, max=30),
+    retry=retry_if_exception(_is_transient_api_error),
+    # tenacity types `before_sleep_log` against its own LoggerProtocol; the
+    # stdlib Logger is structurally compatible but the type stubs disagree.
+    before_sleep=before_sleep_log(cast("Any", logger), logging.WARNING),
+    reraise=True,
+)
+def _generate_with_retry(client: Any, model: str, contents: str, config: Any) -> Any:
+    """Wrap `models.generate_content` in exponential-backoff retry.
+
+    Retries up to 5 attempts on transient API errors (429, 5xx) with
+    exponentially increasing waits up to 30s plus jitter. After the final
+    attempt the exception propagates and the caller records an error row.
+    Non-transient errors (400, 401, 403, schema validation) are not retried.
+    """
+    return client.models.generate_content(model=model, contents=contents, config=config)
+
+
+class GeminiClient(TrustLLMClient):
+    """Trust-signal client using the Gemini Batch API (50% off, 24h SLA)."""
+
+    def __init__(self, api_key: str | None = None) -> None:
+        key = api_key or os.environ.get("GOOGLE_API_KEY")
+        if not key:
+            msg = "GOOGLE_API_KEY env var is required for GeminiClient"
+            raise RuntimeError(msg)
+        self._client = genai.Client(api_key=key)
+
+    def submit_batch(
+        self,
+        bundle: VersionBundle,
+        requests: list[TrustLLMRequest],
+        *,
+        batch_mode: bool = True,
+    ) -> list[TrustLLMResponse]:
+        if not requests:
+            return []
+        if batch_mode:
+            return self._submit_via_batch_api(bundle, requests)
+        return self._submit_sync(bundle, requests)
+
+    def _submit_sync(
+        self,
+        bundle: VersionBundle,
+        requests: list[TrustLLMRequest],
+    ) -> list[TrustLLMResponse]:
+        """Concurrent sync calls — fast iteration for small dev runs.
+
+        Each request is one ``models.generate_content`` call; ``ThreadPoolExecutor``
+        gives concurrency up to :data:`_SYNC_MAX_WORKERS`. Use this when batch
+        latency (5-15 min queue + 24h SLA) outweighs the 50% batch discount.
+        """
+        config = types.GenerateContentConfig(
+            system_instruction=bundle.prompts.system,
+            temperature=bundle.generation.temperature,
+            max_output_tokens=bundle.generation.max_output_tokens,
+            response_mime_type=bundle.generation.response_mime_type,
+        )
+
+        def _one(req: TrustLLMRequest) -> TrustLLMResponse:
+            try:
+                resp = _generate_with_retry(
+                    self._client,
+                    bundle.model,
+                    req.user_prompt,
+                    config,
+                )
+                return TrustLLMResponse(key=req.key, raw_text=resp.text, error=None)
+            except Exception as exc:
+                # Per-row failure (after retry exhaustion or non-transient
+                # error) is recorded as a -1 score so a re-run can retry it.
+                return TrustLLMResponse(key=req.key, raw_text=None, error=str(exc))
+
+        results: dict[str, TrustLLMResponse] = {}
+        # logging_redirect_tqdm routes log records through tqdm.write so
+        # tenacity retry-warnings (and any other INFO/WARNING) don't shred
+        # the progress bar — the bar lifts, the line prints, the bar redraws.
+        with (
+            logging_redirect_tqdm(),
+            ThreadPoolExecutor(max_workers=_SYNC_MAX_WORKERS) as pool,
+            tqdm(total=len(requests), desc="Gemini sync") as pbar,
+        ):
+            futures = {pool.submit(_one, req): req for req in requests}
+            for fut in as_completed(futures):
+                resp = fut.result()
+                results[resp.key] = resp
+                pbar.update(1)
+        return [
+            results.get(
+                req.key,
+                TrustLLMResponse(
+                    key=req.key, raw_text=None, error="missing future result"
+                ),
+            )
+            for req in requests
+        ]
+
+    def _submit_via_batch_api(
+        self,
+        bundle: VersionBundle,
+        requests: list[TrustLLMRequest],
+    ) -> list[TrustLLMResponse]:
+        with tempfile.TemporaryDirectory() as tmp:
+            jsonl_path = Path(tmp) / "trust_batch_input.jsonl"
+            self._write_jsonl(jsonl_path, bundle, requests)
+
+            uploaded = self._client.files.upload(
+                file=str(jsonl_path),
+                config=types.UploadFileConfig(
+                    display_name=f"trust-{bundle.signal_kind}-{len(requests)}",
+                    mime_type="jsonl",
+                ),
+            )
+            uploaded_name = uploaded.name
+            if uploaded_name is None:
+                msg = "Gemini files.upload returned without a name"
+                raise RuntimeError(msg)
+            logger.info(
+                "Uploaded %d-request batch input as %s",
+                len(requests),
+                uploaded_name,
+            )
+
+            job = self._client.batches.create(
+                model=bundle.model,
+                src=uploaded_name,
+                config={"display_name": f"trust-{bundle.signal_kind}"},
+            )
+            job_name = job.name
+            if job_name is None:
+                msg = "Gemini batches.create returned without a name"
+                raise RuntimeError(msg)
+            logger.info("Created Gemini batch job %s", job_name)
+
+            job = self._poll_until_done(job_name)
+            return self._collect_results(job, requests)
+
+    def _write_jsonl(
+        self,
+        path: Path,
+        bundle: VersionBundle,
+        requests: list[TrustLLMRequest],
+    ) -> None:
+        # Note: the yml's `response_schema` is intentionally NOT forwarded to
+        # Gemini. Gemini's REST API requires a Gemini-flavoured Schema (uppercase
+        # type enums, snake_case constraint names) which is not 1:1 with
+        # standard JSON Schema. For v1 we rely on `response_mime_type` +
+        # explicit prompt instructions + pydantic validation on our side. The
+        # schema in the yml still documents intent and contributes to
+        # `config_hash`, so prompt/schema edits still force a re-judge.
+        gen_config: dict[str, Any] = {
+            "temperature": bundle.generation.temperature,
+            "max_output_tokens": bundle.generation.max_output_tokens,
+            "response_mime_type": bundle.generation.response_mime_type,
+        }
+        with path.open("w", encoding="utf-8") as f:
+            for req in requests:
+                record = {
+                    "key": req.key,
+                    "request": {
+                        "contents": [
+                            {"parts": [{"text": req.user_prompt}], "role": "user"}
+                        ],
+                        "system_instruction": {
+                            "parts": [{"text": bundle.prompts.system}]
+                        },
+                        "generation_config": gen_config,
+                    },
+                }
+                f.write(json.dumps(record, ensure_ascii=False))
+                f.write("\n")
+
+    def _poll_until_done(self, name: str) -> Any:
+        # tqdm shows a spinner with the current state + elapsed time. Gemini
+        # doesn't expose per-row progress for a running batch, so this is a
+        # status indicator rather than a percentage bar.
+        bar_format = "{desc} [{elapsed}] {postfix}"
+        with (
+            logging_redirect_tqdm(),
+            tqdm(
+                desc=f"Gemini batch {name}",
+                bar_format=bar_format,
+                leave=True,
+            ) as pbar,
+        ):
+            job = self._client.batches.get(name=name)
+            state_name = _job_state_name(job)
+            pbar.set_postfix_str(state_name)
+            while state_name not in _COMPLETED_STATES:
+                time.sleep(_POLL_INTERVAL_S)
+                pbar.update(0)  # refresh the elapsed clock without advancing
+                job = self._client.batches.get(name=name)
+                state_name = _job_state_name(job)
+                pbar.set_postfix_str(state_name)
+        if state_name != "JOB_STATE_SUCCEEDED":
+            msg = f"Gemini batch {name} ended in {state_name}"
+            raise RuntimeError(msg)
+        return job
+
+    def _collect_results(
+        self,
+        job: Any,
+        requests: list[TrustLLMRequest],
+    ) -> list[TrustLLMResponse]:
+        if not (job.dest and job.dest.file_name):
+            msg = f"Gemini batch {job.name} succeeded but produced no output file"
+            raise RuntimeError(msg)
+
+        raw = self._client.files.download(file=job.dest.file_name)
+        by_key: dict[str, TrustLLMResponse] = {}
+        for line in raw.decode("utf-8").splitlines():
+            if not line.strip():
+                continue
+            rec = json.loads(line)
+            key = rec.get("key", "")
+            err = rec.get("error")
+            if err:
+                by_key[key] = TrustLLMResponse(key=key, raw_text=None, error=str(err))
+                continue
+            by_key[key] = TrustLLMResponse(
+                key=key,
+                raw_text=_extract_text(rec.get("response") or {}),
+                error=None,
+            )
+
+        return [
+            by_key.get(
+                req.key,
+                TrustLLMResponse(
+                    key=req.key,
+                    raw_text=None,
+                    error="missing in batch output",
+                ),
+            )
+            for req in requests
+        ]
+
+
+def _extract_text(response: dict[str, Any]) -> str | None:
+    """Pull the first candidate's first text part from a Gemini response."""
+    candidates = response.get("candidates") or []
+    if not candidates:
+        return None
+    parts = (candidates[0].get("content") or {}).get("parts") or []
+    if not parts:
+        return None
+    text = parts[0].get("text")
+    return text if isinstance(text, str) else None

--- a/backend/kgc/src/pipeline/trust/llm/openai.py
+++ b/backend/kgc/src/pipeline/trust/llm/openai.py
@@ -1,0 +1,25 @@
+"""OpenAI client stub. Not implemented for v1 — fail fast at config time."""
+
+from __future__ import annotations
+
+from .base import TrustLLMClient, TrustLLMRequest, TrustLLMResponse
+
+
+class OpenAIClient(TrustLLMClient):
+    """Stub. v1 ships Gemini only; switch via ``provider:`` in version yml."""
+
+    def __init__(self) -> None:
+        msg = (
+            "OpenAIClient is not implemented yet. v1 ships with provider=gemini; "
+            "set provider: gemini in the version yml or implement OpenAIClient."
+        )
+        raise NotImplementedError(msg)
+
+    def submit_batch(  # pragma: no cover - unreachable; __init__ raises
+        self,
+        bundle,
+        requests: list[TrustLLMRequest],
+        *,
+        batch_mode: bool = True,
+    ) -> list[TrustLLMResponse]:
+        raise NotImplementedError

--- a/backend/kgc/src/pipeline/trust/runner.py
+++ b/backend/kgc/src/pipeline/trust/runner.py
@@ -1,0 +1,270 @@
+"""TrustRunner — score attestations using a trust-signal LLM judge.
+
+Loads :class:`KnowledgeGraph` for attestations + evidence, reads any existing
+``trust_signals.parquet``, selects the to-judge set (no row yet for this
+``(signal_kind, version, config_hash)`` OR existing row has ``score < 0``),
+calls the configured :class:`TrustLLMClient`, validates JSON output, and
+rewrites ``trust_signals.parquet`` so it always represents the latest "best
+knowledge" — no duplicate signal_ids per ``(signal_kind, version,
+config_hash)``.
+
+Errors (LLM/transport) are recorded as rows with ``score = -1`` and a
+non-empty ``error_text`` so they can be retried by the next run; on success
+the upsert in the DB loader overwrites the prior error row.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import pandas as pd
+from pydantic import ValidationError
+
+from ...models.trust_signal import LLMPlausibilityResponse, TrustSignal
+from ..checkpoint import load_checkpoint
+from ..knowledge_graph import KnowledgeGraph
+from .llm import create_client
+from .llm.base import TrustLLMRequest, TrustLLMResponse
+from .versions import VersionBundle, load_version
+
+if TYPE_CHECKING:
+    from ...models.settings import KGCSettings, TrustStageConfig
+
+logger = logging.getLogger(__name__)
+
+FILE_TRUST_SIGNALS = "trust_signals.parquet"
+
+_TRUST_COLUMNS = list(TrustSignal.model_fields.keys())
+
+
+def signal_id(
+    attestation_id: str,
+    signal_kind: str,
+    version: str,
+    config_hash: str,
+) -> str:
+    """Content-addressed signal id: dedup key for a (att, kind, ver, cfg) tuple."""
+    key = f"{attestation_id}|{signal_kind}|{version}|{config_hash}"
+    return hashlib.sha256(key.encode("utf-8")).hexdigest()
+
+
+class TrustRunner:
+    """Orchestrate the TRUST stage: load, judge, persist."""
+
+    def __init__(self, settings: KGCSettings) -> None:
+        self._settings = settings
+        self._cfg: TrustStageConfig = settings.pipeline.stages.trust
+
+    def run(self) -> None:
+        kg_dir = Path(self._settings.kg_dir)
+        load_checkpoint(kg_dir, "enrichment")
+        bundle, config_hash = load_version(self._cfg.signal, self._cfg.version)
+        logger.info(
+            "Trust stage: signal=%s version=%s model=%s config_hash=%s",
+            bundle.signal_kind,
+            self._cfg.version,
+            bundle.model,
+            config_hash[:12],
+        )
+
+        kg = KnowledgeGraph(self._settings)
+
+        existing = _read_existing(kg_dir / FILE_TRUST_SIGNALS)
+        retry_ids = self._select_attestations(kg, existing, bundle, config_hash)
+        if not retry_ids:
+            logger.info("Trust stage: no attestations to judge; exiting.")
+            return
+
+        requests = self._build_requests(kg, retry_ids, bundle)
+        if not requests:
+            logger.info("Trust stage: 0 valid requests after rendering; exiting.")
+            return
+
+        if self._cfg.limit is not None:
+            requests = requests[: self._cfg.limit]
+            logger.info(
+                "Trust stage: capped to %d requests by config.limit",
+                len(requests),
+            )
+
+        client = create_client(bundle.provider)
+        responses = client.submit_batch(
+            bundle, requests, batch_mode=self._cfg.batch_mode
+        )
+
+        new_rows = _responses_to_rows(
+            responses,
+            requests_by_key={r.key: r for r in requests},
+            bundle=bundle,
+            version=self._cfg.version,
+            config_hash=config_hash,
+        )
+
+        merged = _merge_for_run(
+            existing,
+            new_rows,
+            bundle.signal_kind,
+            self._cfg.version,
+            config_hash,
+        )
+        out_path = kg_dir / FILE_TRUST_SIGNALS
+        merged.to_parquet(out_path, index=False)
+        logger.info(
+            "Trust stage: wrote %d rows to %s (this run: %d new/retried)",
+            len(merged),
+            out_path,
+            len(new_rows),
+        )
+
+    def _select_attestations(
+        self,
+        kg: KnowledgeGraph,
+        existing: pd.DataFrame,
+        bundle: VersionBundle,
+        config_hash: str,
+    ) -> list[str]:
+        """Return attestation IDs to judge in this run.
+
+        Selection rule:
+        - If no existing row for (signal_kind, version, config_hash, att_id) → judge it.
+        - If the existing row has score < 0 (a prior error) → judge it (will overwrite).
+        - Otherwise (existing row with score >= 0) → skip.
+        Optionally filtered by ``source_filter`` from the stage config.
+        """
+        att_df: pd.DataFrame = kg.attestations._records
+        if att_df.empty:
+            return []
+
+        candidate = att_df
+        if self._cfg.source_filter:
+            prefixes = tuple(self._cfg.source_filter)
+            candidate = candidate[candidate["source"].str.startswith(prefixes)]
+            logger.info(
+                "Trust stage: source_filter=%r → %d candidate attestations",
+                self._cfg.source_filter,
+                len(candidate),
+            )
+
+        # Attestations whose conc_value is unparseable contribute no signal.
+        candidate = candidate[candidate["conc_value"].notna()]
+
+        if existing.empty:
+            return list(candidate.index)
+
+        run_existing = existing[
+            (existing["signal_kind"] == bundle.signal_kind)
+            & (existing["version"] == self._cfg.version)
+            & (existing["config_hash"] == config_hash)
+        ]
+        done_ids = set(run_existing[run_existing["score"] >= 0]["attestation_id"])
+        return [aid for aid in candidate.index if aid not in done_ids]
+
+    def _build_requests(
+        self,
+        kg: KnowledgeGraph,
+        attestation_ids: list[str],
+        bundle: VersionBundle,
+    ) -> list[TrustLLMRequest]:
+        # The v1 plausibility prompt deliberately sees only food + chemical
+        # + standardized concentration — no original units, no source
+        # sentence, no evidence. This is "is the claim reasonable on its
+        # own?", not "does the source support the claim?" (faithfulness /
+        # entailment is intentionally out of scope for this signal_kind).
+        att_df: pd.DataFrame = kg.attestations._records
+        rows = att_df.loc[attestation_ids]
+
+        requests: list[TrustLLMRequest] = []
+        for att_id, row in rows.iterrows():
+            try:
+                user_prompt = bundle.prompts.user.format(
+                    food=row.get("head_name_raw", ""),
+                    chemical=row.get("tail_name_raw", ""),
+                    conc_value=row["conc_value"],
+                )
+            except KeyError:
+                logger.exception(
+                    "Prompt template references unknown field for %s",
+                    att_id,
+                )
+                continue
+            requests.append(TrustLLMRequest(key=str(att_id), user_prompt=user_prompt))
+        return requests
+
+
+def _read_existing(path: Path) -> pd.DataFrame:
+    if not path.exists() or path.stat().st_size == 0:
+        return pd.DataFrame(columns=_TRUST_COLUMNS)
+    return pd.read_parquet(path)
+
+
+def _responses_to_rows(
+    responses: list[TrustLLMResponse],
+    *,
+    requests_by_key: dict[str, TrustLLMRequest],
+    bundle: VersionBundle,
+    version: str,
+    config_hash: str,
+) -> pd.DataFrame:
+    now = datetime.now(UTC)
+    model_id = f"{bundle.provider}:{bundle.model}"
+    records: list[dict[str, Any]] = []
+    for resp in responses:
+        if resp.key not in requests_by_key:
+            continue  # provider returned an unknown key — ignore
+        if resp.error or resp.raw_text is None:
+            score = -1.0
+            reason = ""
+            error_text = resp.error or "no response text"
+        else:
+            try:
+                parsed = LLMPlausibilityResponse.model_validate_json(resp.raw_text)
+                score = parsed.score
+                reason = parsed.reason
+                error_text = ""
+            except ValidationError as exc:
+                score = -1.0
+                reason = ""
+                error_text = f"response failed schema: {exc!s}"
+
+        sid = signal_id(resp.key, bundle.signal_kind, version, config_hash)
+        records.append(
+            {
+                "signal_id": sid,
+                "attestation_id": resp.key,
+                "signal_kind": bundle.signal_kind,
+                "version": version,
+                "config_hash": config_hash,
+                "model": model_id,
+                "score": score,
+                "reason": reason,
+                "error_text": error_text,
+                "created_at": now,
+            }
+        )
+    return pd.DataFrame.from_records(records, columns=_TRUST_COLUMNS)
+
+
+def _merge_for_run(
+    existing: pd.DataFrame,
+    new_rows: pd.DataFrame,
+    signal_kind: str,
+    version: str,
+    config_hash: str,
+) -> pd.DataFrame:
+    """Drop any existing rows for this run that are being replaced; append new."""
+    if existing.empty:
+        return new_rows
+    if new_rows.empty:
+        return existing
+    new_keys = set(new_rows["signal_id"])
+    keep_mask = ~(
+        (existing["signal_kind"] == signal_kind)
+        & (existing["version"] == version)
+        & (existing["config_hash"] == config_hash)
+        & (existing["signal_id"].isin(new_keys))
+    )
+    return pd.concat([existing[keep_mask], new_rows], ignore_index=True)

--- a/backend/kgc/src/pipeline/trust/versions.py
+++ b/backend/kgc/src/pipeline/trust/versions.py
@@ -1,0 +1,105 @@
+"""Version-bundle loader for trust signals.
+
+Each trust-signal version is a self-contained YAML at
+``versions/<signal_kind>/<version>.yml`` bundling provider, model, prompts,
+generation params, and response schema. The :func:`compute_config_hash` over
+the parsed (canonicalized) yml is the dedup key that lets re-running an
+unchanged version be a no-op while a single-character prompt edit forces a
+re-judge under the same ``version`` label.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+import yaml
+from pydantic import BaseModel, Field
+
+
+class GenerationParams(BaseModel):
+    """LLM generation knobs propagated to the provider call."""
+
+    temperature: float = 0.0
+    max_output_tokens: int = 256
+    response_mime_type: str = "application/json"
+
+
+class PromptTemplates(BaseModel):
+    """Prompt strings; ``user`` is rendered per-attestation via ``str.format``."""
+
+    system: str
+    user: str
+
+
+class VersionBundle(BaseModel):
+    """Parsed and validated version yml.
+
+    Holds only "what we ask the model": provider, model id, prompts,
+    generation params, response schema. Operational knobs (batch vs sync,
+    limits, source filters) live in :class:`TrustStageConfig`. This means
+    flipping sync → batch does NOT change ``config_hash`` and therefore
+    does NOT force a re-judge — same intent, different deployment.
+
+    v1 is LLM-shaped (provider/model/prompts required). Future non-LLM signal
+    kinds (e.g. ``range_check``) will introduce a sibling shape and a
+    discriminated union; not pre-engineered here.
+    """
+
+    signal_kind: str
+    description: str = ""
+    provider: Literal["gemini", "bedrock", "openai"]
+    model: str
+    generation: GenerationParams = Field(default_factory=GenerationParams)
+    prompts: PromptTemplates
+    response_schema: dict[str, Any]
+
+
+_DEFAULT_VERSIONS_DIR = Path(__file__).resolve().parent / "versions"
+
+
+def compute_config_hash(parsed: dict[str, Any]) -> str:
+    """Canonical sha256 of a parsed yml dict.
+
+    Invariant under cosmetic yaml differences (key order, comments, trailing
+    whitespace) because we serialize the parsed structure with sorted keys and
+    no whitespace before hashing. Sensitive to any semantic change — prompt
+    edits, model swaps, temperature tweaks — because those mutate the parsed
+    values that get serialized.
+    """
+    canonical = json.dumps(
+        parsed,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def load_version(
+    signal_kind: str,
+    version: str,
+    *,
+    base_dir: Path | None = None,
+) -> tuple[VersionBundle, str]:
+    """Load and validate ``versions/<signal_kind>/<version>.yml``.
+
+    Returns the parsed :class:`VersionBundle` and the canonical config hash.
+    The hash is the dedup key written to ``trust_signals.parquet`` rows.
+    """
+    base = base_dir if base_dir is not None else _DEFAULT_VERSIONS_DIR
+    path = base / signal_kind / f"{version}.yml"
+    parsed: Any = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(parsed, dict):
+        msg = f"Version yml at {path} did not parse to a mapping"
+        raise ValueError(msg)
+    bundle = VersionBundle.model_validate(parsed)
+    if bundle.signal_kind != signal_kind:
+        msg = (
+            f"Version yml at {path} declares signal_kind={bundle.signal_kind!r} "
+            f"but lives under {signal_kind!r} directory"
+        )
+        raise ValueError(msg)
+    return bundle, compute_config_hash(parsed)

--- a/backend/kgc/src/pipeline/trust/versions/llm_plausibility/v1.yml
+++ b/backend/kgc/src/pipeline/trust/versions/llm_plausibility/v1.yml
@@ -1,0 +1,68 @@
+signal_kind: llm_plausibility
+description: |
+  Plausibility v1 — Gemini 2.5 Flash-Lite via Gemini Batch API.
+
+  Scores how plausible an extracted (food, chemical, concentration) claim is
+  using world knowledge of food composition. Faithfulness (does the source
+  sentence support the claim?) is a separate signal and is intentionally
+  out of scope here.
+
+provider: gemini
+model: gemini-2.5-flash-lite
+
+generation:
+  temperature: 0.0
+  max_output_tokens: 256
+  response_mime_type: application/json
+
+prompts:
+  system: |
+    You are a food chemistry expert evaluating the plausibility of a claim
+    about a chemical's concentration in a food.
+
+    A claim is given as: a food name, a chemical name, and a concentration
+    in milligrams per 100 grams (mg/100g).
+
+    Judge whether the claimed concentration is plausible given general world
+    knowledge of food composition. Consider:
+    - Whether the chemical is known to occur in this food, or in similar foods.
+    - Whether the magnitude is in a typical range for the food / chemical pair.
+      Use orders of magnitude — exact numbers vary by cultivar, ripeness, and
+      measurement method.
+    - Whether the value is physically possible. Anything above 100,000 mg/100g
+      exceeds 100% by mass and is impossible.
+
+    You are NOT given the source paper, the source sentence, or the original
+    units. This is a deliberate choice: this signal is plausibility only, not
+    faithfulness or entailment. Judge the world-state plausibility of the
+    claim as stated, on its own.
+
+    Output a JSON object with two fields:
+      score:  number between 0 and 1.
+              0  = clearly implausible or impossible.
+              1  = clearly plausible, well within typical ranges.
+              ~0.3-0.7 = unusual but not impossible (rare cultivar, extreme
+              processing, edge of known range).
+      reason: ONE short sentence — strictly ≤ 25 words and ≤ 200 characters.
+              Cite an order of magnitude or a specific concern. Do NOT
+              re-state the input or hedge with multiple clauses. Verbose
+              reasons are rejected.
+
+  user: |
+    Food: {food}
+    Chemical: {chemical}
+    Concentration: {conc_value} mg/100g
+
+    Return JSON: {{"score": <number 0..1>, "reason": "<one short sentence>"}}.
+
+response_schema:
+  type: object
+  required: [score, reason]
+  properties:
+    score:
+      type: number
+      minimum: 0
+      maximum: 1
+    reason:
+      type: string
+      maxLength: 200

--- a/backend/kgc/tests/test_pipeline_stages.py
+++ b/backend/kgc/tests/test_pipeline_stages.py
@@ -4,7 +4,7 @@ from src.pipeline.stages import ALL_STAGES, PipelineStage
 
 
 def test_all_stages_present() -> None:
-    assert len(PipelineStage) == 5
+    assert len(PipelineStage) == 6
 
 
 def test_stage_names() -> None:
@@ -14,6 +14,7 @@ def test_stage_names() -> None:
         "TRIPLETS",
         "IE",
         "ENRICHMENT",
+        "TRUST",
     }
     assert {s.name for s in PipelineStage} == expected
 

--- a/backend/kgc/tests/test_trust_labels.py
+++ b/backend/kgc/tests/test_trust_labels.py
@@ -1,0 +1,38 @@
+"""Tests for label_from_score boundary behaviour."""
+
+from src.pipeline.trust.labels import label_from_score
+
+
+class TestLabelFromScore:
+    def test_zero_is_implausible(self):
+        assert label_from_score(0.0) == "implausible"
+
+    def test_below_lower_threshold_is_implausible(self):
+        assert label_from_score(0.32) == "implausible"
+
+    def test_lower_threshold_is_suspicious(self):
+        # boundary is inclusive on the lower side
+        assert label_from_score(0.33) == "suspicious"
+
+    def test_middle_is_suspicious(self):
+        assert label_from_score(0.5) == "suspicious"
+
+    def test_below_upper_threshold_is_suspicious(self):
+        assert label_from_score(0.66) == "suspicious"
+
+    def test_upper_threshold_is_plausible(self):
+        assert label_from_score(0.67) == "plausible"
+
+    def test_one_is_plausible(self):
+        assert label_from_score(1.0) == "plausible"
+
+    def test_custom_thresholds(self):
+        assert (
+            label_from_score(0.4, suspicious_at=0.5, plausible_at=0.9) == "implausible"
+        )
+        assert (
+            label_from_score(0.7, suspicious_at=0.5, plausible_at=0.9) == "suspicious"
+        )
+        assert (
+            label_from_score(0.95, suspicious_at=0.5, plausible_at=0.9) == "plausible"
+        )

--- a/backend/kgc/tests/test_trust_llm_clients.py
+++ b/backend/kgc/tests/test_trust_llm_clients.py
@@ -1,0 +1,65 @@
+"""Tests for trust LLM clients.
+
+Heavy LLM-batch flow (uploads, polling, downloads) is exercised via the
+smoke test, not unit tests — mocking every SDK call is brittle and shallow.
+Unit tests cover: factory dispatch, fail-fast on missing config, stub
+behaviour, empty-input no-op.
+"""
+
+from __future__ import annotations
+
+import pytest
+from src.pipeline.trust.llm import (
+    BedrockClient,
+    GeminiClient,
+    OpenAIClient,
+    create_client,
+)
+from src.pipeline.trust.llm import gemini as gemini_module
+
+
+class TestCreateClient:
+    def test_unknown_provider(self):
+        with pytest.raises(ValueError, match="Unknown trust LLM provider"):
+            create_client("anthropic")
+
+    def test_bedrock_stub_fails_fast(self):
+        with pytest.raises(NotImplementedError):
+            create_client("bedrock")
+
+    def test_openai_stub_fails_fast(self):
+        with pytest.raises(NotImplementedError):
+            create_client("openai")
+
+
+class TestStubsRaiseOnInit:
+    def test_bedrock_init_raises(self):
+        with pytest.raises(NotImplementedError, match="BedrockClient"):
+            BedrockClient()
+
+    def test_openai_init_raises(self):
+        with pytest.raises(NotImplementedError, match="OpenAIClient"):
+            OpenAIClient()
+
+
+class TestGeminiClient:
+    def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        with pytest.raises(RuntimeError, match="GOOGLE_API_KEY"):
+            GeminiClient()
+
+    def test_empty_requests_is_noop(self, monkeypatch):
+        # No SDK call required when there are no requests; constructor still
+        # needs to succeed.
+        monkeypatch.setenv("GOOGLE_API_KEY", "fake-key-for-test")
+
+        class _FakeClient:
+            def __init__(self, *_, **__):
+                pass
+
+        # Patch genai.Client so __init__ does not hit the real SDK.
+        monkeypatch.setattr(gemini_module.genai, "Client", _FakeClient)
+
+        client = GeminiClient(api_key="fake-key-for-test")
+        bundle = object()  # not used on the empty path
+        assert client.submit_batch(bundle, []) == []  # type: ignore[arg-type]

--- a/backend/kgc/tests/test_trust_models.py
+++ b/backend/kgc/tests/test_trust_models.py
@@ -1,0 +1,83 @@
+"""Tests for trust-signal pydantic models."""
+
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import ValidationError
+from src.models.trust_signal import LLMPlausibilityResponse, TrustSignal
+
+
+class TestTrustSignal:
+    def _row(self, **overrides):
+        base = {
+            "signal_id": "a" * 64,
+            "attestation_id": "atabc",
+            "signal_kind": "llm_plausibility",
+            "version": "v1",
+            "config_hash": "b" * 64,
+            "model": "gemini:gemini-2.5-flash-lite",
+            "score": 0.7,
+            "reason": "within typical range",
+            "error_text": "",
+            "created_at": datetime.now(UTC),
+        }
+        base.update(overrides)
+        return base
+
+    def test_valid_score(self):
+        TrustSignal(**self._row(score=0.7))
+
+    def test_zero_and_one_accepted(self):
+        TrustSignal(**self._row(score=0.0))
+        TrustSignal(**self._row(score=1.0))
+
+    def test_error_sentinel_accepted(self):
+        # -1 is the "this row is an error" sentinel.
+        TrustSignal(**self._row(score=-1.0, reason="", error_text="rate limit"))
+
+    def test_score_below_minus_one_rejected(self):
+        with pytest.raises(ValidationError):
+            TrustSignal(**self._row(score=-1.5))
+
+    def test_score_above_one_rejected(self):
+        with pytest.raises(ValidationError):
+            TrustSignal(**self._row(score=1.1))
+
+    def test_defaults_for_optional_fields(self):
+        row = self._row()
+        row.pop("error_text")
+        row.pop("reason")
+        sig = TrustSignal(**row)
+        assert sig.error_text == ""
+        assert sig.reason == ""
+
+
+class TestLLMPlausibilityResponse:
+    def test_valid_response(self):
+        resp = LLMPlausibilityResponse(score=0.85, reason="typical for this food")
+        assert resp.score == 0.85
+
+    def test_score_strict_zero_to_one(self):
+        # The LLM never produces -1; that's set by the runner on error.
+        with pytest.raises(ValidationError):
+            LLMPlausibilityResponse(score=-0.1, reason="x")
+        with pytest.raises(ValidationError):
+            LLMPlausibilityResponse(score=1.5, reason="x")
+
+    def test_reason_max_length(self):
+        # The validator is intentionally more lenient than the prompt asks
+        # for (prompt: ≤ 200 chars; validator: 500). 500 accepts, 501 rejects.
+        LLMPlausibilityResponse(score=0.5, reason="x" * 500)
+        with pytest.raises(ValidationError):
+            LLMPlausibilityResponse(score=0.5, reason="x" * 501)
+
+    def test_reason_default_empty(self):
+        resp = LLMPlausibilityResponse(score=0.5)
+        assert resp.reason == ""
+
+    def test_parses_from_json(self):
+        resp = LLMPlausibilityResponse.model_validate_json(
+            '{"score": 0.42, "reason": "borderline"}'
+        )
+        assert resp.score == 0.42
+        assert resp.reason == "borderline"

--- a/backend/kgc/tests/test_trust_runner.py
+++ b/backend/kgc/tests/test_trust_runner.py
@@ -1,0 +1,194 @@
+"""Tests for trust runner pure helpers (selection, merge, response parsing).
+
+End-to-end runner is exercised via the smoke test, not in unit tests, since
+it needs a live LLM call. These tests cover the deterministic helpers that
+gate correctness: id derivation, response → row translation, parquet merge.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+import pandas as pd
+import pytest
+from src.pipeline.trust.llm.base import TrustLLMRequest, TrustLLMResponse
+from src.pipeline.trust.runner import (
+    _merge_for_run,
+    _responses_to_rows,
+    signal_id,
+)
+from src.pipeline.trust.versions import VersionBundle
+
+
+def _bundle() -> VersionBundle:
+    return VersionBundle(
+        signal_kind="llm_plausibility",
+        provider="gemini",
+        model="gemini-2.5-flash-lite",
+        prompts={"system": "sys", "user": "user {food}"},
+        response_schema={
+            "type": "object",
+            "required": ["score", "reason"],
+            "properties": {
+                "score": {"type": "number"},
+                "reason": {"type": "string"},
+            },
+        },
+    )
+
+
+def _row(**overrides: Any) -> dict[str, Any]:
+    base: dict[str, Any] = {
+        "signal_id": "x" * 64,
+        "attestation_id": "atabc",
+        "signal_kind": "llm_plausibility",
+        "version": "v1",
+        "config_hash": "h" * 64,
+        "model": "gemini:gemini-2.5-flash-lite",
+        "score": 0.8,
+        "reason": "ok",
+        "error_text": "",
+        "created_at": datetime.now(UTC),
+    }
+    base.update(overrides)
+    return base
+
+
+class TestSignalId:
+    def test_deterministic(self):
+        a = signal_id("at1", "llm_plausibility", "v1", "h" * 64)
+        b = signal_id("at1", "llm_plausibility", "v1", "h" * 64)
+        assert a == b
+        assert len(a) == 64
+
+    def test_changes_on_any_field(self):
+        base = signal_id("at1", "llm_plausibility", "v1", "h" * 64)
+        assert signal_id("at2", "llm_plausibility", "v1", "h" * 64) != base
+        assert signal_id("at1", "range_check", "v1", "h" * 64) != base
+        assert signal_id("at1", "llm_plausibility", "v2", "h" * 64) != base
+        assert signal_id("at1", "llm_plausibility", "v1", "g" * 64) != base
+
+
+class TestResponsesToRows:
+    def test_success_row(self):
+        bundle = _bundle()
+        requests = {"at1": TrustLLMRequest(key="at1", user_prompt="...")}
+        responses = [
+            TrustLLMResponse(
+                key="at1",
+                raw_text='{"score": 0.9, "reason": "typical"}',
+                error=None,
+            )
+        ]
+        df = _responses_to_rows(
+            responses,
+            requests_by_key=requests,
+            bundle=bundle,
+            version="v1",
+            config_hash="h" * 64,
+        )
+        assert len(df) == 1
+        assert df.iloc[0]["score"] == pytest.approx(0.9)
+        assert df.iloc[0]["error_text"] == ""
+        assert df.iloc[0]["reason"] == "typical"
+        assert df.iloc[0]["model"] == "gemini:gemini-2.5-flash-lite"
+
+    def test_error_response_becomes_minus_one(self):
+        bundle = _bundle()
+        requests = {"at1": TrustLLMRequest(key="at1", user_prompt="...")}
+        responses = [TrustLLMResponse(key="at1", raw_text=None, error="rate limit")]
+        df = _responses_to_rows(
+            responses,
+            requests_by_key=requests,
+            bundle=bundle,
+            version="v1",
+            config_hash="h" * 64,
+        )
+        assert df.iloc[0]["score"] == -1
+        assert df.iloc[0]["error_text"] == "rate limit"
+
+    def test_invalid_json_becomes_error_row(self):
+        bundle = _bundle()
+        requests = {"at1": TrustLLMRequest(key="at1", user_prompt="...")}
+        # Score out of range — fails LLMPlausibilityResponse validation.
+        responses = [
+            TrustLLMResponse(
+                key="at1",
+                raw_text='{"score": 1.5, "reason": "x"}',
+                error=None,
+            )
+        ]
+        df = _responses_to_rows(
+            responses,
+            requests_by_key=requests,
+            bundle=bundle,
+            version="v1",
+            config_hash="h" * 64,
+        )
+        assert df.iloc[0]["score"] == -1
+        assert "schema" in df.iloc[0]["error_text"]
+
+    def test_unknown_key_dropped(self):
+        bundle = _bundle()
+        requests = {"at1": TrustLLMRequest(key="at1", user_prompt="...")}
+        responses = [
+            TrustLLMResponse(
+                key="at_unknown",
+                raw_text='{"score": 0.5, "reason": "x"}',
+                error=None,
+            )
+        ]
+        df = _responses_to_rows(
+            responses,
+            requests_by_key=requests,
+            bundle=bundle,
+            version="v1",
+            config_hash="h" * 64,
+        )
+        assert df.empty
+
+
+class TestMergeForRun:
+    def test_empty_existing_returns_new(self):
+        new = pd.DataFrame([_row()])
+        merged = _merge_for_run(pd.DataFrame(), new, "llm_plausibility", "v1", "h" * 64)
+        assert len(merged) == 1
+
+    def test_empty_new_returns_existing(self):
+        existing = pd.DataFrame([_row()])
+        merged = _merge_for_run(
+            existing, pd.DataFrame(), "llm_plausibility", "v1", "h" * 64
+        )
+        assert len(merged) == 1
+
+    def test_replaces_old_for_same_signal_id(self):
+        sid = signal_id("at1", "llm_plausibility", "v1", "h" * 64)
+        old = _row(
+            signal_id=sid, attestation_id="at1", score=-1, error_text="rate limit"
+        )
+        new = _row(signal_id=sid, attestation_id="at1", score=0.85, reason="ok")
+        merged = _merge_for_run(
+            pd.DataFrame([old]),
+            pd.DataFrame([new]),
+            "llm_plausibility",
+            "v1",
+            "h" * 64,
+        )
+        assert len(merged) == 1
+        assert merged.iloc[0]["score"] == pytest.approx(0.85)
+        assert merged.iloc[0]["error_text"] == ""
+
+    def test_keeps_other_run_rows_untouched(self):
+        # An existing v2 row for the same attestation must not be dropped.
+        v1_sid = signal_id("at1", "llm_plausibility", "v1", "h" * 64)
+        v2_sid = signal_id("at1", "llm_plausibility", "v2", "k" * 64)
+        existing = pd.DataFrame(
+            [
+                _row(signal_id=v2_sid, version="v2", config_hash="k" * 64, score=0.4),
+            ]
+        )
+        new = pd.DataFrame([_row(signal_id=v1_sid, score=0.85)])
+        merged = _merge_for_run(existing, new, "llm_plausibility", "v1", "h" * 64)
+        assert len(merged) == 2
+        assert set(merged["version"]) == {"v1", "v2"}

--- a/backend/kgc/tests/test_trust_versions.py
+++ b/backend/kgc/tests/test_trust_versions.py
@@ -1,0 +1,147 @@
+"""Tests for the YAML version loader and canonical config hash.
+
+The hash is the dedup signal that lets re-running an unchanged version be a
+no-op while a single-character prompt edit forces a re-judge — so it must be
+invariant under cosmetic yaml differences (key order, comments, whitespace)
+but sensitive to any semantic content change.
+"""
+
+from __future__ import annotations
+
+import textwrap
+from typing import TYPE_CHECKING
+
+import pytest
+from pydantic import ValidationError
+from src.pipeline.trust.versions import (
+    VersionBundle,
+    compute_config_hash,
+    load_version,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_yml(tmp_path: Path, signal_kind: str, version: str, body: str) -> Path:
+    d = tmp_path / signal_kind
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / f"{version}.yml"
+    p.write_text(textwrap.dedent(body), encoding="utf-8")
+    return p
+
+
+_VALID_BODY = """\
+    signal_kind: llm_plausibility
+    description: test
+    provider: gemini
+    model: gemini-2.5-flash-lite
+    generation:
+      temperature: 0.0
+      max_output_tokens: 256
+      response_mime_type: application/json
+    prompts:
+      system: "you are a judge"
+      user: "score this: {food}"
+    response_schema:
+      type: object
+      required: [score, reason]
+      properties:
+        score: {type: number, minimum: 0, maximum: 1}
+        reason: {type: string, maxLength: 280}
+    """
+
+
+class TestComputeConfigHash:
+    def test_invariant_under_key_order(self):
+        a = {"x": 1, "y": 2, "z": [3, 4]}
+        b = {"z": [3, 4], "y": 2, "x": 1}
+        assert compute_config_hash(a) == compute_config_hash(b)
+
+    def test_changes_on_value_edit(self):
+        a = {"prompt": "hello"}
+        b = {"prompt": "hello!"}
+        assert compute_config_hash(a) != compute_config_hash(b)
+
+    def test_int_vs_float_distinct(self):
+        # Documented quirk: yml authors should be consistent.
+        assert compute_config_hash({"t": 0}) != compute_config_hash({"t": 0.0})
+
+    def test_hex_length(self):
+        h = compute_config_hash({"x": 1})
+        assert len(h) == 64
+        int(h, 16)  # raises if non-hex
+
+
+class TestLoadVersion:
+    def test_round_trip(self, tmp_path):
+        _write_yml(tmp_path, "llm_plausibility", "v1", _VALID_BODY)
+        bundle, h = load_version("llm_plausibility", "v1", base_dir=tmp_path)
+        assert isinstance(bundle, VersionBundle)
+        assert bundle.provider == "gemini"
+        assert bundle.model == "gemini-2.5-flash-lite"
+        assert bundle.prompts.system == "you are a judge"
+        assert len(h) == 64
+
+    def test_cosmetic_edit_does_not_change_hash(self, tmp_path):
+        _write_yml(tmp_path, "llm_plausibility", "v1", _VALID_BODY)
+        _, h1 = load_version("llm_plausibility", "v1", base_dir=tmp_path)
+        # Reorder keys + add comment + extra blank line — same parsed structure.
+        reordered = """\
+            # a leading comment that should not affect the hash
+            description: test
+            signal_kind: llm_plausibility
+
+            model: gemini-2.5-flash-lite
+            provider: gemini
+            generation:
+              max_output_tokens: 256
+              temperature: 0.0
+              response_mime_type: application/json
+            response_schema:
+              type: object
+              required: [score, reason]
+              properties:
+                score: {minimum: 0, type: number, maximum: 1}
+                reason: {type: string, maxLength: 280}
+            prompts:
+              user: "score this: {food}"
+              system: "you are a judge"
+            """
+        _write_yml(tmp_path, "llm_plausibility", "v1", reordered)
+        _, h2 = load_version("llm_plausibility", "v1", base_dir=tmp_path)
+        assert h1 == h2
+
+    def test_prompt_edit_changes_hash(self, tmp_path):
+        _write_yml(tmp_path, "llm_plausibility", "v1", _VALID_BODY)
+        _, h1 = load_version("llm_plausibility", "v1", base_dir=tmp_path)
+        edited = _VALID_BODY.replace("you are a judge", "you are a strict judge")
+        _write_yml(tmp_path, "llm_plausibility", "v1", edited)
+        _, h2 = load_version("llm_plausibility", "v1", base_dir=tmp_path)
+        assert h1 != h2
+
+    def test_temperature_edit_changes_hash(self, tmp_path):
+        _write_yml(tmp_path, "llm_plausibility", "v1", _VALID_BODY)
+        _, h1 = load_version("llm_plausibility", "v1", base_dir=tmp_path)
+        edited = _VALID_BODY.replace("temperature: 0.0", "temperature: 0.7")
+        _write_yml(tmp_path, "llm_plausibility", "v1", edited)
+        _, h2 = load_version("llm_plausibility", "v1", base_dir=tmp_path)
+        assert h1 != h2
+
+    def test_signal_kind_directory_mismatch_rejected(self, tmp_path):
+        # File says llm_plausibility but lives under range_check/ — reject.
+        _write_yml(tmp_path, "range_check", "v1", _VALID_BODY)
+        with pytest.raises(ValueError, match="signal_kind="):
+            load_version("range_check", "v1", base_dir=tmp_path)
+
+    def test_unknown_provider_rejected(self, tmp_path):
+        bad = _VALID_BODY.replace("provider: gemini", "provider: vertex")
+        _write_yml(tmp_path, "llm_plausibility", "v1", bad)
+        with pytest.raises(ValidationError):
+            load_version("llm_plausibility", "v1", base_dir=tmp_path)
+
+    def test_missing_required_field_rejected(self, tmp_path):
+        bad = _VALID_BODY.replace("    model: gemini-2.5-flash-lite\n", "")
+        _write_yml(tmp_path, "llm_plausibility", "v1", bad)
+        with pytest.raises(ValidationError):
+            load_version("llm_plausibility", "v1", base_dir=tmp_path)

--- a/backend/kgc/uv.lock
+++ b/backend/kgc/uv.lock
@@ -26,6 +26,19 @@ wheels = [
 ]
 
 [[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
 name = "bandit"
 version = "1.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -101,6 +114,63 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
@@ -266,6 +336,68 @@ wheels = [
 ]
 
 [[package]]
+name = "cryptography"
+version = "47.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ef/b2/7ffa7fe8207a8c42147ffe70c3e360b228160c1d85dc3faff16aaa3244c0/cryptography-47.0.0.tar.gz", hash = "sha256:9f8e55fe4e63613a5e1cc5819030f27b97742d720203a087802ce4ce9ceb52bb", size = 830863, upload-time = "2026-04-24T19:54:57.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/98/40dfe932134bdcae4f6ab5927c87488754bf9eb79297d7e0070b78dd58e9/cryptography-47.0.0-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:160ad728f128972d362e714054f6ba0067cab7fb350c5202a9ae8ae4ce3ef1a0", size = 7912214, upload-time = "2026-04-24T19:53:03.864Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c6/2733531243fba725f58611b918056b277692f1033373dcc8bd01af1c05d4/cryptography-47.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b9a8943e359b7615db1a3ba587994618e094ff3d6fa5a390c73d079ce18b3973", size = 4644617, upload-time = "2026-04-24T19:53:06.909Z" },
+    { url = "https://files.pythonhosted.org/packages/00/e3/b27be1a670a9b87f855d211cf0e1174a5d721216b7616bd52d8581d912ed/cryptography-47.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:f5c15764f261394b22aef6b00252f5195f46f2ca300bec57149474e2538b31f8", size = 4668186, upload-time = "2026-04-24T19:53:09.053Z" },
+    { url = "https://files.pythonhosted.org/packages/81/b9/8443cfe5d17d482d348cee7048acf502bb89a51b6382f06240fd290d4ca3/cryptography-47.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:9c59ab0e0fa3a180a5a9c59f3a5abe3ef90d474bc56d7fadfbe80359491b615b", size = 4651244, upload-time = "2026-04-24T19:53:11.217Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/5e/13ed0cdd0eb88ba159d6dd5ebfece8cb901dbcf1ae5ac4072e28b55d3153/cryptography-47.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:34b4358b925a5ea3e14384ca781a2c0ef7ac219b57bb9eacc4457078e2b19f92", size = 5252906, upload-time = "2026-04-24T19:53:13.532Z" },
+    { url = "https://files.pythonhosted.org/packages/64/16/ed058e1df0f33d440217cd120d41d5dda9dd215a80b8187f68483185af82/cryptography-47.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:0024b87d47ae2399165a6bfb20d24888881eeab83ae2566d62467c5ff0030ce7", size = 4701842, upload-time = "2026-04-24T19:53:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3d30986b30fdbd9e969abbdf8ba00ed0618615144341faeb57f395a084fe/cryptography-47.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:1e47422b5557bb82d3fff997e8d92cff4e28b9789576984f08c248d2b3535d93", size = 4289313, upload-time = "2026-04-24T19:53:17.755Z" },
+    { url = "https://files.pythonhosted.org/packages/df/fd/32db38e3ad0cb331f0691cb4c7a8a6f176f679124dee746b3af6633db4d9/cryptography-47.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:6f29f36582e6151d9686235e586dd35bb67491f024767d10b842e520dc6a07ac", size = 4650964, upload-time = "2026-04-24T19:53:20.062Z" },
+    { url = "https://files.pythonhosted.org/packages/86/53/5395d944dfd48cb1f67917f533c609c34347185ef15eb4308024c876f274/cryptography-47.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a9b761f012a943b7de0e828843c5688d0de94a0578d44d6c85a1bae32f87791f", size = 5207817, upload-time = "2026-04-24T19:53:22.498Z" },
+    { url = "https://files.pythonhosted.org/packages/34/4f/e5711b28e1901f7d480a2b1b688b645aa4c77c73f10731ed17e7f7db3f0d/cryptography-47.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4e1de79e047e25d6e9f8cea71c86b4a53aced64134f0f003bbcbf3655fd172c8", size = 4701544, upload-time = "2026-04-24T19:53:24.356Z" },
+    { url = "https://files.pythonhosted.org/packages/22/22/c8ddc25de3010fc8da447648f5a092c40e7a8fadf01dd6d255d9c0b9373d/cryptography-47.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:ef6b3634087f18d2155b1e8ce264e5345a753da2c5fa9815e7d41315c90f8318", size = 4783536, upload-time = "2026-04-24T19:53:26.665Z" },
+    { url = "https://files.pythonhosted.org/packages/66/b6/d4a68f4ea999c6d89e8498579cba1c5fcba4276284de7773b17e4fa69293/cryptography-47.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:11dbb9f50a0f1bb9757b3d8c27c1101780efb8f0bdecfb12439c22a74d64c001", size = 4926106, upload-time = "2026-04-24T19:53:28.686Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ed/5f524db1fade9c013aa618e1c99c6ed05e8ffc9ceee6cda22fed22dda3f4/cryptography-47.0.0-cp311-abi3-win32.whl", hash = "sha256:7fda2f02c9015db3f42bb8a22324a454516ed10a8c29ca6ece6cdbb5efe2a203", size = 3258581, upload-time = "2026-04-24T19:53:31.058Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/dc/1b901990b174786569029f67542b3edf72ac068b6c3c8683c17e6a2f5363/cryptography-47.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:f5c3296dab66202f1b18a91fa266be93d6aa0c2806ea3d67762c69f60adc71aa", size = 3775309, upload-time = "2026-04-24T19:53:33.054Z" },
+    { url = "https://files.pythonhosted.org/packages/14/88/7aa18ad9c11bc87689affa5ce4368d884b517502d75739d475fc6f4a03c7/cryptography-47.0.0-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:be12cb6a204f77ed968bcefe68086eb061695b540a3dd05edac507a3111b25f0", size = 7904299, upload-time = "2026-04-24T19:53:35.003Z" },
+    { url = "https://files.pythonhosted.org/packages/07/55/c18f75724544872f234678fdedc871391722cb34a2aee19faa9f63100bb2/cryptography-47.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2ebd84adf0728c039a3be2700289378e1c164afc6748df1a5ed456767bef9ba7", size = 4631180, upload-time = "2026-04-24T19:53:37.517Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/65/31a5cc0eaca99cec5bafffe155d407115d96136bb161e8b49e0ef73f09a7/cryptography-47.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f68d6fbc7fbbcfb0939fea72c3b96a9f9a6edfc0e1b1d29778a2066030418b1", size = 4653529, upload-time = "2026-04-24T19:53:39.775Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/bc/641c0519a495f3bfd0421b48d7cd325c4336578523ccd76ea322b6c29c7a/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:6651d32eff255423503aa276739da98c30f26c40cbeffcc6048e0d54ef704c0c", size = 4638570, upload-time = "2026-04-24T19:53:42.129Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/f2/300327b0a47f6dc94dd8b71b57052aefe178bb51745073d73d80604f11ab/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:3fb8fa48075fad7193f2e5496135c6a76ac4b2aa5a38433df0a539296b377829", size = 5238019, upload-time = "2026-04-24T19:53:44.577Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/5b5cf994391d4bf9d9c7efd4c66aabe4d95227256627f8fea6cff7dfadbd/cryptography-47.0.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:11438c7518132d95f354fa01a4aa2f806d172a061a7bed18cf18cbdacdb204d7", size = 4686832, upload-time = "2026-04-24T19:53:47.015Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/2c/ae950e28fd6475c852fc21a44db3e6b5bcc1261d1e370f2b6e42fa800fef/cryptography-47.0.0-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:8c1a736bbb3288005796c3f7ccb9453360d7fed483b13b9f468aea5171432923", size = 4269301, upload-time = "2026-04-24T19:53:48.97Z" },
+    { url = "https://files.pythonhosted.org/packages/67/fb/6a39782e150ffe5cc1b0018cb6ddc48bf7ca62b498d7539ffc8a758e977d/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:f1557695e5c2b86e204f6ce9470497848634100787935ab7adc5397c54abd7ab", size = 4638110, upload-time = "2026-04-24T19:53:51.011Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/d7/0b3c71090a76e5c203164a47688b697635ece006dcd2499ab3a4dbd3f0bd/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:f9a034b642b960767fb343766ae5ba6ad653f2e890ddd82955aef288ffea8736", size = 5194988, upload-time = "2026-04-24T19:53:52.962Z" },
+    { url = "https://files.pythonhosted.org/packages/63/33/63a961498a9df51721ab578c5a2622661411fc520e00bd83b0cc64eb20c4/cryptography-47.0.0-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:b1c76fca783aa7698eb21eb14f9c4aa09452248ee54a627d125025a43f83e7a7", size = 4686563, upload-time = "2026-04-24T19:53:55.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/bf/5ee5b145248f92250de86145d1c1d6edebbd57a7fe7caa4dedb5d4cf06a1/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:4f7722c97826770bab8ae92959a2e7b20a5e9e9bf4deae68fd86c3ca457bab52", size = 4770094, upload-time = "2026-04-24T19:53:57.753Z" },
+    { url = "https://files.pythonhosted.org/packages/92/43/21d220b2da5d517773894dacdcdb5c682c28d3fffce65548cb06e87d5501/cryptography-47.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:09f6d7bf6724f8db8b32f11eccf23efc8e759924bc5603800335cf8859a3ddbd", size = 4913811, upload-time = "2026-04-24T19:54:00.236Z" },
+    { url = "https://files.pythonhosted.org/packages/31/98/dc4ad376ac5f1a1a7d4a83f7b0c6f2bcad36b5d2d8f30aeb482d3a7d9582/cryptography-47.0.0-cp314-cp314t-win32.whl", hash = "sha256:6eebcaf0df1d21ce1f90605c9b432dd2c4f4ab665ac29a40d5e3fc68f51b5e63", size = 3237158, upload-time = "2026-04-24T19:54:02.606Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/da/97f62d18306b5133468bc3f8cc73a3111e8cdc8cf8d3e69474d6e5fd2d1b/cryptography-47.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:51c9313e90bd1690ec5a75ed047c27c0b8e6c570029712943d6116ef9a90620b", size = 3758706, upload-time = "2026-04-24T19:54:04.433Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/34/a4fae8ae7c3bc227460c9ae43f56abf1b911da0ec29e0ebac53bb0a4b6b7/cryptography-47.0.0-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:14432c8a9bcb37009784f9594a62fae211a2ae9543e96c92b2a8e4c3cd5cd0c4", size = 7904072, upload-time = "2026-04-24T19:54:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/01/64/d7b1e54fdb69f22d24a64bb3e88dc718b31c7fb10ef0b9691a3cf7eeea6e/cryptography-47.0.0-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:07efe86201817e7d3c18781ca9770bc0db04e1e48c994be384e4602bc38f8f27", size = 4635767, upload-time = "2026-04-24T19:54:08.519Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/7b/cca826391fb2a94efdcdfe4631eb69306ee1cff0b22f664a412c90713877/cryptography-47.0.0-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b45761c6ec22b7c726d6a829558777e32d0f1c8be7c3f3480f9c912d5ee8a10", size = 4654350, upload-time = "2026-04-24T19:54:10.795Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/65/4b57bcc823f42a991627c51c2f68c9fd6eb1393c1756aac876cba2accae2/cryptography-47.0.0-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:edd4da498015da5b9f26d38d3bfc2e90257bfa9cbed1f6767c282a0025ae649b", size = 4643394, upload-time = "2026-04-24T19:54:13.275Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/c4/2c5fbeea70adbbca2bbae865e1d605d6a4a7f8dbd9d33eaf69645087f06c/cryptography-47.0.0-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:9af828c0d5a65c70ec729cd7495a4bf1a67ecb66417b8f02ff125ab8a6326a74", size = 5225777, upload-time = "2026-04-24T19:54:15.18Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/b8/ac57107ef32749d2b244e36069bb688792a363aaaa3acc9e3cf84c130315/cryptography-47.0.0-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:256d07c78a04d6b276f5df935a9923275f53bd1522f214447fdf365494e2d515", size = 4688771, upload-time = "2026-04-24T19:54:17.835Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fc/9f1de22ff8be99d991f240a46863c52d475404c408886c5a38d2b5c3bb26/cryptography-47.0.0-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:5d0e362ff51041b0c0d219cc7d6924d7b8996f57ce5712bdcef71eb3c65a59cc", size = 4270753, upload-time = "2026-04-24T19:54:19.963Z" },
+    { url = "https://files.pythonhosted.org/packages/00/68/d70c852797aa68e8e48d12e5a87170c43f67bb4a59403627259dd57d15de/cryptography-47.0.0-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:1581aef4219f7ca2849d0250edaa3866212fb74bf5667284f46aa92f9e65c1ca", size = 4642911, upload-time = "2026-04-24T19:54:21.818Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/51/661cbee74f594c5d97ff82d34f10d5551c085ca4668645f4606ebd22bd5d/cryptography-47.0.0-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:a49a3eb5341b9503fa3000a9a0db033161db90d47285291f53c2a9d2cd1b7f76", size = 5181411, upload-time = "2026-04-24T19:54:24.376Z" },
+    { url = "https://files.pythonhosted.org/packages/94/87/f2b6c374a82cf076cfa1416992ac8e8ec94d79facc37aec87c1a5cb72352/cryptography-47.0.0-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:2207a498b03275d0051589e326b79d4cf59985c99031b05bb292ac52631c37fe", size = 4688262, upload-time = "2026-04-24T19:54:26.946Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/8b7462f4acf21ec509616f0245018bb197194ab0b65c2ea21a0bdd53c0eb/cryptography-47.0.0-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:7a02675e2fabd0c0fc04c868b8781863cbf1967691543c22f5470500ff840b31", size = 4775506, upload-time = "2026-04-24T19:54:28.926Z" },
+    { url = "https://files.pythonhosted.org/packages/70/75/158e494e4c08dc05e039da5bb48553826bd26c23930cf8d3cd5f21fa8921/cryptography-47.0.0-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80887c5cbd1774683cb126f0ab4184567f080071d5acf62205acb354b4b753b7", size = 4912060, upload-time = "2026-04-24T19:54:30.869Z" },
+    { url = "https://files.pythonhosted.org/packages/06/bd/0a9d3edbf5eadbac926d7b9b3cd0c4be584eeeae4a003d24d9eda4affbbd/cryptography-47.0.0-cp38-abi3-win32.whl", hash = "sha256:ed67ea4e0cfb5faa5bc7ecb6e2b8838f3807a03758eec239d6c21c8769355310", size = 3248487, upload-time = "2026-04-24T19:54:33.494Z" },
+    { url = "https://files.pythonhosted.org/packages/60/80/5681af756d0da3a599b7bdb586fac5a1540f1bcefd2717a20e611ddade45/cryptography-47.0.0-cp38-abi3-win_amd64.whl", hash = "sha256:835d2d7f47cdc53b3224e90810fb1d36ca94ea29cc1801fb4c1bc43876735769", size = 3755737, upload-time = "2026-04-24T19:54:35.408Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
 name = "et-xmlfile"
 version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -282,6 +414,7 @@ dependencies = [
     { name = "beautifulsoup4" },
     { name = "biopython" },
     { name = "click" },
+    { name = "google-genai" },
     { name = "inflection" },
     { name = "lxml" },
     { name = "numpy" },
@@ -318,6 +451,7 @@ requires-dist = [
     { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "biopython", specifier = ">=1.84" },
     { name = "click", specifier = ">=8.1.0" },
+    { name = "google-genai", specifier = ">=1.0.0" },
     { name = "inflection", specifier = ">=0.5.1" },
     { name = "lxml", specifier = ">=5.1.0" },
     { name = "numpy", specifier = ">=1.26.0" },
@@ -347,6 +481,82 @@ dev = [
     { name = "types-beautifulsoup4", specifier = ">=4.12.0" },
     { name = "types-pyyaml", specifier = ">=6.0.0" },
     { name = "types-requests", specifier = ">=2.31.0" },
+]
+
+[[package]]
+name = "google-auth"
+version = "2.49.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "pyasn1-modules" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c6/fc/e925290a1ad95c975c459e2df070fac2b90954e13a0370ac505dff78cb99/google_auth-2.49.2.tar.gz", hash = "sha256:c1ae38500e73065dcae57355adb6278cf8b5c8e391994ae9cbadbcb9631ab409", size = 333958, upload-time = "2026-04-10T00:41:21.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/73/76/d241a5c927433420507215df6cac1b1fa4ac0ba7a794df42a84326c68da8/google_auth-2.49.2-py3-none-any.whl", hash = "sha256:c2720924dfc82dedb962c9f52cabb2ab16714fd0a6a707e40561d217574ed6d5", size = 240638, upload-time = "2026-04-10T00:41:14.501Z" },
+]
+
+[package.optional-dependencies]
+requests = [
+    { name = "requests" },
+]
+
+[[package]]
+name = "google-genai"
+version = "1.73.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "google-auth", extra = ["requests"] },
+    { name = "httpx" },
+    { name = "pydantic" },
+    { name = "requests" },
+    { name = "sniffio" },
+    { name = "tenacity" },
+    { name = "typing-extensions" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/d8/40f5f107e5a2976bbac52d421f04d14fc221b55a8f05e66be44b2f739fe6/google_genai-1.73.1.tar.gz", hash = "sha256:b637e3a3b9e2eccc46f27136d470165803de84eca52abfed2e7352081a4d5a15", size = 530998, upload-time = "2026-04-14T21:06:19.153Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/af/508e0528015240d710c6763f7c89ff44fab9a94a80b4377e265d692cbfd6/google_genai-1.73.1-py3-none-any.whl", hash = "sha256:af2d2287d25e42a187de19811ef33beb2e347c7e2bdb4dc8c467d78254e43a2c", size = 783595, upload-time = "2026-04-14T21:06:17.464Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -770,6 +980,36 @@ wheels = [
 ]
 
 [[package]]
+name = "pyasn1"
+version = "0.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5f/6583902b6f79b399c9c40674ac384fd9cd77805f9e6205075f828ef11fb2/pyasn1-0.6.3.tar.gz", hash = "sha256:697a8ecd6d98891189184ca1fa05d1bb00e2f84b5977c481452050549c8a72cf", size = 148685, upload-time = "2026-03-17T01:06:53.382Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/a0/7d793dce3fa811fe047d6ae2431c672364b462850c6235ae306c0efd025f/pyasn1-0.6.3-py3-none-any.whl", hash = "sha256:a80184d120f0864a52a073acc6fc642847d0be408e7c7252f31390c0f4eadcde", size = 83997, upload-time = "2026-03-17T01:06:52.036Z" },
+]
+
+[[package]]
+name = "pyasn1-modules"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyasn1" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e9/e6/78ebbb10a8c8e4b61a59249394a4a594c1a7af95593dc933a349c8d00964/pyasn1_modules-0.4.2.tar.gz", hash = "sha256:677091de870a80aae844b1ca6134f54652fa2c8c5a52aa396440ac3106e941e6", size = 307892, upload-time = "2025-03-28T02:41:22.17Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/47/8d/d529b5d697919ba8c11ad626e835d4039be708a35b0d22de83a269a6682c/pyasn1_modules-0.4.2-py3-none-any.whl", hash = "sha256:29253a9207ce32b64c3ac6600edc75368f98473906e8fd1043bd6b5b1de2c14a", size = 181259, upload-time = "2025-03-28T02:41:19.028Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
+]
+
+[[package]]
 name = "pydantic"
 version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
@@ -1162,6 +1402,15 @@ wheels = [
 ]
 
 [[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.8.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1177,6 +1426,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/6d/90764092216fa560f6587f83bb70113a8ba510ba436c6476a2b47359057c/stevedore-5.7.0.tar.gz", hash = "sha256:31dd6fe6b3cbe921e21dcefabc9a5f1cf848cf538a1f27543721b8ca09948aa3", size = 516200, upload-time = "2026-02-20T13:27:06.765Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/69/06/36d260a695f383345ab5bbc3fd447249594ae2fa8dfd19c533d5ae23f46b/stevedore-5.7.0-py3-none-any.whl", hash = "sha256:fd25efbb32f1abb4c9e502f385f0018632baac11f9ee5d1b70f88cc5e22ad4ed", size = 54483, upload-time = "2026-02-20T13:27:05.561Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]
@@ -1294,6 +1552,51 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]
 
 [[package]]

--- a/frontend/components/basic/TrustBadge.tsx
+++ b/frontend/components/basic/TrustBadge.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { MdWarningAmber } from "react-icons/md";
+import { twMerge } from "tailwind-merge";
+
+import Tooltip from "@/components/basic/Tooltip";
+
+// Pill that surfaces low LLM-plausibility data points on a row in the
+// composition table. Mirrors AmbiguityBadge: hidden when the count is zero,
+// click-through opens the evidence modal pre-filtered to low-trust items.
+interface TrustBadgeProps {
+  lowTrustCount: number;
+  totalCount: number;
+  onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void;
+  className?: string;
+}
+
+export const TrustBadge = ({
+  lowTrustCount,
+  totalCount,
+  onClick,
+  className,
+}: TrustBadgeProps) => {
+  if (lowTrustCount <= 0) return null;
+  const allLow = lowTrustCount === totalCount;
+  return (
+    <Tooltip
+      content={
+        <span className="whitespace-normal">
+          {allLow
+            ? `All ${totalCount} data point${
+                totalCount === 1 ? " has" : "s have"
+              } low LLM-plausibility.`
+            : `${lowTrustCount} of ${totalCount} data points ${
+                lowTrustCount === 1 ? "has" : "have"
+              } low LLM-plausibility.`}{" "}
+          Click to review.
+        </span>
+      }
+    >
+      <button
+        type="button"
+        onClick={onClick}
+        className={twMerge(
+          "inline-flex items-center gap-1 rounded-full border px-1.5 py-[0.1rem] text-[0.6rem] font-mono font-medium transition-colors",
+          allLow
+            ? "text-rose-400 border-rose-500 bg-rose-500/15 hover:bg-rose-500/25"
+            : "text-rose-400/90 border-rose-500/60 bg-rose-500/10 hover:bg-rose-500/20",
+          className
+        )}
+      >
+        <MdWarningAmber className="size-3" />
+        {lowTrustCount}
+      </button>
+    </Tooltip>
+  );
+};
+
+TrustBadge.displayName = "TrustBadge";

--- a/frontend/components/entities/food/FoodCompositionEvidenceModal.tsx
+++ b/frontend/components/entities/food/FoodCompositionEvidenceModal.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { MdCallSplit } from "react-icons/md";
+import { MdCallSplit, MdWarningAmber } from "react-icons/md";
 import { twMerge } from "tailwind-merge";
 
 import FoodAtlasEvidence from "@/components/entities/food/FoodAtlasEvidence";
@@ -15,7 +15,13 @@ import { FoodEvidence, FoodEvidenceExtraction } from "@/types/Evidence";
 const isCounterpartAmbiguous = (ex: FoodEvidenceExtraction): boolean =>
   (ex.chemical_candidates?.length ?? 0) > 1;
 
-type AmbiguityFilter = "all" | "ambiguous" | "not-ambiguous";
+const isLowTrust = (ex: FoodEvidenceExtraction): boolean => Boolean(ex.trust_low);
+
+export type EvidenceFilter =
+  | "all"
+  | "ambiguous"
+  | "not-ambiguous"
+  | "low-trust";
 
 interface FoodCompositionEvidenceModalProps {
   foodName: string;
@@ -23,10 +29,11 @@ interface FoodCompositionEvidenceModalProps {
   evidences: FoodEvidence[] | undefined;
   isOpen: boolean;
   onClose: () => void;
-  initialFilter?: AmbiguityFilter;
+  initialFilter?: EvidenceFilter;
 }
 
-const FILTER_ORDER: AmbiguityFilter[] = ["all", "ambiguous", "not-ambiguous"];
+const AMBIGUITY_CYCLE: EvidenceFilter[] = ["all", "ambiguous", "not-ambiguous"];
+const LOW_TRUST_CYCLE: EvidenceFilter[] = ["all", "low-trust"];
 
 const FoodCompositionEvidenceModal = ({
   foodName,
@@ -36,18 +43,11 @@ const FoodCompositionEvidenceModal = ({
   onClose,
   initialFilter = "all",
 }: FoodCompositionEvidenceModalProps) => {
-  const [filter, setFilter] = useState<AmbiguityFilter>(initialFilter);
+  const [filter, setFilter] = useState<EvidenceFilter>(initialFilter);
 
   useEffect(() => {
     if (isOpen) setFilter(initialFilter);
   }, [isOpen, initialFilter]);
-
-  const cycleFilter = () => {
-    setFilter((f) => {
-      const idx = FILTER_ORDER.indexOf(f);
-      return FILTER_ORDER[(idx + 1) % FILTER_ORDER.length];
-    });
-  };
 
   // sort all evidences by their highest converted concentration value
   const sortedEvidences = evidences?.slice().sort((a, b) => {
@@ -67,6 +67,25 @@ const FoodCompositionEvidenceModal = ({
       ev.extraction.some(isCounterpartAmbiguous)
     ).length ?? 0;
   const notAmbiguousCount = totalCount - ambiguousCount;
+  const lowTrustCount =
+    sortedEvidences?.filter((ev) => ev.extraction.some(isLowTrust)).length ?? 0;
+
+  const cycleAmbiguityFilter = () => {
+    setFilter((f) => {
+      const idx = AMBIGUITY_CYCLE.indexOf(f);
+      // If we're not on the ambiguity axis, jump to the first non-"all" state.
+      if (idx === -1) return AMBIGUITY_CYCLE[1];
+      return AMBIGUITY_CYCLE[(idx + 1) % AMBIGUITY_CYCLE.length];
+    });
+  };
+
+  const cycleLowTrustFilter = () => {
+    setFilter((f) => {
+      const idx = LOW_TRUST_CYCLE.indexOf(f);
+      if (idx === -1) return LOW_TRUST_CYCLE[1];
+      return LOW_TRUST_CYCLE[(idx + 1) % LOW_TRUST_CYCLE.length];
+    });
+  };
 
   const displayedEvidences =
     filter === "ambiguous"
@@ -77,14 +96,21 @@ const FoodCompositionEvidenceModal = ({
       ? sortedEvidences?.filter(
           (ev) => !ev.extraction.some(isCounterpartAmbiguous)
         )
+      : filter === "low-trust"
+      ? sortedEvidences?.filter((ev) => ev.extraction.some(isLowTrust))
       : sortedEvidences;
 
-  const filterLabel =
-    filter === "all"
-      ? `All (${totalCount})`
-      : filter === "ambiguous"
+  const ambiguityLabel =
+    filter === "ambiguous"
       ? `Only ambiguous (${ambiguousCount})`
-      : `Not ambiguous (${notAmbiguousCount})`;
+      : filter === "not-ambiguous"
+      ? `Not ambiguous (${notAmbiguousCount})`
+      : `All (${totalCount})`;
+
+  const lowTrustLabel =
+    filter === "low-trust"
+      ? `Only low-trust (${lowTrustCount})`
+      : `All (${totalCount})`;
 
   const handleModalClose = () => {
     onClose();
@@ -101,24 +127,42 @@ const FoodCompositionEvidenceModal = ({
             contains{" "}
             <span className="capitalize font-semibold">{chemicalName}</span>
           </p>
-          {ambiguousCount > 0 && (
-            <button
-              type="button"
-              onClick={cycleFilter}
-              className={twMerge(
-                "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium w-fit transition-colors",
-                filter === "all"
-                  ? "text-light-300 border-light-500 bg-light-500/10 hover:bg-light-500/20"
-                  : filter === "ambiguous"
-                  ? "text-amber-300 border-amber-400 bg-amber-500/20 hover:bg-amber-500/30"
-                  : "text-light-300 border-light-400 bg-light-400/15 hover:bg-light-400/25"
-              )}
-              aria-label="Cycle ambiguity filter"
-            >
-              <MdCallSplit className="size-3.5 rotate-90" />
-              {filterLabel}
-            </button>
-          )}
+          <div className="flex flex-wrap gap-2">
+            {ambiguousCount > 0 && (
+              <button
+                type="button"
+                onClick={cycleAmbiguityFilter}
+                className={twMerge(
+                  "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium w-fit transition-colors",
+                  filter === "ambiguous"
+                    ? "text-amber-300 border-amber-400 bg-amber-500/20 hover:bg-amber-500/30"
+                    : filter === "not-ambiguous"
+                    ? "text-light-300 border-light-400 bg-light-400/15 hover:bg-light-400/25"
+                    : "text-light-300 border-light-500 bg-light-500/10 hover:bg-light-500/20"
+                )}
+                aria-label="Cycle ambiguity filter"
+              >
+                <MdCallSplit className="size-3.5 rotate-90" />
+                {ambiguityLabel}
+              </button>
+            )}
+            {lowTrustCount > 0 && (
+              <button
+                type="button"
+                onClick={cycleLowTrustFilter}
+                className={twMerge(
+                  "inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium w-fit transition-colors",
+                  filter === "low-trust"
+                    ? "text-rose-300 border-rose-400 bg-rose-500/20 hover:bg-rose-500/30"
+                    : "text-light-300 border-light-500 bg-light-500/10 hover:bg-light-500/20"
+                )}
+                aria-label="Cycle low-trust filter"
+              >
+                <MdWarningAmber className="size-3.5" />
+                {lowTrustLabel}
+              </button>
+            )}
+          </div>
         </div>
       }
       isOpen={isOpen}

--- a/frontend/components/entities/food/FoodCompositionSection.tsx
+++ b/frontend/components/entities/food/FoodCompositionSection.tsx
@@ -31,7 +31,10 @@ import Pagination from "@/components/basic/Pagination";
 import LoadingCard from "@/components/basic/LoadingCard";
 import Heading from "@/components/basic/Heading";
 import { AmbiguityBadge } from "@/components/basic/Ambiguity";
-import FoodCompositionEvidenceModal from "@/components/entities/food/FoodCompositionEvidenceModal";
+import { TrustBadge } from "@/components/basic/TrustBadge";
+import FoodCompositionEvidenceModal, {
+  EvidenceFilter,
+} from "@/components/entities/food/FoodCompositionEvidenceModal";
 import { usePaginations } from "@/context/paginationsContext";
 import { encodeSpace, formatConcentrationValueAlt } from "@/utils/utils";
 import {
@@ -106,10 +109,10 @@ const FoodCompositionSection = ({
     direction: "desc",
   });
   const [showAllConcentrations, setShowAllConcentrations] = useState(true);
+  const [showLowTrust, setShowLowTrust] = useState(false);
   const [selectedEvidenceName, setSelectedEvidenceName] = useState("");
-  const [ambiguousFilter, setAmbiguousFilter] = useState<
-    "all" | "ambiguous" | "not-ambiguous"
-  >("all");
+  const [evidenceFilter, setEvidenceFilter] =
+    useState<EvidenceFilter>("all");
   const [sourceCounts, setSourceCounts] = useState<Record<string, number>>({});
   const [classificationFilter, setClassificationFilter] = useState<
     string[]
@@ -168,7 +171,8 @@ const FoodCompositionSection = ({
           searchTerm,
           sort,
           showAllConcentrations,
-          activeClsFilter
+          activeClsFilter,
+          showLowTrust ? "show_all" : "default"
         );
         // client-side filter: only keep rows with evidence from selected sources
         const filteredData = (
@@ -201,6 +205,7 @@ const FoodCompositionSection = ({
     searchTerm,
     sort,
     showAllConcentrations,
+    showLowTrust,
     classificationFilter,
     classificationCounts,
   ]);
@@ -218,7 +223,7 @@ const FoodCompositionSection = ({
   ) => {
     event.preventDefault();
     event.stopPropagation();
-    setAmbiguousFilter("all");
+    setEvidenceFilter("all");
     setSelectedEvidenceName(name);
   };
 
@@ -229,7 +234,18 @@ const FoodCompositionSection = ({
   ) => {
     event.preventDefault();
     event.stopPropagation();
-    setAmbiguousFilter("ambiguous");
+    setEvidenceFilter("ambiguous");
+    setSelectedEvidenceName(name);
+  };
+
+  // handle trust badge click (opens modal pre-filtered to low-trust)
+  const handleTrustBadgeClick = (
+    event: React.MouseEvent<HTMLButtonElement>,
+    name: string
+  ) => {
+    event.preventDefault();
+    event.stopPropagation();
+    setEvidenceFilter("low-trust");
     setSelectedEvidenceName(name);
   };
 
@@ -245,6 +261,19 @@ const FoodCompositionSection = ({
     return all.filter((ev) =>
       ev.extraction.some((ex) => (ex.chemical_candidates?.length ?? 0) > 1)
     ).length;
+  };
+
+  // count evidences (= "data points") that contain ≥1 low-trust extraction.
+  // Only meaningful when showLowTrust is on (otherwise the API filtered them
+  // server-side and the annotation isn't on the response).
+  const getRowLowTrustCount = (row: FoodCompositionData) => {
+    const all = [
+      ...(row.foodatlas_evidences ?? []),
+      ...(row.fdc_evidences ?? []),
+      ...(row.dmd_evidences ?? []),
+    ];
+    return all.filter((ev) => ev.extraction.some((ex) => ex.trust_low === true))
+      .length;
   };
 
   // handle search
@@ -270,6 +299,11 @@ const FoodCompositionSection = ({
 
   const handleConcentrationSwitchChange = () => {
     setShowAllConcentrations((prev) => !prev);
+    setTablePaginations("food-composition-table", 1, 20);
+  };
+
+  const handleLowTrustSwitchChange = () => {
+    setShowLowTrust((prev) => !prev);
     setTablePaginations("food-composition-table", 1, 20);
   };
 
@@ -311,6 +345,19 @@ const FoodCompositionSection = ({
                 <Switch
                   checked={showAllConcentrations}
                   onChange={handleConcentrationSwitchChange}
+                  className="group inline-flex h-6 w-11 items-center rounded-full bg-light-700 data-[checked]:bg-accent-600 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 flex-shrink-0"
+                >
+                  <span className="size-4 translate-x-1 rounded-full bg-white transition group-data-[checked]:translate-x-6" />
+                </Switch>
+              </div>
+              {/* switch to surface low-trust data points */}
+              <div className="flex gap-3 items-center justify-between">
+                <span className="uppercase text-xs text-light-400 md:max-w-[10rem] lg:text-right">
+                  show low trustworthiness data points
+                </span>
+                <Switch
+                  checked={showLowTrust}
+                  onChange={handleLowTrustSwitchChange}
                   className="group inline-flex h-6 w-11 items-center rounded-full bg-light-700 data-[checked]:bg-accent-600 data-[disabled]:cursor-not-allowed data-[disabled]:opacity-50 flex-shrink-0"
                 >
                   <span className="size-4 translate-x-1 rounded-full bg-white transition group-data-[checked]:translate-x-6" />
@@ -598,6 +645,13 @@ const FoodCompositionSection = ({
                               handleAmbiguityBadgeClick(e, row.name)
                             }
                           />
+                          <TrustBadge
+                            lowTrustCount={getRowLowTrustCount(row)}
+                            totalCount={getRowEvidenceCount(row)}
+                            onClick={(e) =>
+                              handleTrustBadgeClick(e, row.name)
+                            }
+                          />
                         </div>
                       </td>
                       {/* classification */}
@@ -704,7 +758,7 @@ const FoodCompositionSection = ({
           })()}
           isOpen={selectedEvidenceName !== ""}
           onClose={() => setSelectedEvidenceName("")}
-          initialFilter={ambiguousFilter}
+          initialFilter={evidenceFilter}
         />
       </Portal>
     </>

--- a/frontend/types/Evidence.ts
+++ b/frontend/types/Evidence.ts
@@ -26,6 +26,7 @@ export type Evidence = {
 // };
 
 export type FoodEvidenceExtraction = {
+  attestation_id?: string;
   extracted_food_name: string | null;
   extracted_chemical_name: string | null;
   extracted_concentration: string | null;
@@ -33,6 +34,10 @@ export type FoodEvidenceExtraction = {
   method: string;
   food_candidates?: string[] | null;
   chemical_candidates?: string[] | null;
+  // True only when the extraction has an LLM-plausibility score and that
+  // score is below the API-side threshold. Set by the API on trust=show_all
+  // responses; absent (treated as false) on trust=default responses.
+  trust_low?: boolean;
 };
 
 export type FoodEvidence = {

--- a/frontend/utils/fetching.ts
+++ b/frontend/utils/fetching.ts
@@ -82,6 +82,14 @@ export async function getFoodMacroAndMicroData(
 }
 
 // fetch food composition data, i.e. its chemical composition
+//
+// `trust` is forwarded to the API:
+//   - "default"  : low-trust extractions hidden (server-side filter)
+//   - "show_all" : every extraction returned, annotated with `trust_low`
+//   - "low_only" : only low-trust extractions returned (used when the user
+//                  clicks the trust badge from the row)
+export type TrustMode = "default" | "show_all" | "low_only";
+
 export async function getFoodCompositionData(
   commonName: string,
   currentPage: number,
@@ -89,7 +97,8 @@ export async function getFoodCompositionData(
   searchTerm: string,
   sort: { column: string; direction: string },
   showAllConcentrations: boolean,
-  classificationFilters: string[] = []
+  classificationFilters: string[] = [],
+  trust: TrustMode = "default"
 ) {
   const clsParam =
     classificationFilters.length > 0
@@ -104,7 +113,7 @@ export async function getFoodCompositionData(
       "%2B"
     )}&search=${encodeURIComponent(searchTerm)}&sort_by=${
       sort.column
-    }&sort_dir=${sort.direction}&show_all_rows=${showAllConcentrations}${clsParam}`,
+    }&sort_dir=${sort.direction}&show_all_rows=${showAllConcentrations}${clsParam}&trust=${trust}`,
     {
       headers: {
         Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY}`,


### PR DESCRIPTION
…#169)

* feat(kgc): add trust stage with v1 LLM plausibility judge

Adds a TRUST stage (#5) to the KGC pipeline that emits per-attestation trustworthiness signals to outputs/kg/trust_signals.parquet, plus a DB loader extension that upserts those rows into base_trust_signals on a separate TrustBase so signals survive db load rebuilds.

The v1 signal is an LLM plausibility judge using Gemini 2.5 Flash-Lite via the Gemini API. Pluggable TrustLLMClient interface (bedrock/openai stubs fail fast) makes it cheap to swap providers in future versions.

Each version is a self-contained YAML bundle under src/pipeline/trust/versions/<signal>/<version>.yml that pins provider, model, prompts, generation params, and response schema. config_hash over the canonicalized YAML is the dedup key, so any semantic edit (prompt, model, temperature) produces a new hash and re-judges; purely operational knobs (sync vs batch, limit, source filter) live in TrustStageConfig and don't change the hash.

Errors are recorded as score=-1 + error_text rather than dropped, so the next run retries them automatically; the DB upsert uses ON CONFLICT DO UPDATE so a successful retry overwrites the prior error row. Tenacity-based per-call retry on 429/5xx with exponential backoff and jitter, with tqdm log redirect so retry warnings don't shred the progress bar.

Enrichment now also saves an "enrichment" checkpoint at end so the trust stage can load it (filling a pre-existing gap in the chain).

defaults.json gets a new pipeline.stages.trust block with production defaults (lit2kg-only source filter, batch_mode=true). Includes scripts/spot_check_food.py — ad-hoc per-food calibration that does not touch the persistent parquet.

Tests: five new test modules (~50 unit tests) covering models, label thresholds, version-bundle hashing, runner pure helpers, LLM-client factory + stubs; total coverage stays >80%.

Follow-ups tracked as separate issues:
- #160 drop obsolete attestation columns (validated, validated_correct, filter_score)
- #161 move >100% bound from conc_parser into a range_check signal
- #162 consolidate .env handling + add .env.example templates
- #164 deep-merge config defaults
- #165 dormant grouping module + dead data_cleaning_dir

* feat(api,db): per-attestation trust filter on /food/composition

Surfaces the trust signals shipped in the previous commit through to the food composition endpoint, plus a trust-only DB load path so trust iterations don't require rebuilding the full KG.

backend/db
- materializer_composition: every evidence dict (FDC, foodatlas, DMD) now carries `attestation_id`, exposing the FK the API needs to JOIN against base_trust_signals at request time without re-aggregating from base tables. One-time `db refresh` required after this lands.
- loader: new `load_trust_only(conn, parquet_dir)` and corresponding `db load --only trust` CLI flag — skips schema drop, base bulk inserts, and MV refresh; idempotent TrustBase.create_all + upsert from trust_signals.parquet. Chunked at 5000 rows/batch to stay under Postgres' 65535 bind-parameter cap.
- tests: chunking covered; load_trust_only verified to skip full-ETL helpers; materializer fixtures updated for the new attestation_id.

backend/api
- new APISettings.trust_low_threshold (0.3 default), tunable per env.
- new repositories/trust_filter.py — async helper that batch-fetches scores from base_trust_signals and filters/annotates evidence dicts in-place. Three modes:
    * default — drop extractions below threshold; drop rows with no evidences left
    * show_all — pass through unchanged (no DB hit)
    * low_only — keep only extractions below threshold (mirrors the "ambiguous" pattern: shows only the suspicious data points) Attestations without a trust signal default to score=1.0 so FDC/DMD evidence (currently unjudged) passes default and is excluded from low_only.
- food.get_composition + /food/composition route accept `trust` param.
- 10 unit tests covering every mode, threshold boundaries, edge cases.

Caveats (acceptable for v1):
- Trust filter applies post-pagination, so total_rows / page sizes are approximate when trust\!=show_all. Revisit if it becomes a real UX issue (CTE-based row-level filtering is the upgrade path).
- /chemical/composition returns aggregated foods without per-attestation evidence arrays, so the trust filter doesn't apply there yet. If we ever want to drop foods whose only-evidence-for-this-chemical is low-trust, that's a separate design conversation.

* feat(frontend,api,kgc): trust toggle on /food/composition + prompt v1 cleanup

End-to-end UX for the trust signal: a "Show low trustworthiness data points" toggle on the chemical composition table, with a TrustBadge per row mirroring AmbiguityBadge — click it to filter the evidence modal to just the suspicious extractions.

Frontend
- New components/basic/TrustBadge.tsx: rose pill, hidden when zero, tooltip explains the count, click handler opens the modal.
- FoodCompositionSection: new Switch ("Show low trustworthiness data points", default off) wired to trust=show_all vs trust=default in the API call; TrustBadge per row using the new trust_low annotation; evidenceFilter state subsumes the old ambiguousFilter so badges and cycle buttons cooperate.
- FoodCompositionEvidenceModal: filter type widened to "all" | "ambiguous" | "not-ambiguous" | "low-trust"; two independent cycle buttons (ambiguity 3-state, low-trust 2-state) that only render when the corresponding count > 0.
- types/Evidence.ts gains attestation_id + trust_low on extractions.
- utils/fetching.ts forwards a TrustMode query param.

API
- trust_filter now annotates extractions with trust_low under show_all (so the UI can render the badge without re-running the threshold) and recomputes median_concentration per surviving row under default / low_only (the MV's stored median is computed at refresh time across every extraction; once we drop low-trust ones it's stale).
- Threshold flipped to inclusive low-side (score <= threshold counts as low) — the model lands on round numbers like 0.3 and strict `<` was letting them slip; bumped default from 0.3 to 0.4 in API config.
- Per-attestation score query now uses ROW_NUMBER() OVER (PARTITION BY attestation_id ORDER BY created_at DESC) to pick the latest judgment rather than MAX(score) — re-judging a prompt iteration appends rows with new config_hash, and we want the freshest score per attestation to win, not the highest one across all historical versions.
- food.get_composition now fetches all matching rows and paginates in Python after trust filtering, so total_rows / total_pages reflect the post-filter count and the page is sorted by recomputed median (rows whose data points were dropped no longer get stuck at the top).

KGC
- v1 prompt stripped to pure plausibility: model now sees only food + chemical + standardized concentration. The original units and source sentence are removed because exposing them invited entailment reasoning ("does the source support this claim?") which is out-of-scope for this signal_kind. Pure plausibility judges the world-state of the claim alone — useful side-effect: dw values silently standardized as ww now correctly fail plausibility, surfacing IE-side normalization bugs as low-trust signals.
- runner: drop sentence resolution and evidence loading; _build_requests no longer needs to walk EvidenceStore.
- v1's config_hash changes — reruns will re-judge from scratch.

DB-side helper scripts (not part of the loader)
- scripts/inspect_trust.py: filter by canonical food/chemical name (via base_entities), dump per-attestation scores; used to diagnose individual rows ("why is X still showing under default mode").
- scripts/trust_distribution.py: histogram + below-threshold cumulative counts for the whole base_trust_signals table.
- scripts/wipe_trust.py: DELETE FROM base_trust_signals; useful when iterating the prompt before shipping.

Follow-ups filed:
- #167 per-extraction trust visibility (icon/score) inside evidences
- #168 inconsistent data-point counting (per-evidence vs per-extraction; DMD combining)