### PR TITLE
feat(frontend): add umami tracking with first-party proxy, gated to p…

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Portal } from "@headlessui/react";
 import { GoogleAnalytics } from "@next/third-parties/google";
+import Script from "next/script";
 
 import Providers from "@/app/providers";
 import SearchBar from "@/components/search/SearchBar";
@@ -28,6 +29,14 @@ const Layout = ({ children }: ClientLayoutProps) => {
         <GoogleAnalytics
           gaId={process.env.NEXT_PUBLIC_GA_MEASUREMENT_ID ?? ""}
         />
+        {process.env.VERCEL_ENV === "production" && (
+          <Script
+            defer
+            src="/_a/script.js"
+            data-website-id="a63b88b0-aa17-4ca1-a3c6-62a568fe0757"
+            data-host-url="/_a"
+          />
+        )}
         <Providers>
           <main id="main-content">
             {children}

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -3,6 +3,18 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
+  rewrites: async () => [
+    // Proxy umami through a first-party path so adblock pattern rules
+    // (||umami.*, /script.js, /api/send) don't match.
+    {
+      source: "/_a/script.js",
+      destination: "https://umami.aifs.ucdavis.edu/script.js",
+    },
+    {
+      source: "/_a/api/send",
+      destination: "https://umami.aifs.ucdavis.edu/api/send",
+    },
+  ],
   redirects: async () => [
     // old urls
     {


### PR DESCRIPTION
…rod (#177)

Adds umami alongside the existing GoogleAnalytics tag. The <Script> loads from /_a/script.js with data-host-url="/_a"; next.config.mjs rewrites /_a/script.js and /_a/api/send through to umami.aifs.ucdavis.edu so EasyPrivacy/uBlock can't pattern-match ||umami.* or the literal /script.js, /api/send paths.

Wrapped in process.env.VERCEL_ENV === "production" so preview deploys and local dev don't pollute the umami stats.