### PR TITLE
fix(frontend): return 404 instead of 500 for unknown entity slugs (#172)

### DIFF
--- a/frontend/app/(everything-else)/disease/[slug]/page.tsx
+++ b/frontend/app/(everything-else)/disease/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { Metadata } from "next";
+import { notFound } from "next/navigation";
 import { Suspense } from "react";
 
 import DiseaseCorrelationsSection from "@/components/entities/disease/DiseaseCorrelationsSection";
@@ -20,11 +21,12 @@ export async function generateMetadata({
   const commonName = decodeSpace(decodeURIComponent(slug));
 
   const metaData = await getMetaData(commonName, "disease");
+  if (!metaData) notFound();
 
   return {
-    title: `${toTitleCase(metaData?.common_name)} and Your Health`,
+    title: `${toTitleCase(metaData.common_name)} and Your Health`,
     description: `Evidence-based correlations between ${toTitleCase(
-      metaData?.common_name
+      metaData.common_name
     )} and the foods that contain it.`,
   };
 }

--- a/frontend/app/(everything-else)/food/[slug]/page.tsx
+++ b/frontend/app/(everything-else)/food/[slug]/page.tsx
@@ -1,5 +1,6 @@
 import { Suspense } from "react";
 import { Metadata } from "next";
+import { notFound } from "next/navigation";
 
 import FoodCompositionSection from "@/components/entities/food/FoodCompositionSection";
 import HeaderSection from "@/components/entities/HeaderSection";
@@ -22,6 +23,7 @@ export async function generateMetadata({
   const commonName = decodeSpace(decodeURIComponent(slug));
 
   const metaData = await getMetaData(commonName, "food");
+  if (!metaData) notFound();
 
   return {
     title: `${toTitleCase(metaData.common_name)} - Food Composition`,

--- a/frontend/utils/__tests__/fetching.test.ts
+++ b/frontend/utils/__tests__/fetching.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { getMetaData } from "@/utils/fetching";
+
+const ok = (body: unknown) =>
+  ({
+    ok: true,
+    json: async () => body,
+  }) as unknown as Response;
+
+describe("getMetaData", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_API_URL", "http://api.test");
+    vi.stubEnv("NEXT_PUBLIC_API_KEY", "k");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("returns null when the API returns an empty data array", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      ok({ data: [], metadata: { row_count: 0 } })
+    );
+
+    const result = await getMetaData("nonexistent", "food");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns the first entity when the API returns matches", async () => {
+    const entity = {
+      id: "FA-1",
+      entity_type: "food",
+      common_name: "tomato",
+      scientific_name: "Solanum lycopersicum",
+      synonyms: [],
+      external_ids: {},
+    };
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      ok({ data: [entity], metadata: { row_count: 1 } })
+    );
+
+    const result = await getMetaData("tomato", "food");
+
+    expect(result).toEqual(entity);
+  });
+
+  it("throws when the API responds with a non-ok status", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      json: async () => ({}),
+    } as unknown as Response);
+
+    await expect(getMetaData("tomato", "food")).rejects.toThrow(
+      "Failed to fetch metadata for food tomato"
+    );
+  });
+});

--- a/frontend/utils/fetching.ts
+++ b/frontend/utils/fetching.ts
@@ -1,10 +1,11 @@
 import { MacroAndMicroData, Metadata, TaxonomyData } from "@/types";
 
 // fetch metadata for a given entity
+// returns null when no entity matches the given common name
 export async function getMetaData(
   commonName: string,
   entityType: string
-): Promise<Metadata> {
+): Promise<Metadata | null> {
   const res = await fetch(
     `${
       process.env.NEXT_PUBLIC_API_URL
@@ -23,7 +24,7 @@ export async function getMetaData(
 
   const data = await res.json();
 
-  return data.data[0];
+  return data.data[0] ?? null;
 }
 
 // fetch taxonomy ancestry for a given entity


### PR DESCRIPTION
* fix(frontend): return 404 instead of 500 for unknown entity slugs

The food and disease entity pages crashed with a generic "An error occurred in the Server Components render" 500 whenever a slug had no matching row in the materialized entity views. The API returns HTTP 200 with `{"data": []}` in that case, so `getMetaData` resolved to `undefined`, and `generateMetadata` then read `.common_name` on it (food) or passed it through `toTitleCase` (disease), throwing a TypeError out of metadata generation and aborting the route.

Have `getMetaData` resolve to `null` on empty results and call `notFound()` from `generateMetadata` when there is no entity, so missing slugs render the existing `app/not-found.tsx` UI instead of the runtime error page. Add unit tests covering empty/populated/non-ok responses.



* chore: trigger preview rebuild without build cache

NEXT_PUBLIC_API_URL/KEY are baked at build time; need a fresh build after wiring those env vars into the Preview environment.



---------