### PR TITLE
feat(frontend): umami tracking with first-party proxy

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Portal } from "@headlessui/react";
 import { GoogleAnalytics } from "@next/third-parties/google";
+import Script from "next/script";
 
 import Providers from "@/app/providers";
 import SearchBar from "@/components/search/SearchBar";
@@ -28,6 +29,14 @@ const Layout = ({ children }: ClientLayoutProps) => {
         <GoogleAnalytics
           gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? ""}
         />
+        {process.env.VERCEL_ENV === "production" && (
+          <Script
+            defer
+            src="/_a/script.js"
+            data-website-id="a63b88b0-aa17-4ca1-a3c6-62a568fe0757"
+            data-host-url="/_a"
+          />
+        )}
         <Providers>
           <main id="main-content">
             {children}

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -3,6 +3,18 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
+  rewrites: async () => [
+    // Proxy umami through a first-party path so adblock pattern rules
+    // (||umami.*, /script.js, /api/send) don't match.
+    {
+      source: "/_a/script.js",
+      destination: "https://umami.aifs.ucdavis.edu/script.js",
+    },
+    {
+      source: "/_a/api/send",
+      destination: "https://umami.aifs.ucdavis.edu/api/send",
+    },
+  ],
   redirects: async () => [
     // old urls
     {


### PR DESCRIPTION
## Summary
- Adds umami tracking (`<Script>` in root `app/layout.tsx`) alongside the existing `GoogleAnalytics` — both run, neither replaces the other.
- Loads from `/_a/script.js` with `data-host-url="/_a"`; `next.config.mjs` `rewrites` proxy `/_a/script.js` and `/_a/api/send` through to `umami.aifs.ucdavis.edu`, so EasyPrivacy / uBlock can't pattern-match `||umami.*`, `/script.js`, or `/api/send`.
- Wrapped in `process.env.VERCEL_ENV === "production"` so preview deploys and local dev don't pollute the dashboard.

## Why proxy
Self-hosting umami doesn't beat path-based filterlist rules; only first-party origin does. Estimated audience-dependent loss is ~10–40%. Same pattern applied to byproduct-database, milkcomposition, AIVO, AIFS website, preclinical-db, dmd-frontend already.

## Test plan
- [ ] `pnpm --filter web build` / `next build` succeeds.
- [ ] Preview deploy: tag absent (gate filters it).
- [ ] Production deploy (`view-source`): umami `<script>` tag visible; DevTools shows `/_a/script.js` 200 + `/_a/api/send` POST 200 with adblocker enabled.
- [ ] Page-view appears in Umami dashboard for website-id `a63b88b0-...` within ~1 min.
- [ ] GoogleAnalytics continues to fire normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)