### PR TITLE
feat: public /v1/ API with email-issued keys

### DIFF
--- a/backend/api/pyproject.toml
+++ b/backend/api/pyproject.toml
@@ -12,6 +12,8 @@ dependencies = [
     "pydantic>=2.6",
     "pydantic-settings>=2.1",
     "httpx>=0.28",
+    "boto3>=1.34",
+    "click>=8.1",
 ]
 
 [tool.uv]

--- a/backend/api/scripts/issue_public_key.py
+++ b/backend/api/scripts/issue_public_key.py
@@ -1,0 +1,94 @@
+"""Issue a new /v1/ public API key.
+
+Usage::
+
+    cd backend/api && uv run python scripts/issue_public_key.py
+
+The script never touches AWS itself — it prints the plaintext key (email it
+to the recipient) and the ``aws secretsmanager`` command you can paste into
+the terminal to merge the new entry into ``foodatlas/public-api-keys``.
+Plaintext keys are not written to disk.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import secrets
+
+import click
+
+DEFAULT_SECRET_NAME = "foodatlas/public-api-keys"
+
+
+@click.command()
+@click.option(
+    "--email",
+    prompt="Researcher email",
+    help="Email of the person receiving the key (stored in the secret).",
+)
+@click.option(
+    "--notes",
+    prompt="Notes (optional, e.g. project name)",
+    default="",
+    help="Free-form notes attached to the key record.",
+)
+@click.option(
+    "--secret-name",
+    default=DEFAULT_SECRET_NAME,
+    show_default=True,
+    help="AWS Secrets Manager secret name to update.",
+)
+@click.option(
+    "--region",
+    default="us-west-1",
+    show_default=True,
+    help="AWS region holding the secret.",
+)
+def main(email: str, notes: str, secret_name: str, region: str) -> None:
+    """Generate a key and emit the plaintext + AWS CLI merge command."""
+    plaintext = secrets.token_urlsafe(32)
+    key_hash = hashlib.sha256(plaintext.encode("utf-8")).hexdigest()
+    created = dt.date.today().isoformat()
+
+    record = {
+        key_hash: {
+            "email": email,
+            "created": created,
+            "notes": notes,
+        }
+    }
+
+    click.echo("")
+    click.secho("New API key (email this to the recipient):", fg="green", bold=True)
+    click.echo(plaintext)
+    click.echo("")
+    click.secho("Add to Secrets Manager:", fg="cyan", bold=True)
+    click.echo(_aws_merge_command(secret_name, region, record))
+    click.echo("")
+    click.secho(
+        "The running API picks up new keys on its next refresh tick "
+        "(default 5 minutes) — no redeploy needed.",
+        fg="yellow",
+    )
+
+
+def _aws_merge_command(secret_name: str, region: str, new_entry: dict) -> str:
+    """Build a one-liner that merges ``new_entry`` into the existing secret."""
+    new_json = json.dumps(new_entry)
+    # Reads current secret, merges in the new entry via jq, writes back.
+    return (
+        "EXISTING=$("
+        f"aws secretsmanager get-secret-value --region {region} "
+        f"--secret-id {secret_name} --query SecretString --output text "
+        "2>/dev/null || echo '{}'"
+        ") && \\\n"
+        f"  echo \"$EXISTING\" | jq -c '. + {new_json}' | \\\n"
+        f"  xargs -0 aws secretsmanager update-secret --region {region} "
+        f"--secret-id {secret_name} --secret-string"
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/api/src/app.py
+++ b/backend/api/src/app.py
@@ -4,22 +4,61 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.openapi.utils import get_openapi
 
 from src.config import APISettings
 from src.dependencies import init_session_factory
+from src.public_keys import get_store, init_store
 from src.routes import chemical, disease, download, food, metadata, resolve
+from src.routes import v1 as v1_routes
+
+PUBLIC_API_DESCRIPTION = """
+FoodAtlas exposes its food-chemical-disease knowledge graph through a
+versioned public REST API under `/v1/`. Internal UI routes (e.g. `/food/`,
+`/chemical/`) are not part of the public contract; use `/v1/` for any
+external integration.
+
+### Authentication
+All `/v1/` requests must include `Authorization: Bearer <key>`. To request
+a key, email aifs@ucdavis.edu with your name, affiliation, and intended
+use.
+
+### Rate limits
+No per-key limits are enforced today. Please be polite; we will reach out
+if usage looks abusive.
+
+### Versioning & terms
+Endpoints under `/v1/` follow a stable contract. Use is intended for
+academic and non-commercial research. Cite FoodAtlas in any published work
+that uses this data.
+""".strip()
 
 
 def create_app(settings: APISettings | None = None) -> FastAPI:
     """Create and configure the FastAPI application."""
     settings = settings or APISettings()
+    init_store(settings)
 
     @asynccontextmanager
     async def lifespan(_app: FastAPI):
         init_session_factory()
-        yield
+        store = get_store()
+        if store is not None and not settings.debug:
+            await store.start()
+        try:
+            yield
+        finally:
+            if store is not None:
+                await store.stop()
 
-    app = FastAPI(title="FoodAtlas API", version="0.1.0", lifespan=lifespan)
+    app = FastAPI(
+        title="FoodAtlas API",
+        version="1.0.0",
+        description=PUBLIC_API_DESCRIPTION,
+        contact={"name": "FoodAtlas Team", "email": "aifs@ucdavis.edu"},
+        license_info={"name": "Academic use only"},
+        lifespan=lifespan,
+    )
 
     app.add_middleware(
         CORSMiddleware,
@@ -34,6 +73,7 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
         """Liveness probe for the ALB target group (no auth required)."""
         return {"status": "ok"}
 
+    # Internal UI router (not part of the public contract)
     app.include_router(food.router)
     app.include_router(chemical.router)
     app.include_router(disease.router)
@@ -41,7 +81,40 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
     app.include_router(download.router)
     app.include_router(resolve.router)
 
+    # Public versioned API
+    app.include_router(v1_routes.router)
+
+    app.openapi = _build_openapi(app)  # type: ignore[method-assign]
     return app
+
+
+def _build_openapi(app: FastAPI):
+    """Inject a Bearer security scheme so the /docs Authorize button works."""
+
+    def custom_openapi():
+        if app.openapi_schema:
+            return app.openapi_schema
+        schema = get_openapi(
+            title=app.title,
+            version=app.version,
+            description=app.description,
+            routes=app.routes,
+            contact=app.contact,
+            license_info=app.license_info,
+        )
+        schema.setdefault("components", {}).setdefault("securitySchemes", {})[
+            "bearerAuth"
+        ] = {"type": "http", "scheme": "bearer"}
+        for path, methods in schema.get("paths", {}).items():
+            if not path.startswith("/v1/"):
+                continue
+            for op in methods.values():
+                if isinstance(op, dict):
+                    op["security"] = [{"bearerAuth": []}]
+        app.openapi_schema = schema
+        return schema
+
+    return custom_openapi
 
 
 app = create_app()

--- a/backend/api/src/config.py
+++ b/backend/api/src/config.py
@@ -22,3 +22,9 @@ class APISettings(BaseSettings):
     # (show only low-trust). Threshold lives here so it can be tuned
     # without redeploying the frontend or rerunning the trust stage.
     trust_low_threshold: float = 0.4
+    # Public /v1/ API key store: AWS Secrets Manager secret holding a JSON
+    # object {sha256_hex(key): {email, created, notes}}. Empty disables the
+    # public key path (only the internal `key` is accepted on /v1/*).
+    public_keys_secret_name: str = ""
+    public_keys_refresh_seconds: int = 300
+    aws_region: str = "us-west-1"

--- a/backend/api/src/dependencies.py
+++ b/backend/api/src/dependencies.py
@@ -12,6 +12,7 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from src.config import APISettings
+from src.public_keys import get_store
 
 
 class DBSettings(BaseSettings):
@@ -82,3 +83,32 @@ async def verify_api_key(
     auth = request.headers.get("Authorization", "")
     if auth != f"Bearer {settings.key}":
         raise HTTPException(status_code=401, detail="Invalid API key")
+
+
+async def verify_v1_key(
+    request: Request,
+    settings: APISettings = _settings_dep,
+) -> None:
+    """Authorise /v1/* requests with either the internal key or a public key.
+
+    Accept order: debug bypass → internal ``settings.key`` (the frontend) →
+    sha256 hash matches a record in :class:`PublicKeyStore`. Misses 401.
+
+    The matched public key's email is stashed on ``request.state.api_key_email``
+    so future logging middleware can attribute usage without re-reading
+    headers.
+    """
+    if settings.debug:
+        return
+    auth = request.headers.get("Authorization", "")
+    if not auth.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Invalid API key")
+    token = auth[len("Bearer ") :]
+    if settings.key and token == settings.key:
+        request.state.api_key_email = "internal"
+        return
+    store = get_store()
+    record = store.verify(token) if store is not None else None
+    if record is None:
+        raise HTTPException(status_code=401, detail="Invalid API key")
+    request.state.api_key_email = record.email

--- a/backend/api/src/public_keys.py
+++ b/backend/api/src/public_keys.py
@@ -1,0 +1,172 @@
+"""Public /v1/ API key store, backed by AWS Secrets Manager.
+
+The secret named by :attr:`APISettings.public_keys_secret_name` holds a JSON
+object keyed by ``sha256_hex(plaintext_key)``::
+
+    {
+        "<sha256-of-key>": {
+            "email":   "alice@uni.edu",
+            "created": "2026-05-13",
+            "notes":   "DMD paper figure code"
+        },
+        ...
+    }
+
+Plaintext keys never live on disk or in this process — only their hashes do.
+A new key is issued by ``scripts/issue_public_key.py`` and pasted into the
+secret via ``aws secretsmanager update-secret``; the running API picks it up
+on the next refresh tick (default 300s) or restart.
+
+Failure model: the initial load on startup is fail-closed (the app refuses
+to come up) unless ``debug=True`` or ``public_keys_secret_name`` is empty.
+After the initial load succeeds, refresh failures log a warning but keep
+the previously-loaded map so a transient AWS outage doesn't lock everyone
+out mid-flight.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from src.config import APISettings
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class KeyRecord:
+    """Metadata for an issued key. Plaintext is never stored — only the hash."""
+
+    email: str
+    created: str = ""
+    notes: str = ""
+
+
+@dataclass
+class PublicKeyStore:
+    """In-memory map of sha256(key) → KeyRecord, refreshed from Secrets Manager.
+
+    The store is safe to share across requests: ``verify`` only reads
+    :attr:`_keys`, and refreshes swap the dict atomically.
+    """
+
+    secret_name: str
+    region: str
+    refresh_seconds: int = 300
+    _keys: dict[str, KeyRecord] = field(default_factory=dict)
+    _task: asyncio.Task[None] | None = None
+    # Test injection point: when set, the loader calls this instead of boto3.
+    _client_factory: Callable[[], Any] | None = None
+
+    def verify(self, token: str) -> KeyRecord | None:
+        """Return the matching record (and identify the caller) or None."""
+        if not token:
+            return None
+        return self._keys.get(_hash(token))
+
+    async def load(self) -> None:
+        """Fetch the secret once and replace the in-memory map atomically."""
+        raw = await asyncio.to_thread(self._fetch_secret)
+        self._keys = _parse_secret_payload(raw)
+
+    async def start(self) -> None:
+        """Initial load + start the refresh loop. Call from app lifespan."""
+        if not self.secret_name:
+            logger.info("public_keys: secret name empty; public key path disabled")
+            return
+        await self.load()
+        self._task = asyncio.create_task(
+            self._refresh_loop(), name="public_keys_refresh"
+        )
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._task
+            self._task = None
+
+    async def _refresh_loop(self) -> None:
+        while True:
+            try:
+                await asyncio.sleep(self.refresh_seconds)
+                await self.load()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    "public_keys: refresh failed, keeping previous map: %s", exc
+                )
+
+    def _fetch_secret(self) -> str:
+        if self._client_factory is not None:
+            client = self._client_factory()
+        else:
+            import boto3  # noqa: PLC0415
+
+            client = boto3.client("secretsmanager", region_name=self.region)
+        resp = client.get_secret_value(SecretId=self.secret_name)
+        return str(resp.get("SecretString") or "{}")
+
+
+def _hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _parse_secret_payload(raw: str) -> dict[str, KeyRecord]:
+    """Parse the secret JSON; drop malformed entries with a warning."""
+    try:
+        payload = json.loads(raw or "{}")
+    except json.JSONDecodeError as exc:
+        msg = f"public_keys secret is not valid JSON: {exc}"
+        raise ValueError(msg) from exc
+    if not isinstance(payload, dict):
+        msg = "public_keys secret must be a JSON object keyed by key hash"
+        raise ValueError(msg)
+    out: dict[str, KeyRecord] = {}
+    for key_hash, meta in payload.items():
+        if not isinstance(key_hash, str) or len(key_hash) != 64:
+            logger.warning("public_keys: skipping non-hash key %r", key_hash)
+            continue
+        if not isinstance(meta, dict):
+            logger.warning("public_keys: skipping non-object metadata for %s", key_hash)
+            continue
+        out[key_hash] = KeyRecord(
+            email=str(meta.get("email", "")),
+            created=str(meta.get("created", "")),
+            notes=str(meta.get("notes", "")),
+        )
+    return out
+
+
+_store: PublicKeyStore | None = None
+
+
+def init_store(settings: APISettings) -> PublicKeyStore:
+    """Build (or rebuild) the module-level store from settings."""
+    global _store  # noqa: PLW0603
+    _store = PublicKeyStore(
+        secret_name=settings.public_keys_secret_name,
+        region=settings.aws_region,
+        refresh_seconds=settings.public_keys_refresh_seconds,
+    )
+    return _store
+
+
+def get_store() -> PublicKeyStore | None:
+    return _store
+
+
+def set_store_for_tests(store: PublicKeyStore | None) -> None:
+    """Test-only override; production code uses ``init_store``."""
+    global _store  # noqa: PLW0603
+    _store = store

--- a/backend/api/src/repositories/v1/__init__.py
+++ b/backend/api/src/repositories/v1/__init__.py
@@ -1,0 +1,1 @@
+"""Public /v1/ repositories — flat, decoupled-from-UI query layer."""

--- a/backend/api/src/repositories/v1/entities.py
+++ b/backend/api/src/repositories/v1/entities.py
@@ -1,0 +1,125 @@
+"""Flat entity queries for /v1/ (food, chemical, disease).
+
+Reuses the existing materialised views (``mv_food_entities``,
+``mv_chemical_entities``, ``mv_disease_entities``) but returns the columns
+flat — no UI fields like ``ambiguity_siblings``, no external-id reformatting.
+External IDs are returned as-is from the source data so consumers can map
+them however they like.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+from .pagination import offset as _offset
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+_ENTITY_TABLE: dict[str, str] = {
+    "food": "mv_food_entities",
+    "chemical": "mv_chemical_entities",
+    "disease": "mv_disease_entities",
+}
+
+_ENTITY_SELECT: dict[str, str] = {
+    "food": (
+        "foodatlas_id AS id, common_name, scientific_name, synonyms, "
+        "external_ids, food_classification"
+    ),
+    "chemical": (
+        "foodatlas_id AS id, common_name, scientific_name, synonyms, "
+        "external_ids, chemical_classification, flavor_descriptors"
+    ),
+    "disease": (
+        "foodatlas_id AS id, common_name, scientific_name, synonyms, external_ids"
+    ),
+}
+
+
+async def list_entities(
+    session: AsyncSession,
+    entity_type: str,
+    *,
+    q: str = "",
+    classification: str = "",
+    page: int = 1,
+    page_size: int = 50,
+) -> tuple[list[dict], int]:
+    """Return (rows, total) for an entity list.
+
+    ``q`` is a case-insensitive substring filter on ``common_name``.
+    ``classification`` is an exact-membership filter on the per-type
+    classification array (food: ``food_classification``;
+    chemical: ``chemical_classification``; ignored for disease).
+    """
+    table = _ENTITY_TABLE[entity_type]
+    cols = _ENTITY_SELECT[entity_type]
+
+    where: list[str] = []
+    params: dict[str, object] = {}
+    if q:
+        where.append("common_name ILIKE :q")
+        params["q"] = f"%{q}%"
+    if classification and entity_type in ("food", "chemical"):
+        col = (
+            "food_classification"
+            if entity_type == "food"
+            else "chemical_classification"
+        )
+        where.append(f":cls = ANY({col})")
+        params["cls"] = classification
+
+    where_sql = " WHERE " + " AND ".join(where) if where else ""
+
+    count_sql = f"SELECT COUNT(*) FROM {table}{where_sql}"
+    count_result = await session.execute(text(count_sql), params)
+    total = int(count_result.scalar() or 0)
+
+    params["limit"] = page_size
+    params["offset"] = _offset(page, page_size)
+    list_sql = (
+        f"SELECT {cols} FROM {table}{where_sql} ORDER BY common_name "
+        "OFFSET :offset ROWS FETCH FIRST :limit ROWS ONLY"
+    )
+    list_result = await session.execute(text(list_sql), params)
+    rows = [dict(r._mapping) for r in list_result]
+    return rows, total
+
+
+async def get_entity(
+    session: AsyncSession,
+    entity_type: str,
+    *,
+    entity_id: str | None = None,
+    common_name: str | None = None,
+) -> dict | None:
+    """Look up a single entity by foodatlas_id or common_name (exact)."""
+    table = _ENTITY_TABLE[entity_type]
+    cols = _ENTITY_SELECT[entity_type]
+    if entity_id is not None:
+        sql = f"SELECT {cols} FROM {table} WHERE foodatlas_id = :v"
+        params: dict[str, object] = {"v": entity_id}
+    elif common_name is not None:
+        sql = f"SELECT {cols} FROM {table} WHERE common_name = :v"
+        params = {"v": common_name}
+    else:
+        return None
+    result = await session.execute(text(sql), params)
+    row = result.first()
+    return dict(row._mapping) if row else None
+
+
+async def resolve_id(session: AsyncSession, entity_id: str) -> tuple[str, str] | None:
+    """Return (entity_type, common_name) for a foodatlas_id, or None."""
+    result = await session.execute(
+        text(
+            "SELECT entity_type, common_name FROM base_entities "
+            "WHERE foodatlas_id = :id"
+        ),
+        {"id": entity_id},
+    )
+    row = result.first()
+    return (row[0], row[1]) if row else None

--- a/backend/api/src/repositories/v1/pagination.py
+++ b/backend/api/src/repositories/v1/pagination.py
@@ -1,0 +1,27 @@
+"""Shared pagination helpers for /v1/ list endpoints."""
+
+from __future__ import annotations
+
+from src.repositories.v1.serializers import Page
+
+DEFAULT_PAGE_SIZE = 50
+MAX_PAGE_SIZE = 100
+
+
+def clamp_page_size(page_size: int) -> int:
+    if page_size < 1:
+        return DEFAULT_PAGE_SIZE
+    return min(page_size, MAX_PAGE_SIZE)
+
+
+def offset(page: int, page_size: int) -> int:
+    return max(0, (page - 1) * page_size)
+
+
+def build_page(page: int, page_size: int, total: int) -> Page:
+    return Page(
+        page=page,
+        page_size=page_size,
+        total=total,
+        has_more=(page * page_size) < total,
+    )

--- a/backend/api/src/repositories/v1/relationships.py
+++ b/backend/api/src/repositories/v1/relationships.py
@@ -1,0 +1,133 @@
+"""Flat composition + correlation queries for /v1/.
+
+Both endpoints return the same flat row shape regardless of which side
+("food's chemicals" vs. "chemical's foods") the caller asked for. Sources
+are aggregated into a single list rather than the UI's
+fdc/foodatlas/dmd-grouped evidence arrays.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+from .pagination import offset as _offset
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+_RELATION_TO_ID: dict[str, str] = {"reduces": "r4", "worsens": "r3"}
+
+
+_COMPOSITION_SELECT_CLAUSE = """
+    food_foodatlas_id AS food_id,
+    food_name,
+    chemical_foodatlas_id AS chemical_id,
+    chemical_name,
+    chemical_classification,
+    median_concentration,
+    COALESCE(jsonb_array_length(fdc_evidences), 0)
+        + COALESCE(jsonb_array_length(foodatlas_evidences), 0)
+        + COALESCE(jsonb_array_length(dmd_evidences), 0) AS attestation_count,
+    ARRAY_REMOVE(
+        ARRAY[
+            CASE WHEN fdc_evidences IS NOT NULL THEN 'fdc' END,
+            CASE WHEN foodatlas_evidences IS NOT NULL THEN 'foodatlas' END,
+            CASE WHEN dmd_evidences IS NOT NULL THEN 'dmd' END
+        ],
+        NULL
+    ) AS sources
+"""
+
+
+async def list_composition(
+    session: AsyncSession,
+    *,
+    food_id: str | None = None,
+    chemical_id: str | None = None,
+    page: int = 1,
+    page_size: int = 50,
+) -> tuple[list[dict], int]:
+    """List composition rows filtered by either food_id or chemical_id."""
+    if food_id is not None:
+        where = "food_foodatlas_id = :v"
+        order = "chemical_name"
+        params: dict[str, object] = {"v": food_id}
+    elif chemical_id is not None:
+        where = "chemical_foodatlas_id = :v"
+        order = "food_name"
+        params = {"v": chemical_id}
+    else:
+        return [], 0
+
+    count_result = await session.execute(
+        text(f"SELECT COUNT(*) FROM mv_food_chemical_composition WHERE {where}"),
+        params,
+    )
+    total = int(count_result.scalar() or 0)
+
+    params["limit"] = page_size
+    params["offset"] = _offset(page, page_size)
+    sql = (
+        f"SELECT {_COMPOSITION_SELECT_CLAUSE} "
+        f"FROM mv_food_chemical_composition WHERE {where} "
+        f"ORDER BY {order} OFFSET :offset ROWS FETCH FIRST :limit ROWS ONLY"
+    )
+    list_result = await session.execute(text(sql), params)
+    rows = [dict(r._mapping) for r in list_result]
+    return rows, total
+
+
+async def list_correlation(
+    session: AsyncSession,
+    *,
+    chemical_id: str | None = None,
+    disease_id: str | None = None,
+    relation: str = "reduces",
+    page: int = 1,
+    page_size: int = 50,
+) -> tuple[list[dict], int]:
+    """List chemical-disease correlations from either side."""
+    relationship_id = _RELATION_TO_ID.get(relation)
+    if relationship_id is None:
+        return [], 0
+    if chemical_id is not None:
+        where = "chemical_foodatlas_id = :v AND relationship_id = :rel"
+        params: dict[str, object] = {"v": chemical_id, "rel": relationship_id}
+    elif disease_id is not None:
+        where = "disease_foodatlas_id = :v AND relationship_id = :rel"
+        params = {"v": disease_id, "rel": relationship_id}
+    else:
+        return [], 0
+
+    count_result = await session.execute(
+        text(f"SELECT COUNT(*) FROM mv_chemical_disease_correlation WHERE {where}"),
+        params,
+    )
+    total = int(count_result.scalar() or 0)
+
+    params["limit"] = page_size
+    params["offset"] = _offset(page, page_size)
+    sql = f"""
+        SELECT
+            chemical_foodatlas_id AS chemical_id,
+            chemical_name,
+            disease_foodatlas_id AS disease_id,
+            disease_name,
+            source_chemical_foodatlas_id AS source_chemical_id,
+            source_chemical_name,
+            sources,
+            evidence_count
+        FROM mv_chemical_disease_correlation
+        WHERE {where}
+        ORDER BY evidence_count DESC
+        OFFSET :offset ROWS FETCH FIRST :limit ROWS ONLY
+    """
+    list_result = await session.execute(text(sql), params)
+    rows = []
+    for r in list_result:
+        row = dict(r._mapping)
+        row["relation"] = relation
+        rows.append(row)
+    return rows, total

--- a/backend/api/src/repositories/v1/search.py
+++ b/backend/api/src/repositories/v1/search.py
@@ -1,0 +1,85 @@
+"""Search + stats for /v1/.
+
+Reuses the existing ``mv_search_auto_complete`` and ``mv_metadata_statistics``
+materialised views, but returns a flat shape.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+from .pagination import offset as _offset
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def search(
+    session: AsyncSession,
+    *,
+    q: str,
+    entity_type: str = "",
+    page: int = 1,
+    page_size: int = 50,
+) -> tuple[list[dict], int]:
+    """Trigram autocomplete; optional ``entity_type`` filter."""
+    word = q.lower().strip()
+    if not word:
+        return [], 0
+
+    where = ["substr_auto LIKE :pattern"]
+    params: dict[str, object] = {"pattern": f"%{word}%", "word": word}
+    if entity_type:
+        where.append("entity_type = :etype")
+        params["etype"] = entity_type
+    where_sql = " AND ".join(where)
+
+    count_result = await session.execute(
+        text(f"SELECT COUNT(*) FROM mv_search_auto_complete WHERE {where_sql}"),
+        params,
+    )
+    total = int(count_result.scalar() or 0)
+
+    params["limit"] = page_size
+    params["offset"] = _offset(page, page_size)
+    sql = f"""
+        SELECT
+            foodatlas_id AS id,
+            entity_type,
+            common_name,
+            scientific_name,
+            associations
+        FROM mv_search_auto_complete
+        WHERE {where_sql}
+        ORDER BY
+            CASE WHEN exact_auto @> ARRAY[:word] THEN 1 ELSE 2 END,
+            associations DESC,
+            similarity(substr_auto, :word) DESC
+        OFFSET :offset ROWS FETCH FIRST :limit ROWS ONLY
+    """
+    result = await session.execute(text(sql), params)
+    return [dict(r._mapping) for r in result], total
+
+
+_STAT_KEY_MAP = {
+    "number of foods": "foods",
+    "number of chemicals": "chemicals",
+    "number of diseases": "diseases",
+    "number of publications": "publications",
+    "number of associations": "connections",
+}
+
+
+async def get_stats(session: AsyncSession) -> dict[str, int]:
+    result = await session.execute(
+        text("SELECT field, count FROM mv_metadata_statistics")
+    )
+    out: dict[str, int] = dict.fromkeys(_STAT_KEY_MAP.values(), 0)
+    for row in result:
+        mapping = row._mapping
+        key = _STAT_KEY_MAP.get(mapping["field"])
+        if key:
+            out[key] = int(mapping["count"])
+    return out

--- a/backend/api/src/repositories/v1/serializers.py
+++ b/backend/api/src/repositories/v1/serializers.py
@@ -1,0 +1,187 @@
+"""Pydantic models for the public /v1/ API.
+
+These models are the *public contract*. Keep them stable; if the shape needs
+to change, version up to /v2/ rather than editing in place.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class Page(BaseModel):
+    """Pagination metadata returned with every list response."""
+
+    page: int = Field(..., ge=1, description="1-indexed page number")
+    page_size: int = Field(..., ge=1, le=100)
+    total: int = Field(..., ge=0, description="Total matching rows across all pages")
+    has_more: bool
+
+
+class ListResponse[T](BaseModel):
+    data: list[T]
+    page: Page
+
+
+class ItemResponse[T](BaseModel):
+    data: T
+
+
+class ExternalIds(BaseModel):
+    """Raw external identifiers grouped by source (e.g. ``chebi``, ``fdc``)."""
+
+    model_config = {"extra": "allow"}
+
+
+class FoodSummary(BaseModel):
+    id: str = Field(..., description="FoodAtlas id, e.g. FA:0001")
+    common_name: str
+    scientific_name: str = ""
+    food_classification: list[str] = Field(default_factory=list)
+
+
+class Food(FoodSummary):
+    synonyms: list[str] = Field(default_factory=list)
+    external_ids: dict[str, list[str]] = Field(default_factory=dict)
+
+
+class ChemicalSummary(BaseModel):
+    id: str
+    common_name: str
+    scientific_name: str = ""
+    chemical_classification: list[str] = Field(default_factory=list)
+
+
+class Chemical(ChemicalSummary):
+    synonyms: list[str] = Field(default_factory=list)
+    flavor_descriptors: list[str] = Field(default_factory=list)
+    external_ids: dict[str, list[str]] = Field(default_factory=dict)
+
+
+class DiseaseSummary(BaseModel):
+    id: str
+    common_name: str
+    scientific_name: str = ""
+
+
+class Disease(DiseaseSummary):
+    synonyms: list[str] = Field(default_factory=list)
+    external_ids: dict[str, list[str]] = Field(default_factory=dict)
+
+
+class Concentration(BaseModel):
+    value: float
+    unit: str
+
+
+class CompositionRow(BaseModel):
+    """Flat row for /v1/foods/{id}/chemicals and /v1/chemicals/{id}/foods.
+
+    Aggregates evidence across all sources (FDC, FoodAtlas literature, DMD)
+    into a single ``sources[]`` list + ``attestation_count`` — no UI-specific
+    per-source grouping.
+    """
+
+    food_id: str
+    food_name: str
+    chemical_id: str
+    chemical_name: str
+    chemical_classification: list[str] = Field(default_factory=list)
+    median_concentration: Concentration | None = None
+    attestation_count: int = 0
+    sources: list[str] = Field(default_factory=list)
+
+
+class CorrelationRow(BaseModel):
+    """Flat row for /v1/chemicals/{id}/diseases and /v1/diseases/{id}/chemicals.
+
+    The ``relation`` field is one of ``reduces`` (r4) or ``worsens`` (r3).
+    """
+
+    chemical_id: str
+    chemical_name: str
+    disease_id: str
+    disease_name: str
+    relation: Literal["reduces", "worsens"]
+    source_chemical_id: str = ""
+    source_chemical_name: str = ""
+    sources: list[str] = Field(default_factory=list)
+    evidence_count: int = 0
+
+
+class AttestationSummary(BaseModel):
+    attestation_id: str
+    source: str
+    evidence_id: str
+    trust_score: float | None = None
+
+
+class Attestation(AttestationSummary):
+    head_id: str
+    head_name_raw: str
+    tail_id: str
+    tail_name_raw: str
+    relationship_id: str
+    conc_value: float | None = None
+    conc_unit: str = ""
+    food_part: str = ""
+    food_processing: str = ""
+    validated: bool = False
+    validated_correct: bool = True
+    trust_reason: str = ""
+
+
+class Triplet(BaseModel):
+    triplet_id: int
+    head_id: str
+    head_name: str
+    relationship_id: str
+    relationship_name: str
+    tail_id: str
+    tail_name: str
+    source: str = ""
+    attestations: list[AttestationSummary] = Field(default_factory=list)
+
+
+class TaxonomyNode(BaseModel):
+    id: str
+    name: str
+    has_page: bool
+
+
+class TaxonomyEdge(BaseModel):
+    child_id: str
+    parent_id: str
+
+
+class Taxonomy(BaseModel):
+    entity_id: str | None
+    nodes: list[TaxonomyNode]
+    edges: list[TaxonomyEdge]
+
+
+class SearchHit(BaseModel):
+    id: str
+    common_name: str
+    entity_type: Literal["food", "chemical", "disease"]
+    scientific_name: str = ""
+    associations: int = 0
+
+
+class Stats(BaseModel):
+    foods: int = 0
+    chemicals: int = 0
+    diseases: int = 0
+    publications: int = 0
+    connections: int = 0
+
+
+class Bundle(BaseModel):
+    version: str
+    release_date: str
+    file_size: str = ""
+    kgc_run: str = ""
+    download_link: str
+    summary_link: str = ""

--- a/backend/api/src/repositories/v1/triplets.py
+++ b/backend/api/src/repositories/v1/triplets.py
@@ -1,0 +1,259 @@
+"""Graph-primitive queries for /v1/ (triplets + attestations).
+
+These expose the raw knowledge graph: every triplet is a (head, relationship,
+tail) edge, every attestation is one piece of evidence backing one triplet.
+This is the surface a researcher building over the KG actually wants —
+flat rows, stable ids, no UI-level aggregation.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+from .pagination import offset as _offset
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+_VALID_RELATIONSHIPS = {"r1", "r2", "r3", "r4", "r5"}
+_RELATIONSHIP_ALIASES = {
+    "contains": "r1",
+    "is_a": "r2",
+    "worsens": "r3",
+    "reduces": "r4",
+}
+
+
+def _resolve_relationship(value: str) -> str | None:
+    if not value:
+        return None
+    if value in _VALID_RELATIONSHIPS:
+        return value
+    return _RELATIONSHIP_ALIASES.get(value.lower())
+
+
+async def list_triplets(
+    session: AsyncSession,
+    *,
+    head_id: str = "",
+    tail_id: str = "",
+    relationship: str = "",
+    source: str = "",
+    page: int = 1,
+    page_size: int = 50,
+) -> tuple[list[dict], int]:
+    """List triplets, filtered by any combination of head/tail/rel/source."""
+    where: list[str] = []
+    params: dict[str, object] = {}
+    if head_id:
+        where.append("t.head_id = :head_id")
+        params["head_id"] = head_id
+    if tail_id:
+        where.append("t.tail_id = :tail_id")
+        params["tail_id"] = tail_id
+    rel_id = _resolve_relationship(relationship) if relationship else None
+    if relationship and rel_id is None:
+        return [], 0
+    if rel_id:
+        where.append("t.relationship_id = :rel_id")
+        params["rel_id"] = rel_id
+    if source:
+        where.append("t.source = :source")
+        params["source"] = source
+    where_sql = " WHERE " + " AND ".join(where) if where else ""
+
+    count_result = await session.execute(
+        text(f"SELECT COUNT(*) FROM base_triplets t{where_sql}"), params
+    )
+    total = int(count_result.scalar() or 0)
+
+    params["limit"] = page_size
+    params["offset"] = _offset(page, page_size)
+    sql = f"""
+        SELECT
+            t.triplet_id,
+            t.head_id,
+            h.common_name AS head_name,
+            t.relationship_id,
+            r.name AS relationship_name,
+            t.tail_id,
+            tl.common_name AS tail_name,
+            t.source,
+            t.attestation_ids
+        FROM base_triplets t
+        JOIN base_entities h  ON h.foodatlas_id = t.head_id
+        JOIN base_entities tl ON tl.foodatlas_id = t.tail_id
+        JOIN relationships r  ON r.foodatlas_id = t.relationship_id
+        {where_sql}
+        ORDER BY t.triplet_id
+        OFFSET :offset ROWS FETCH FIRST :limit ROWS ONLY
+    """
+    rows_result = await session.execute(text(sql), params)
+    rows = [dict(r._mapping) for r in rows_result]
+
+    if rows:
+        att_summaries = await _attestation_summaries(
+            session,
+            {aid for row in rows for aid in (row.get("attestation_ids") or [])},
+        )
+        for row in rows:
+            row["attestations"] = [
+                att_summaries[aid]
+                for aid in (row.pop("attestation_ids", []) or [])
+                if aid in att_summaries
+            ]
+    else:
+        for row in rows:
+            row["attestations"] = []
+    return rows, total
+
+
+async def get_triplet(session: AsyncSession, triplet_id: int) -> dict | None:
+    """Return a single triplet with attestation summaries."""
+    sql = """
+        SELECT
+            t.triplet_id,
+            t.head_id,
+            h.common_name AS head_name,
+            t.relationship_id,
+            r.name AS relationship_name,
+            t.tail_id,
+            tl.common_name AS tail_name,
+            t.source,
+            t.attestation_ids
+        FROM base_triplets t
+        JOIN base_entities h  ON h.foodatlas_id = t.head_id
+        JOIN base_entities tl ON tl.foodatlas_id = t.tail_id
+        JOIN relationships r  ON r.foodatlas_id = t.relationship_id
+        WHERE t.triplet_id = :tid
+    """
+    result = await session.execute(text(sql), {"tid": triplet_id})
+    row = result.first()
+    if row is None:
+        return None
+    row_dict = dict(row._mapping)
+    aids = row_dict.pop("attestation_ids", None) or []
+    summaries = await _attestation_summaries(session, set(aids))
+    row_dict["attestations"] = [summaries[a] for a in aids if a in summaries]
+    return row_dict
+
+
+async def get_attestation(session: AsyncSession, attestation_id: str) -> dict | None:
+    """Return one attestation as a flat dict.
+
+    Joins to ``base_triplets`` to surface (head_id, tail_id, relationship_id)
+    since the attestation table itself only has raw names. An attestation
+    can back many triplets via ``attestation_ids``; the first matching
+    triplet is returned for the head/tail/rel fields. Trust score is the
+    latest valid ``llm_plausibility`` row.
+    """
+    att_sql = """
+        SELECT
+            a.attestation_id,
+            a.source,
+            a.evidence_id,
+            a.head_name_raw,
+            a.tail_name_raw,
+            a.conc_value,
+            a.conc_unit,
+            a.food_part,
+            a.food_processing,
+            a.validated,
+            a.validated_correct
+        FROM base_attestations a
+        WHERE a.attestation_id = :aid
+    """
+    result = await session.execute(text(att_sql), {"aid": attestation_id})
+    row = result.first()
+    if row is None:
+        return None
+    out = dict(row._mapping)
+
+    trip_sql = """
+        SELECT head_id, tail_id, relationship_id
+        FROM base_triplets
+        WHERE :aid = ANY(attestation_ids)
+        LIMIT 1
+    """
+    trip = (await session.execute(text(trip_sql), {"aid": attestation_id})).first()
+    out["head_id"] = trip[0] if trip else ""
+    out["tail_id"] = trip[1] if trip else ""
+    out["relationship_id"] = trip[2] if trip else ""
+
+    summaries = await _attestation_summaries(session, {attestation_id})
+    summary = summaries.get(attestation_id)
+    out["trust_score"] = summary["trust_score"] if summary else None
+    out["trust_reason"] = await _trust_reason(session, attestation_id) or ""
+    return out
+
+
+async def _attestation_summaries(
+    session: AsyncSession, attestation_ids: set[str]
+) -> dict[str, dict]:
+    """Fetch summary rows + latest trust scores for a set of attestation ids."""
+    if not attestation_ids:
+        return {}
+    rows_result = await session.execute(
+        text(
+            "SELECT attestation_id, source, evidence_id "
+            "FROM base_attestations WHERE attestation_id = ANY(:ids)"
+        ),
+        {"ids": list(attestation_ids)},
+    )
+    base = {
+        r.attestation_id: {
+            "attestation_id": r.attestation_id,
+            "source": r.source,
+            "evidence_id": r.evidence_id,
+            "trust_score": None,
+        }
+        for r in rows_result
+    }
+    scores = await _latest_trust_scores(session, list(attestation_ids))
+    for aid, score in scores.items():
+        if aid in base:
+            base[aid]["trust_score"] = score
+    return base
+
+
+async def _latest_trust_scores(
+    session: AsyncSession, attestation_ids: list[str]
+) -> dict[str, float]:
+    if not attestation_ids:
+        return {}
+    result = await session.execute(
+        text("""
+            WITH ranked AS (
+                SELECT attestation_id, score,
+                       ROW_NUMBER() OVER (
+                           PARTITION BY attestation_id
+                           ORDER BY created_at DESC
+                       ) AS rn
+                FROM base_trust_signals
+                WHERE attestation_id = ANY(:ids)
+                  AND signal_kind = 'llm_plausibility'
+                  AND score >= 0
+            )
+            SELECT attestation_id, score FROM ranked WHERE rn = 1
+        """),
+        {"ids": attestation_ids},
+    )
+    return {row.attestation_id: float(row.score) for row in result}
+
+
+async def _trust_reason(session: AsyncSession, attestation_id: str) -> str | None:
+    result = await session.execute(
+        text("""
+            SELECT reason FROM base_trust_signals
+            WHERE attestation_id = :aid
+              AND signal_kind = 'llm_plausibility'
+              AND score >= 0
+            ORDER BY created_at DESC
+            LIMIT 1
+        """),
+        {"aid": attestation_id},
+    )
+    row = result.first()
+    return row[0] if row else None

--- a/backend/api/src/routes/v1/__init__.py
+++ b/backend/api/src/routes/v1/__init__.py
@@ -1,0 +1,30 @@
+"""Aggregate router for the public /v1/ API."""
+
+from fastapi import APIRouter, Depends
+
+from src.dependencies import verify_v1_key
+
+from . import (
+    attestations,
+    bundles,
+    chemicals,
+    diseases,
+    foods,
+    search,
+    stats,
+    triplets,
+)
+
+router = APIRouter(
+    prefix="/v1",
+    dependencies=[Depends(verify_v1_key)],
+    tags=["public-v1"],
+)
+router.include_router(foods.router)
+router.include_router(chemicals.router)
+router.include_router(diseases.router)
+router.include_router(triplets.router)
+router.include_router(attestations.router)
+router.include_router(search.router)
+router.include_router(stats.router)
+router.include_router(bundles.router)

--- a/backend/api/src/routes/v1/attestations.py
+++ b/backend/api/src/routes/v1/attestations.py
@@ -1,0 +1,25 @@
+"""Public attestation endpoints (/v1/attestations)."""
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.dependencies import get_db
+from src.repositories.v1 import triplets as triplets_repo
+from src.repositories.v1.serializers import Attestation, ItemResponse
+
+router = APIRouter(prefix="/attestations")
+
+
+@router.get(
+    "/{attestation_id}",
+    response_model=ItemResponse[Attestation],
+    summary="Get one attestation (raw evidence row backing a triplet)",
+    responses={404: {"description": "Attestation not found"}},
+)
+async def get_attestation(
+    attestation_id: str, db: AsyncSession = Depends(get_db)
+) -> ItemResponse[Attestation]:
+    row = await triplets_repo.get_attestation(db, attestation_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Attestation not found")
+    return ItemResponse[Attestation](data=Attestation(**row))

--- a/backend/api/src/routes/v1/bundles.py
+++ b/backend/api/src/routes/v1/bundles.py
@@ -1,0 +1,34 @@
+"""Public bundle-downloads endpoint (/v1/bundles)."""
+
+from fastapi import APIRouter, Depends
+
+from src.config import APISettings
+from src.dependencies import get_settings
+from src.repositories import downloads
+from src.repositories.v1.serializers import Bundle, ListResponse, Page
+
+router = APIRouter(prefix="/bundles")
+
+
+@router.get(
+    "",
+    response_model=ListResponse[Bundle],
+    summary="List released bulk-download bundles",
+)
+async def list_bundles(
+    settings: APISettings = Depends(get_settings),
+) -> ListResponse[Bundle]:
+    entries: list[dict] = []
+    if settings.downloads_bucket:
+        entries = await downloads.fetch_manifest(
+            settings.downloads_bucket, settings.downloads_region
+        )
+    return ListResponse[Bundle](
+        data=[Bundle(**e) for e in entries],
+        page=Page(
+            page=1,
+            page_size=max(len(entries), 1),
+            total=len(entries),
+            has_more=False,
+        ),
+    )

--- a/backend/api/src/routes/v1/chemicals.py
+++ b/backend/api/src/routes/v1/chemicals.py
@@ -1,0 +1,126 @@
+"""Public chemical endpoints (/v1/chemicals)."""
+
+from typing import cast
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.dependencies import get_db
+from src.repositories import taxonomy as taxonomy_repo
+from src.repositories.v1 import entities, relationships
+from src.repositories.v1.pagination import build_page, clamp_page_size
+from src.repositories.v1.serializers import (
+    Chemical,
+    ChemicalSummary,
+    CompositionRow,
+    CorrelationRow,
+    ItemResponse,
+    ListResponse,
+    Taxonomy,
+)
+
+router = APIRouter(prefix="/chemicals")
+
+
+@router.get(
+    "",
+    response_model=ListResponse[ChemicalSummary],
+    summary="List chemicals",
+)
+async def list_chemicals(
+    q: str = Query(""),
+    classification: str = Query(""),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> ListResponse[ChemicalSummary]:
+    size = clamp_page_size(page_size)
+    rows, total = await entities.list_entities(
+        db, "chemical", q=q, classification=classification, page=page, page_size=size
+    )
+    return ListResponse[ChemicalSummary](
+        data=[ChemicalSummary(**r) for r in rows],
+        page=build_page(page, size, total),
+    )
+
+
+@router.get(
+    "/{chemical_id}",
+    response_model=ItemResponse[Chemical],
+    responses={404: {"description": "Chemical not found"}},
+)
+async def get_chemical(
+    chemical_id: str, db: AsyncSession = Depends(get_db)
+) -> ItemResponse[Chemical]:
+    row = await entities.get_entity(db, "chemical", entity_id=chemical_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Chemical not found")
+    return ItemResponse[Chemical](data=Chemical(**row))
+
+
+@router.get(
+    "/{chemical_id}/foods",
+    response_model=ListResponse[CompositionRow],
+    summary="Foods containing this chemical",
+)
+async def chemical_foods(
+    chemical_id: str,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> ListResponse[CompositionRow]:
+    size = clamp_page_size(page_size)
+    rows, total = await relationships.list_composition(
+        db, chemical_id=chemical_id, page=page, page_size=size
+    )
+    return ListResponse[CompositionRow](
+        data=[CompositionRow(**r) for r in rows],
+        page=build_page(page, size, total),
+    )
+
+
+@router.get(
+    "/{chemical_id}/diseases",
+    response_model=ListResponse[CorrelationRow],
+    summary="Diseases this chemical reduces or worsens",
+)
+async def chemical_diseases(
+    chemical_id: str,
+    relation: str = Query(
+        "reduces",
+        description="'reduces' (r4) or 'worsens' (r3)",
+    ),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> ListResponse[CorrelationRow]:
+    if relation not in {"reduces", "worsens"}:
+        raise HTTPException(
+            status_code=422, detail="relation must be reduces or worsens"
+        )
+    size = clamp_page_size(page_size)
+    rows, total = await relationships.list_correlation(
+        db,
+        chemical_id=chemical_id,
+        relation=relation,
+        page=page,
+        page_size=size,
+    )
+    return ListResponse[CorrelationRow](
+        data=[CorrelationRow(**r) for r in rows],
+        page=build_page(page, size, total),
+    )
+
+
+@router.get(
+    "/{chemical_id}/taxonomy",
+    response_model=ItemResponse[Taxonomy],
+)
+async def chemical_taxonomy(
+    chemical_id: str, db: AsyncSession = Depends(get_db)
+) -> ItemResponse[Taxonomy]:
+    entity = await entities.get_entity(db, "chemical", entity_id=chemical_id)
+    if entity is None:
+        raise HTTPException(status_code=404, detail="Chemical not found")
+    payload = await taxonomy_repo.get_taxonomy(db, entity["common_name"], "chemical")
+    return ItemResponse[Taxonomy](data=Taxonomy(**cast("dict", payload["data"])))

--- a/backend/api/src/routes/v1/diseases.py
+++ b/backend/api/src/routes/v1/diseases.py
@@ -1,0 +1,92 @@
+"""Public disease endpoints (/v1/diseases)."""
+
+from typing import cast
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.dependencies import get_db
+from src.repositories import taxonomy as taxonomy_repo
+from src.repositories.v1 import entities, relationships
+from src.repositories.v1.pagination import build_page, clamp_page_size
+from src.repositories.v1.serializers import (
+    CorrelationRow,
+    Disease,
+    DiseaseSummary,
+    ItemResponse,
+    ListResponse,
+    Taxonomy,
+)
+
+router = APIRouter(prefix="/diseases")
+
+
+@router.get("", response_model=ListResponse[DiseaseSummary])
+async def list_diseases(
+    q: str = Query(""),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> ListResponse[DiseaseSummary]:
+    size = clamp_page_size(page_size)
+    rows, total = await entities.list_entities(
+        db, "disease", q=q, page=page, page_size=size
+    )
+    return ListResponse[DiseaseSummary](
+        data=[DiseaseSummary(**r) for r in rows],
+        page=build_page(page, size, total),
+    )
+
+
+@router.get(
+    "/{disease_id}",
+    response_model=ItemResponse[Disease],
+    responses={404: {"description": "Disease not found"}},
+)
+async def get_disease(
+    disease_id: str, db: AsyncSession = Depends(get_db)
+) -> ItemResponse[Disease]:
+    row = await entities.get_entity(db, "disease", entity_id=disease_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Disease not found")
+    return ItemResponse[Disease](data=Disease(**row))
+
+
+@router.get(
+    "/{disease_id}/chemicals",
+    response_model=ListResponse[CorrelationRow],
+    summary="Chemicals that reduce or worsen this disease",
+)
+async def disease_chemicals(
+    disease_id: str,
+    relation: str = Query("reduces"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> ListResponse[CorrelationRow]:
+    if relation not in {"reduces", "worsens"}:
+        raise HTTPException(
+            status_code=422, detail="relation must be reduces or worsens"
+        )
+    size = clamp_page_size(page_size)
+    rows, total = await relationships.list_correlation(
+        db, disease_id=disease_id, relation=relation, page=page, page_size=size
+    )
+    return ListResponse[CorrelationRow](
+        data=[CorrelationRow(**r) for r in rows],
+        page=build_page(page, size, total),
+    )
+
+
+@router.get(
+    "/{disease_id}/taxonomy",
+    response_model=ItemResponse[Taxonomy],
+)
+async def disease_taxonomy(
+    disease_id: str, db: AsyncSession = Depends(get_db)
+) -> ItemResponse[Taxonomy]:
+    entity = await entities.get_entity(db, "disease", entity_id=disease_id)
+    if entity is None:
+        raise HTTPException(status_code=404, detail="Disease not found")
+    payload = await taxonomy_repo.get_taxonomy(db, entity["common_name"], "disease")
+    return ItemResponse[Taxonomy](data=Taxonomy(**cast("dict", payload["data"])))

--- a/backend/api/src/routes/v1/foods.py
+++ b/backend/api/src/routes/v1/foods.py
@@ -1,0 +1,94 @@
+"""Public food endpoints (/v1/foods)."""
+
+from typing import cast
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.dependencies import get_db
+from src.repositories import taxonomy as taxonomy_repo
+from src.repositories.v1 import entities, relationships
+from src.repositories.v1.pagination import build_page, clamp_page_size
+from src.repositories.v1.serializers import (
+    CompositionRow,
+    Food,
+    FoodSummary,
+    ItemResponse,
+    ListResponse,
+    Taxonomy,
+)
+
+router = APIRouter(prefix="/foods")
+
+
+@router.get("", response_model=ListResponse[FoodSummary], summary="List foods")
+async def list_foods(
+    q: str = Query("", description="Case-insensitive substring filter on common_name"),
+    classification: str = Query(
+        "", description="Exact match against food_classification (e.g. 'fruit')"
+    ),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> ListResponse[FoodSummary]:
+    """Paginated list of food entities."""
+    size = clamp_page_size(page_size)
+    rows, total = await entities.list_entities(
+        db, "food", q=q, classification=classification, page=page, page_size=size
+    )
+    return ListResponse[FoodSummary](
+        data=[FoodSummary(**r) for r in rows],
+        page=build_page(page, size, total),
+    )
+
+
+@router.get(
+    "/{food_id}",
+    response_model=ItemResponse[Food],
+    summary="Get one food by FoodAtlas id",
+    responses={404: {"description": "Food not found"}},
+)
+async def get_food(
+    food_id: str, db: AsyncSession = Depends(get_db)
+) -> ItemResponse[Food]:
+    row = await entities.get_entity(db, "food", entity_id=food_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Food not found")
+    return ItemResponse[Food](data=Food(**row))
+
+
+@router.get(
+    "/{food_id}/chemicals",
+    response_model=ListResponse[CompositionRow],
+    summary="Chemicals contained in a food",
+)
+async def food_chemicals(
+    food_id: str,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> ListResponse[CompositionRow]:
+    """Flat composition rows: one chemical per row, evidence aggregated."""
+    size = clamp_page_size(page_size)
+    rows, total = await relationships.list_composition(
+        db, food_id=food_id, page=page, page_size=size
+    )
+    return ListResponse[CompositionRow](
+        data=[CompositionRow(**r) for r in rows],
+        page=build_page(page, size, total),
+    )
+
+
+@router.get(
+    "/{food_id}/taxonomy",
+    response_model=ItemResponse[Taxonomy],
+    summary="IS_A taxonomy ancestry for a food",
+)
+async def food_taxonomy(
+    food_id: str, db: AsyncSession = Depends(get_db)
+) -> ItemResponse[Taxonomy]:
+    entity = await entities.get_entity(db, "food", entity_id=food_id)
+    if entity is None:
+        raise HTTPException(status_code=404, detail="Food not found")
+    payload = await taxonomy_repo.get_taxonomy(db, entity["common_name"], "food")
+    return ItemResponse[Taxonomy](data=Taxonomy(**cast("dict", payload["data"])))

--- a/backend/api/src/routes/v1/search.py
+++ b/backend/api/src/routes/v1/search.py
@@ -1,0 +1,40 @@
+"""Public search endpoint (/v1/search)."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.dependencies import get_db
+from src.repositories.v1 import search as search_repo
+from src.repositories.v1.pagination import build_page, clamp_page_size
+from src.repositories.v1.serializers import ListResponse, SearchHit
+
+router = APIRouter(prefix="/search")
+
+_VALID_TYPES = {"", "food", "chemical", "disease"}
+
+
+@router.get(
+    "",
+    response_model=ListResponse[SearchHit],
+    summary="Trigram autocomplete across entity names",
+)
+async def search(
+    q: str = Query(..., min_length=1, description="Search term"),
+    entity_type: str = Query("", description="Filter to food|chemical|disease"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> ListResponse[SearchHit]:
+    if entity_type not in _VALID_TYPES:
+        raise HTTPException(
+            status_code=422,
+            detail="entity_type must be one of food, chemical, disease",
+        )
+    size = clamp_page_size(page_size)
+    rows, total = await search_repo.search(
+        db, q=q, entity_type=entity_type, page=page, page_size=size
+    )
+    return ListResponse[SearchHit](
+        data=[SearchHit(**r) for r in rows],
+        page=build_page(page, size, total),
+    )

--- a/backend/api/src/routes/v1/stats.py
+++ b/backend/api/src/routes/v1/stats.py
@@ -1,0 +1,20 @@
+"""Public stats endpoint (/v1/stats)."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.dependencies import get_db
+from src.repositories.v1 import search as search_repo
+from src.repositories.v1.serializers import ItemResponse, Stats
+
+router = APIRouter(prefix="/stats")
+
+
+@router.get(
+    "",
+    response_model=ItemResponse[Stats],
+    summary="Aggregate counts (foods, chemicals, diseases, publications, connections)",
+)
+async def get_stats(db: AsyncSession = Depends(get_db)) -> ItemResponse[Stats]:
+    row = await search_repo.get_stats(db)
+    return ItemResponse[Stats](data=Stats(**row))

--- a/backend/api/src/routes/v1/triplets.py
+++ b/backend/api/src/routes/v1/triplets.py
@@ -1,0 +1,60 @@
+"""Public triplet (graph edge) endpoints (/v1/triplets)."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.dependencies import get_db
+from src.repositories.v1 import triplets as triplets_repo
+from src.repositories.v1.pagination import build_page, clamp_page_size
+from src.repositories.v1.serializers import ItemResponse, ListResponse, Triplet
+
+router = APIRouter(prefix="/triplets")
+
+
+@router.get(
+    "",
+    response_model=ListResponse[Triplet],
+    summary="List knowledge-graph triplets",
+)
+async def list_triplets(
+    head_id: str = Query("", description="Filter by head entity id"),
+    tail_id: str = Query("", description="Filter by tail entity id"),
+    relationship: str = Query(
+        "",
+        description=(
+            "One of contains|is_a|worsens|reduces, or the raw relationship_id (r1..r5)"
+        ),
+    ),
+    source: str = Query("", description="Filter by source string"),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> ListResponse[Triplet]:
+    size = clamp_page_size(page_size)
+    rows, total = await triplets_repo.list_triplets(
+        db,
+        head_id=head_id,
+        tail_id=tail_id,
+        relationship=relationship,
+        source=source,
+        page=page,
+        page_size=size,
+    )
+    return ListResponse[Triplet](
+        data=[Triplet(**r) for r in rows],
+        page=build_page(page, size, total),
+    )
+
+
+@router.get(
+    "/{triplet_id}",
+    response_model=ItemResponse[Triplet],
+    responses={404: {"description": "Triplet not found"}},
+)
+async def get_triplet(
+    triplet_id: int, db: AsyncSession = Depends(get_db)
+) -> ItemResponse[Triplet]:
+    row = await triplets_repo.get_triplet(db, triplet_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Triplet not found")
+    return ItemResponse[Triplet](data=Triplet(**row))

--- a/backend/api/tests/conftest.py
+++ b/backend/api/tests/conftest.py
@@ -7,7 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 from src.app import create_app
 from src.config import APISettings
-from src.dependencies import get_db, get_settings, verify_api_key
+from src.dependencies import get_db, get_settings, verify_api_key, verify_v1_key
 
 
 def _make_debug_settings() -> APISettings:
@@ -33,6 +33,7 @@ def _build_client(settings: APISettings, mock_db: AsyncMock) -> TestClient:
 
     app.dependency_overrides[get_db] = _override_db
     app.dependency_overrides[verify_api_key] = _override_verify
+    app.dependency_overrides[verify_v1_key] = _override_verify
     app.dependency_overrides[get_settings] = lambda: settings
 
     return TestClient(app, raise_server_exceptions=False)

--- a/backend/api/tests/test_dependencies_v1.py
+++ b/backend/api/tests/test_dependencies_v1.py
@@ -1,0 +1,93 @@
+"""Tests for verify_v1_key auth dependency."""
+
+from __future__ import annotations
+
+import hashlib
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+from src.config import APISettings
+from src.dependencies import verify_v1_key
+from src.public_keys import KeyRecord, PublicKeyStore, set_store_for_tests
+
+
+def _hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def _settings(debug: bool = False, internal_key: str = "internal-key") -> APISettings:
+    s = APISettings(_env_file=None)  # type: ignore[call-arg]
+    s.debug = debug
+    s.key = internal_key
+    return s
+
+
+class TestVerifyV1Key:
+    @pytest.mark.asyncio
+    async def test_debug_bypasses_auth(self) -> None:
+        request = MagicMock()
+        request.headers.get.return_value = ""
+        await verify_v1_key(request, _settings(debug=True))
+
+    @pytest.mark.asyncio
+    async def test_internal_key_accepted(self) -> None:
+        request = MagicMock()
+        request.headers.get.return_value = "Bearer internal-key"
+        request.state = MagicMock()
+        await verify_v1_key(request, _settings())
+        assert request.state.api_key_email == "internal"
+
+    @pytest.mark.asyncio
+    async def test_public_key_accepted(self) -> None:
+        store = PublicKeyStore(secret_name="s", region="us-west-1")
+        store._keys = {_hash("pub-key"): KeyRecord(email="alice@u.edu")}
+        prev = None
+        set_store_for_tests(store)
+        try:
+            request = MagicMock()
+            request.headers.get.return_value = "Bearer pub-key"
+            request.state = MagicMock()
+            await verify_v1_key(request, _settings())
+            assert request.state.api_key_email == "alice@u.edu"
+        finally:
+            set_store_for_tests(prev)
+
+    @pytest.mark.asyncio
+    async def test_missing_header_rejected(self) -> None:
+        request = MagicMock()
+        request.headers.get.return_value = ""
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_v1_key(request, _settings())
+        assert exc_info.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_non_bearer_rejected(self) -> None:
+        request = MagicMock()
+        request.headers.get.return_value = "Basic abc"
+        with pytest.raises(HTTPException):
+            await verify_v1_key(request, _settings())
+
+    @pytest.mark.asyncio
+    async def test_unknown_token_rejected(self) -> None:
+        prev = None
+        set_store_for_tests(PublicKeyStore(secret_name="s", region="us-west-1"))
+        try:
+            request = MagicMock()
+            request.headers.get.return_value = "Bearer not-known"
+            with pytest.raises(HTTPException):
+                await verify_v1_key(request, _settings())
+        finally:
+            set_store_for_tests(prev)
+
+    @pytest.mark.asyncio
+    async def test_no_store_rejects_non_internal(self) -> None:
+        prev = None
+        set_store_for_tests(None)
+        try:
+            request = MagicMock()
+            request.headers.get.return_value = "Bearer some-key"
+            with pytest.raises(HTTPException):
+                await verify_v1_key(request, _settings())
+        finally:
+            set_store_for_tests(prev)

--- a/backend/api/tests/test_public_keys.py
+++ b/backend/api/tests/test_public_keys.py
@@ -1,0 +1,202 @@
+"""Tests for the PublicKeyStore (AWS Secrets Manager-backed)."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from src.config import APISettings
+from src.public_keys import (
+    KeyRecord,
+    PublicKeyStore,
+    _parse_secret_payload,
+    get_store,
+    init_store,
+    set_store_for_tests,
+)
+
+
+def _hash(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+class TestParseSecretPayload:
+    def test_returns_records_keyed_by_hash(self) -> None:
+        payload = json.dumps(
+            {
+                _hash("k1"): {"email": "a@x", "created": "2026-05-13", "notes": "n"},
+            }
+        )
+        result = _parse_secret_payload(payload)
+        assert result[_hash("k1")] == KeyRecord(
+            email="a@x", created="2026-05-13", notes="n"
+        )
+
+    def test_empty_string_returns_empty(self) -> None:
+        assert _parse_secret_payload("") == {}
+
+    def test_skips_non_hash_keys(self) -> None:
+        payload = json.dumps({"not-a-hash": {"email": "x"}})
+        assert _parse_secret_payload(payload) == {}
+
+    def test_skips_non_dict_meta(self) -> None:
+        payload = json.dumps({_hash("k"): "scalar"})
+        assert _parse_secret_payload(payload) == {}
+
+    def test_invalid_json_raises(self) -> None:
+        with pytest.raises(ValueError, match="not valid JSON"):
+            _parse_secret_payload("{not json")
+
+    def test_non_object_raises(self) -> None:
+        with pytest.raises(ValueError, match="JSON object"):
+            _parse_secret_payload("[]")
+
+
+class TestPublicKeyStoreVerify:
+    def test_returns_record_for_known_hash(self) -> None:
+        store = PublicKeyStore(secret_name="s", region="us-west-1")
+        store._keys = {_hash("plain"): KeyRecord(email="a@x")}
+        record = store.verify("plain")
+        assert record is not None
+        assert record.email == "a@x"
+
+    def test_returns_none_for_unknown(self) -> None:
+        store = PublicKeyStore(secret_name="s", region="us-west-1")
+        assert store.verify("anything") is None
+
+    def test_returns_none_for_empty(self) -> None:
+        store = PublicKeyStore(secret_name="s", region="us-west-1")
+        store._keys = {_hash("x"): KeyRecord(email="a")}
+        assert store.verify("") is None
+
+
+class TestPublicKeyStoreLoad:
+    @pytest.mark.asyncio
+    async def test_load_populates_keys(self) -> None:
+        payload = {_hash("k1"): {"email": "a@x"}}
+        client = MagicMock()
+        client.get_secret_value.return_value = {"SecretString": json.dumps(payload)}
+        store = PublicKeyStore(
+            secret_name="s",
+            region="us-west-1",
+            _client_factory=lambda: client,
+        )
+        await store.load()
+        assert store.verify("k1") is not None
+
+    @pytest.mark.asyncio
+    async def test_load_replaces_previous(self) -> None:
+        client = MagicMock()
+        client.get_secret_value.return_value = {
+            "SecretString": json.dumps({_hash("new"): {"email": "n@x"}})
+        }
+        store = PublicKeyStore(
+            secret_name="s",
+            region="us-west-1",
+            _client_factory=lambda: client,
+        )
+        store._keys = {_hash("old"): KeyRecord(email="o@x")}
+        await store.load()
+        assert store.verify("old") is None
+        assert store.verify("new") is not None
+
+    @pytest.mark.asyncio
+    async def test_load_handles_missing_secret_string(self) -> None:
+        client = MagicMock()
+        client.get_secret_value.return_value = {}
+        store = PublicKeyStore(
+            secret_name="s",
+            region="us-west-1",
+            _client_factory=lambda: client,
+        )
+        await store.load()
+        assert store._keys == {}
+
+
+class TestPublicKeyStoreLifecycle:
+    @pytest.mark.asyncio
+    async def test_start_does_nothing_when_no_secret_name(self) -> None:
+        store = PublicKeyStore(secret_name="", region="us-west-1")
+        await store.start()
+        assert store._task is None
+
+    @pytest.mark.asyncio
+    async def test_start_loads_and_launches_refresh_task(self) -> None:
+        client = MagicMock()
+        client.get_secret_value.return_value = {"SecretString": "{}"}
+        store = PublicKeyStore(
+            secret_name="s",
+            region="us-west-1",
+            refresh_seconds=3600,
+            _client_factory=lambda: client,
+        )
+        await store.start()
+        try:
+            assert store._task is not None
+            assert not store._task.done()
+        finally:
+            await store.stop()
+
+    @pytest.mark.asyncio
+    async def test_stop_cancels_task(self) -> None:
+        client = MagicMock()
+        client.get_secret_value.return_value = {"SecretString": "{}"}
+        store = PublicKeyStore(
+            secret_name="s",
+            region="us-west-1",
+            refresh_seconds=3600,
+            _client_factory=lambda: client,
+        )
+        await store.start()
+        await store.stop()
+        assert store._task is None
+
+    @pytest.mark.asyncio
+    async def test_refresh_loop_swallows_failure(self) -> None:
+        """A refresh failure must keep the old map and not crash the loop."""
+        calls = {"n": 0}
+
+        def factory() -> MagicMock:
+            client = MagicMock()
+            if calls["n"] == 0:
+                client.get_secret_value.return_value = {
+                    "SecretString": json.dumps({_hash("k"): {"email": "a@x"}})
+                }
+            else:
+                client.get_secret_value.side_effect = RuntimeError("boom")
+            calls["n"] += 1
+            return client
+
+        store = PublicKeyStore(
+            secret_name="s",
+            region="us-west-1",
+            refresh_seconds=0,  # 0 → loop fires immediately
+            _client_factory=factory,
+        )
+        await store.start()
+        # Yield several times so the refresh tick has a chance to run + fail.
+        for _ in range(5):
+            await asyncio.sleep(0)
+        await store.stop()
+        # Original map preserved despite the refresh failure.
+        assert store.verify("k") is not None
+
+
+class TestInitStore:
+    def test_creates_store_from_settings(self) -> None:
+        prev = get_store()
+        try:
+            settings = APISettings(_env_file=None)  # type: ignore[call-arg]
+            settings.public_keys_secret_name = "test/secret"
+            settings.aws_region = "us-east-1"
+            settings.public_keys_refresh_seconds = 60
+            store = init_store(settings)
+            assert store.secret_name == "test/secret"
+            assert store.region == "us-east-1"
+            assert store.refresh_seconds == 60
+            assert get_store() is store
+        finally:
+            set_store_for_tests(prev)

--- a/backend/api/tests/test_repo_v1.py
+++ b/backend/api/tests/test_repo_v1.py
@@ -1,0 +1,451 @@
+"""Tests for /v1/ repositories (entities, relationships, triplets, search)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from src.repositories.v1 import entities, relationships, search, triplets
+from src.repositories.v1.pagination import (
+    DEFAULT_PAGE_SIZE,
+    build_page,
+    clamp_page_size,
+    offset,
+)
+
+
+def _row(**kwargs: object) -> MagicMock:
+    r = MagicMock()
+    r._mapping = kwargs
+    for key, val in kwargs.items():
+        setattr(r, key, val)
+    return r
+
+
+def _iter_result(rows: list[MagicMock]) -> MagicMock:
+    result = MagicMock()
+    result.__iter__ = lambda self: iter(rows)
+    return result
+
+
+def _first_result(row: MagicMock | None) -> MagicMock:
+    result = MagicMock()
+    result.first.return_value = row
+    return result
+
+
+def _scalar_result(value: int) -> MagicMock:
+    result = MagicMock()
+    result.scalar.return_value = value
+    return result
+
+
+# -- Pagination -------------------------------------------------------------
+
+
+class TestPagination:
+    def test_clamp_below_one_returns_default(self) -> None:
+        assert clamp_page_size(0) == DEFAULT_PAGE_SIZE
+        assert clamp_page_size(-1) == DEFAULT_PAGE_SIZE
+
+    def test_clamp_above_max_returns_max(self) -> None:
+        assert clamp_page_size(1000) == 100
+
+    def test_clamp_within_range(self) -> None:
+        assert clamp_page_size(25) == 25
+
+    def test_offset_for_first_page_is_zero(self) -> None:
+        assert offset(1, 50) == 0
+
+    def test_offset_for_third_page(self) -> None:
+        assert offset(3, 50) == 100
+
+    def test_build_page_has_more_true(self) -> None:
+        page = build_page(1, 10, 100)
+        assert page.has_more
+
+    def test_build_page_has_more_false(self) -> None:
+        page = build_page(10, 10, 100)
+        assert not page.has_more
+
+
+# -- Entities ---------------------------------------------------------------
+
+
+class TestListEntities:
+    @pytest.mark.asyncio
+    async def test_list_foods_returns_rows_and_total(self) -> None:
+        row = _row(
+            id="FA:0001",
+            common_name="apple",
+            scientific_name="Malus",
+            synonyms=[],
+            external_ids={},
+            food_classification=["fruit"],
+        )
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(1), _iter_result([row])]
+        rows, total = await entities.list_entities(session, "food")
+        assert total == 1
+        assert rows[0]["common_name"] == "apple"
+
+    @pytest.mark.asyncio
+    async def test_q_filter_substring(self) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(0), _iter_result([])]
+        _rows, total = await entities.list_entities(session, "chemical", q="glu")
+        assert total == 0
+        params = session.execute.call_args_list[0][0][1]
+        assert params["q"] == "%glu%"
+
+    @pytest.mark.asyncio
+    async def test_classification_filter_passed_for_food(self) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(0), _iter_result([])]
+        await entities.list_entities(session, "food", classification="fruit")
+        params = session.execute.call_args_list[0][0][1]
+        assert params["cls"] == "fruit"
+
+    @pytest.mark.asyncio
+    async def test_classification_ignored_for_disease(self) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(0), _iter_result([])]
+        await entities.list_entities(session, "disease", classification="anything")
+        params = session.execute.call_args_list[0][0][1]
+        assert "cls" not in params
+
+
+class TestGetEntity:
+    @pytest.mark.asyncio
+    async def test_lookup_by_id(self) -> None:
+        row = _row(
+            id="FA:0001",
+            common_name="apple",
+            scientific_name="",
+            synonyms=[],
+            external_ids={},
+            food_classification=[],
+        )
+        session = AsyncMock()
+        session.execute.return_value = _first_result(row)
+        result = await entities.get_entity(session, "food", entity_id="FA:0001")
+        assert result is not None
+        assert result["common_name"] == "apple"
+
+    @pytest.mark.asyncio
+    async def test_lookup_by_common_name(self) -> None:
+        row = _row(
+            id="FA:C001",
+            common_name="glucose",
+            scientific_name="",
+            synonyms=[],
+            external_ids={},
+            chemical_classification=[],
+            flavor_descriptors=[],
+        )
+        session = AsyncMock()
+        session.execute.return_value = _first_result(row)
+        result = await entities.get_entity(session, "chemical", common_name="glucose")
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_missing(self) -> None:
+        session = AsyncMock()
+        session.execute.return_value = _first_result(None)
+        result = await entities.get_entity(session, "food", entity_id="FA:NOPE")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_no_lookup_args_returns_none(self) -> None:
+        session = AsyncMock()
+        result = await entities.get_entity(session, "food")
+        assert result is None
+        session.execute.assert_not_called()
+
+
+class TestResolveId:
+    @pytest.mark.asyncio
+    async def test_returns_tuple_when_found(self) -> None:
+        row = MagicMock()
+        row.__getitem__ = lambda self, i: ("food", "apple")[i]
+        session = AsyncMock()
+        session.execute.return_value = _first_result(row)
+        result = await entities.resolve_id(session, "FA:0001")
+        assert result == ("food", "apple")
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_missing(self) -> None:
+        session = AsyncMock()
+        session.execute.return_value = _first_result(None)
+        assert await entities.resolve_id(session, "FA:NOPE") is None
+
+
+# -- Relationships ----------------------------------------------------------
+
+
+class TestListComposition:
+    @pytest.mark.asyncio
+    async def test_filter_by_food_id(self) -> None:
+        row = _row(
+            food_id="FA:0001",
+            food_name="apple",
+            chemical_id="FA:C001",
+            chemical_name="glucose",
+            chemical_classification=["carbohydrate"],
+            median_concentration={"value": 5.0, "unit": "mg/100g"},
+            attestation_count=3,
+            sources=["fdc"],
+        )
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(1), _iter_result([row])]
+        rows, total = await relationships.list_composition(session, food_id="FA:0001")
+        assert total == 1
+        assert rows[0]["chemical_name"] == "glucose"
+
+    @pytest.mark.asyncio
+    async def test_filter_by_chemical_id(self) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(0), _iter_result([])]
+        _rows, total = await relationships.list_composition(
+            session, chemical_id="FA:C001"
+        )
+        assert total == 0
+
+    @pytest.mark.asyncio
+    async def test_no_filter_returns_empty(self) -> None:
+        session = AsyncMock()
+        rows, total = await relationships.list_composition(session)
+        assert rows == [] and total == 0
+        session.execute.assert_not_called()
+
+
+class TestListCorrelation:
+    @pytest.mark.asyncio
+    async def test_filter_by_chemical_with_relation(self) -> None:
+        row = _row(
+            chemical_id="FA:C001",
+            chemical_name="glucose",
+            disease_id="FA:D001",
+            disease_name="diabetes",
+            source_chemical_id="FA:C001",
+            source_chemical_name="glucose",
+            sources=["pubmed"],
+            evidence_count=2,
+        )
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(1), _iter_result([row])]
+        rows, total = await relationships.list_correlation(
+            session, chemical_id="FA:C001", relation="reduces"
+        )
+        assert total == 1
+        assert rows[0]["relation"] == "reduces"
+
+    @pytest.mark.asyncio
+    async def test_unknown_relation_returns_empty(self) -> None:
+        session = AsyncMock()
+        rows, total = await relationships.list_correlation(
+            session, chemical_id="FA:C001", relation="bogus"
+        )
+        assert rows == [] and total == 0
+        session.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_filter_returns_empty(self) -> None:
+        session = AsyncMock()
+        rows, total = await relationships.list_correlation(session)
+        assert rows == [] and total == 0
+
+
+# -- Triplets / Attestations ------------------------------------------------
+
+
+class TestListTriplets:
+    @pytest.mark.asyncio
+    async def test_filters_and_attestation_lookup(self) -> None:
+        triplet_row = _row(
+            triplet_id=1,
+            head_id="FA:0001",
+            head_name="apple",
+            relationship_id="r1",
+            relationship_name="contains",
+            tail_id="FA:C001",
+            tail_name="glucose",
+            source="fdc",
+            attestation_ids=["att1"],
+        )
+        att_row = _row(
+            attestation_id="att1",
+            source="fdc",
+            evidence_id="ev1",
+        )
+        session = AsyncMock()
+        session.execute.side_effect = [
+            _scalar_result(1),  # count
+            _iter_result([triplet_row]),  # list
+            _iter_result([att_row]),  # summary lookup
+            _iter_result([]),  # trust scores
+        ]
+        rows, total = await triplets.list_triplets(
+            session, head_id="FA:0001", relationship="contains"
+        )
+        assert total == 1
+        assert rows[0]["attestations"][0]["attestation_id"] == "att1"
+
+    @pytest.mark.asyncio
+    async def test_invalid_relationship_alias_returns_empty(self) -> None:
+        session = AsyncMock()
+        rows, total = await triplets.list_triplets(session, relationship="bogus")
+        assert rows == [] and total == 0
+        session.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_relationship_raw_id_accepted(self) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(0), _iter_result([])]
+        await triplets.list_triplets(session, relationship="r1")
+        params = session.execute.call_args_list[0][0][1]
+        assert params["rel_id"] == "r1"
+
+
+class TestGetTriplet:
+    @pytest.mark.asyncio
+    async def test_returns_triplet_with_attestations(self) -> None:
+        triplet_row = _row(
+            triplet_id=1,
+            head_id="FA:0001",
+            head_name="apple",
+            relationship_id="r1",
+            relationship_name="contains",
+            tail_id="FA:C001",
+            tail_name="glucose",
+            source="fdc",
+            attestation_ids=["att1"],
+        )
+        att_row = _row(attestation_id="att1", source="fdc", evidence_id="ev1")
+        session = AsyncMock()
+        session.execute.side_effect = [
+            _first_result(triplet_row),
+            _iter_result([att_row]),
+            _iter_result([]),
+        ]
+        result = await triplets.get_triplet(session, 1)
+        assert result is not None
+        assert result["triplet_id"] == 1
+        assert len(result["attestations"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_missing(self) -> None:
+        session = AsyncMock()
+        session.execute.return_value = _first_result(None)
+        assert await triplets.get_triplet(session, 99) is None
+
+
+class TestGetAttestation:
+    @pytest.mark.asyncio
+    async def test_returns_full_row(self) -> None:
+        att_row = _row(
+            attestation_id="att1",
+            source="fdc",
+            evidence_id="ev1",
+            head_name_raw="apple",
+            tail_name_raw="glucose",
+            conc_value=5.0,
+            conc_unit="mg/100g",
+            food_part="fruit",
+            food_processing="raw",
+            validated=False,
+            validated_correct=True,
+        )
+        triplet_join_row = MagicMock()
+        triplet_join_row.__getitem__ = lambda self, i: ("FA:0001", "FA:C001", "r1")[i]
+        summary_row = _row(attestation_id="att1", source="fdc", evidence_id="ev1")
+        session = AsyncMock()
+        session.execute.side_effect = [
+            _first_result(att_row),
+            _first_result(triplet_join_row),
+            _iter_result([summary_row]),
+            _iter_result([]),
+            _first_result(None),  # trust reason
+        ]
+        result = await triplets.get_attestation(session, "att1")
+        assert result is not None
+        assert result["head_id"] == "FA:0001"
+        assert result["tail_id"] == "FA:C001"
+        assert result["trust_score"] is None
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_missing(self) -> None:
+        session = AsyncMock()
+        session.execute.return_value = _first_result(None)
+        assert await triplets.get_attestation(session, "missing") is None
+
+
+# -- Search + stats ---------------------------------------------------------
+
+
+class TestSearchRepo:
+    @pytest.mark.asyncio
+    async def test_returns_hits(self) -> None:
+        row = _row(
+            id="FA:0001",
+            entity_type="food",
+            common_name="apple",
+            scientific_name="Malus",
+            associations=42,
+        )
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(1), _iter_result([row])]
+        rows, total = await search.search(session, q="apple")
+        assert total == 1
+        assert rows[0]["common_name"] == "apple"
+
+    @pytest.mark.asyncio
+    async def test_empty_query_returns_empty(self) -> None:
+        session = AsyncMock()
+        rows, total = await search.search(session, q="   ")
+        assert rows == [] and total == 0
+        session.execute.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_entity_type_filter_applied(self) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(0), _iter_result([])]
+        await search.search(session, q="x", entity_type="chemical")
+        params = session.execute.call_args_list[0][0][1]
+        assert params["etype"] == "chemical"
+
+
+def _stat_row(field_value: str, count_value: int) -> MagicMock:
+    row = MagicMock()
+    row._mapping = {"field": field_value, "count": count_value}
+    return row
+
+
+class TestStatsRepo:
+    @pytest.mark.asyncio
+    async def test_maps_known_fields(self) -> None:
+        rows = [
+            _stat_row("number of foods", 1),
+            _stat_row("number of chemicals", 2),
+            _stat_row("number of diseases", 3),
+            _stat_row("number of publications", 4),
+            _stat_row("number of associations", 5),
+        ]
+        session = AsyncMock()
+        session.execute.return_value = _iter_result(rows)
+        out = await search.get_stats(session)
+        assert out == {
+            "foods": 1,
+            "chemicals": 2,
+            "diseases": 3,
+            "publications": 4,
+            "connections": 5,
+        }
+
+    @pytest.mark.asyncio
+    async def test_unknown_field_ignored(self) -> None:
+        rows = [_stat_row("other", 99)]
+        session = AsyncMock()
+        session.execute.return_value = _iter_result(rows)
+        out = await search.get_stats(session)
+        assert out["foods"] == 0

--- a/backend/api/tests/test_routes_v1.py
+++ b/backend/api/tests/test_routes_v1.py
@@ -1,0 +1,344 @@
+"""Tests for /v1/ routes (HTTP layer)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+
+# -- /v1/foods --------------------------------------------------------------
+
+
+class TestListFoods:
+    def test_returns_paginated_envelope(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.entities.list_entities",
+            return_value=(
+                [
+                    {
+                        "id": "FA:0001",
+                        "common_name": "apple",
+                        "scientific_name": "",
+                        "food_classification": [],
+                    }
+                ],
+                1,
+            ),
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/foods")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"][0]["id"] == "FA:0001"
+        assert body["page"] == {
+            "page": 1,
+            "page_size": 50,
+            "total": 1,
+            "has_more": False,
+        }
+
+    def test_clamps_page_size(self, client: TestClient) -> None:
+        # FastAPI Query validation rejects > 100; this confirms the bound.
+        resp = client.get("/v1/foods?page_size=500")
+        assert resp.status_code == 422
+
+
+class TestGetFood:
+    def test_returns_food(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.entities.get_entity",
+            return_value={
+                "id": "FA:0001",
+                "common_name": "apple",
+                "scientific_name": "",
+                "synonyms": [],
+                "external_ids": {},
+                "food_classification": [],
+            },
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/foods/FA:0001")
+        assert resp.status_code == 200
+        assert resp.json()["data"]["common_name"] == "apple"
+
+    def test_404_when_missing(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.entities.get_entity",
+            return_value=None,
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/foods/FA:NOPE")
+        assert resp.status_code == 404
+
+
+class TestFoodChemicals:
+    def test_returns_composition_rows(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.relationships.list_composition",
+            return_value=(
+                [
+                    {
+                        "food_id": "FA:0001",
+                        "food_name": "apple",
+                        "chemical_id": "FA:C001",
+                        "chemical_name": "glucose",
+                        "chemical_classification": [],
+                        "median_concentration": None,
+                        "attestation_count": 0,
+                        "sources": [],
+                    }
+                ],
+                1,
+            ),
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/foods/FA:0001/chemicals")
+        assert resp.status_code == 200
+        assert resp.json()["data"][0]["chemical_id"] == "FA:C001"
+
+
+# -- /v1/chemicals ----------------------------------------------------------
+
+
+class TestChemicalDiseases:
+    def test_relation_required_to_be_valid(self, client: TestClient) -> None:
+        resp = client.get("/v1/chemicals/FA:C001/diseases?relation=bogus")
+        assert resp.status_code == 422
+
+    def test_returns_correlation_rows(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.relationships.list_correlation",
+            return_value=(
+                [
+                    {
+                        "chemical_id": "FA:C001",
+                        "chemical_name": "glucose",
+                        "disease_id": "FA:D001",
+                        "disease_name": "diabetes",
+                        "relation": "worsens",
+                        "source_chemical_id": "",
+                        "source_chemical_name": "",
+                        "sources": [],
+                        "evidence_count": 1,
+                    }
+                ],
+                1,
+            ),
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/chemicals/FA:C001/diseases?relation=worsens")
+        assert resp.status_code == 200
+        assert resp.json()["data"][0]["relation"] == "worsens"
+
+
+# -- /v1/triplets -----------------------------------------------------------
+
+
+class TestListTriplets:
+    def test_returns_triplet_list(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.triplets.list_triplets",
+            return_value=(
+                [
+                    {
+                        "triplet_id": 1,
+                        "head_id": "FA:0001",
+                        "head_name": "apple",
+                        "relationship_id": "r1",
+                        "relationship_name": "contains",
+                        "tail_id": "FA:C001",
+                        "tail_name": "glucose",
+                        "source": "",
+                        "attestations": [],
+                    }
+                ],
+                1,
+            ),
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/triplets?relationship=contains")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"][0]["triplet_id"] == 1
+
+
+class TestGetTriplet:
+    def test_404_when_missing(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.triplets.get_triplet",
+            return_value=None,
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/triplets/9999")
+        assert resp.status_code == 404
+
+
+# -- /v1/attestations -------------------------------------------------------
+
+
+class TestGetAttestation:
+    def test_returns_attestation(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.triplets.get_attestation",
+            return_value={
+                "attestation_id": "att1",
+                "source": "fdc",
+                "evidence_id": "ev1",
+                "head_id": "FA:0001",
+                "head_name_raw": "apple",
+                "tail_id": "FA:C001",
+                "tail_name_raw": "glucose",
+                "relationship_id": "r1",
+                "conc_value": 5.0,
+                "conc_unit": "mg/100g",
+                "food_part": "fruit",
+                "food_processing": "",
+                "validated": False,
+                "validated_correct": True,
+                "trust_score": None,
+                "trust_reason": "",
+            },
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/attestations/att1")
+        assert resp.status_code == 200
+        assert resp.json()["data"]["attestation_id"] == "att1"
+
+    def test_404_when_missing(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.triplets.get_attestation",
+            return_value=None,
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/attestations/missing")
+        assert resp.status_code == 404
+
+
+# -- /v1/search -------------------------------------------------------------
+
+
+class TestSearch:
+    def test_q_required(self, client: TestClient) -> None:
+        resp = client.get("/v1/search")
+        assert resp.status_code == 422
+
+    def test_returns_hits(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.search.search",
+            return_value=(
+                [
+                    {
+                        "id": "FA:0001",
+                        "common_name": "apple",
+                        "entity_type": "food",
+                        "scientific_name": "Malus",
+                        "associations": 42,
+                    }
+                ],
+                1,
+            ),
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/search?q=apple")
+        assert resp.status_code == 200
+        assert resp.json()["data"][0]["common_name"] == "apple"
+
+    def test_invalid_entity_type_rejected(self, client: TestClient) -> None:
+        resp = client.get("/v1/search?q=apple&entity_type=bogus")
+        assert resp.status_code == 422
+
+
+# -- /v1/stats --------------------------------------------------------------
+
+
+class TestStats:
+    def test_returns_counts(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.search.get_stats",
+            return_value={
+                "foods": 100,
+                "chemicals": 50,
+                "diseases": 25,
+                "publications": 200,
+                "connections": 1000,
+            },
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/stats")
+        assert resp.status_code == 200
+        assert resp.json()["data"]["foods"] == 100
+
+
+# -- /v1/bundles ------------------------------------------------------------
+
+
+class TestBundles:
+    def test_empty_when_no_bucket(self, client: TestClient) -> None:
+        resp = client.get("/v1/bundles")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"] == []
+        assert body["page"]["total"] == 0
+
+    def test_lists_bundles(self, client_with_downloads_bucket: TestClient) -> None:
+        with patch(
+            "src.repositories.downloads.fetch_manifest",
+            return_value=[
+                {
+                    "version": "v1.0",
+                    "release_date": "2026-04-20",
+                    "file_size": "1 GB",
+                    "kgc_run": "x",
+                    "download_link": "https://example/foodatlas-v1.0.zip",
+                    "summary_link": "",
+                }
+            ],
+            new_callable=AsyncMock,
+        ):
+            resp = client_with_downloads_bucket.get("/v1/bundles")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"][0]["version"] == "v1.0"
+
+
+# -- /v1/diseases -----------------------------------------------------------
+
+
+class TestDiseaseEndpoints:
+    def test_get_disease_404(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.entities.get_entity",
+            return_value=None,
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/diseases/FA:NOPE")
+        assert resp.status_code == 404
+
+    def test_disease_chemicals_relation_validated(self, client: TestClient) -> None:
+        resp = client.get("/v1/diseases/FA:D001/chemicals?relation=bogus")
+        assert resp.status_code == 422
+
+
+# -- OpenAPI security scheme ------------------------------------------------
+
+
+class TestOpenAPISchema:
+    def test_security_scheme_registered(self, client: TestClient) -> None:
+        resp = client.get("/openapi.json")
+        assert resp.status_code == 200
+        schema = resp.json()
+        assert schema["components"]["securitySchemes"]["bearerAuth"] == {
+            "type": "http",
+            "scheme": "bearer",
+        }
+
+    def test_v1_routes_carry_security(self, client: TestClient) -> None:
+        schema = client.get("/openapi.json").json()
+        v1_paths = [p for p in schema["paths"] if p.startswith("/v1/")]
+        assert v1_paths
+        for path in v1_paths:
+            for op in schema["paths"][path].values():
+                if isinstance(op, dict):
+                    assert op.get("security") == [{"bearerAuth": []}]

--- a/backend/api/uv.lock
+++ b/backend/api/uv.lock
@@ -55,6 +55,34 @@ wheels = [
 ]
 
 [[package]]
+name = "boto3"
+version = "1.43.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+    { name = "jmespath" },
+    { name = "s3transfer" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0a/37/78c630d1308964aa9abf44951d9c4df776546ff37251ec2434944e205c4e/boto3-1.43.6.tar.gz", hash = "sha256:e6315effaf12b890b99956e6f8e2c3000a3f64e4ee91943cec3895ce9a836afb", size = 113153, upload-time = "2026-05-07T20:49:59.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/e2/3c2eef44f55eafab256836d1d9479bd6a74f70c26cbfdc0639a0e23e4327/boto3-1.43.6-py3-none-any.whl", hash = "sha256:179601ec2992726a718053bf41e43c223ceba397d31ceab11f64d9c910d9fc3a", size = 140502, upload-time = "2026-05-07T20:49:57.8Z" },
+]
+
+[[package]]
+name = "botocore"
+version = "1.43.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jmespath" },
+    { name = "python-dateutil" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/a7/23d0f5028011455096a1eeac0ddf3cbe147b3e855e127342f8202552194d/botocore-1.43.6.tar.gz", hash = "sha256:b1e395b347356860398da42e61c808cf1e34b6fa7180cf2b9d87d986e1a06ba0", size = 15336070, upload-time = "2026-05-07T20:49:48.14Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/c8/6f47223840e8d8cfa8c9f7c0ec1b77970417f257fc885169ff4f6326ce09/botocore-1.43.6-py3-none-any.whl", hash = "sha256:b6d1fdbc6f65a5fe0b7e947823aa37535d3f39f3ba4d21110fab1f55bbbcc04b", size = 15017094, upload-time = "2026-05-07T20:49:44.964Z" },
+]
+
+[[package]]
 name = "certifi"
 version = "2026.2.25"
 source = { registry = "https://pypi.org/simple" }
@@ -189,6 +217,8 @@ name = "foodatlas-api"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "boto3" },
+    { name = "click" },
     { name = "fastapi" },
     { name = "httpx" },
     { name = "psycopg", extra = ["binary"] },
@@ -211,6 +241,8 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "boto3", specifier = ">=1.34" },
+    { name = "click", specifier = ">=8.1" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
@@ -352,6 +384,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jmespath"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d3/59/322338183ecda247fb5d1763a6cbe46eff7222eaeebafd9fa65d4bf5cb11/jmespath-1.1.0.tar.gz", hash = "sha256:472c87d80f36026ae83c6ddd0f1d05d4e510134ed462851fd5f754c8c3cbb88d", size = 27377, upload-time = "2026-01-22T16:35:26.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/2f/967ba146e6d58cf6a652da73885f52fc68001525b4197effc174321d70b4/jmespath-1.1.0-py3-none-any.whl", hash = "sha256:a5663118de4908c91729bea0acadca56526eb2698e83de10cd116ae0f4e97c64", size = 20419, upload-time = "2026-01-22T16:35:24.919Z" },
 ]
 
 [[package]]
@@ -638,6 +679,18 @@ wheels = [
 ]
 
 [[package]]
+name = "python-dateutil"
+version = "2.9.0.post0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "six" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/66/c0/0c8b6ad9f17a802ee498c46e004a0eb49bc148f2fd230864601a86dcf6db/python-dateutil-2.9.0.post0.tar.gz", hash = "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3", size = 342432, upload-time = "2024-03-01T18:36:20.211Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/57/56b9bcc3c9c6a792fcbaf139543cee77261f3651ca9da0c93f5c1221264b/python_dateutil-2.9.0.post0-py2.py3-none-any.whl", hash = "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427", size = 229892, upload-time = "2024-03-01T18:36:18.57Z" },
+]
+
+[[package]]
 name = "python-dotenv"
 version = "1.2.2"
 source = { registry = "https://pypi.org/simple" }
@@ -728,6 +781,27 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/37/e6/90b2b33419f59d0f2c4c8a48a4b74b460709a557e8e0064cf33ad894f983/ruff-0.15.8-py3-none-win32.whl", hash = "sha256:bc1f0a51254ba21767bfa9a8b5013ca8149dcf38092e6a9eb704d876de94dc34", size = 10571959, upload-time = "2026-03-26T18:39:36.117Z" },
     { url = "https://files.pythonhosted.org/packages/1f/a2/ef467cb77099062317154c63f234b8a7baf7cb690b99af760c5b68b9ee7f/ruff-0.15.8-py3-none-win_amd64.whl", hash = "sha256:04f79eff02a72db209d47d665ba7ebcad609d8918a134f86cb13dd132159fc89", size = 11743893, upload-time = "2026-03-26T18:39:25.01Z" },
     { url = "https://files.pythonhosted.org/packages/15/e2/77be4fff062fa78d9b2a4dea85d14785dac5f1d0c1fb58ed52331f0ebe28/ruff-0.15.8-py3-none-win_arm64.whl", hash = "sha256:cf891fa8e3bb430c0e7fac93851a5978fc99c8fa2c053b57b118972866f8e5f2", size = 11048175, upload-time = "2026-03-26T18:40:01.06Z" },
+]
+
+[[package]]
+name = "s3transfer"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "botocore" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/ec/7c692cde9125b77e84b307354d4fb705f98b8ccad59a036d5957ca75bfc3/s3transfer-0.17.0.tar.gz", hash = "sha256:9edeb6d1c3c2f89d6050348548834ad8289610d886e5bf7b7207728bd43ce33a", size = 155337, upload-time = "2026-04-29T22:07:36.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/72/c6c32d2b657fa3dad1de340254e14390b1e334ce38268b7ad51abda3c8c2/s3transfer-0.17.0-py3-none-any.whl", hash = "sha256:ce3801712acf4ad3e89fb9990df97b4972e93f4b3b0004d214be5bce12814c20", size = 86811, upload-time = "2026-04-29T22:07:34.966Z" },
+]
+
+[[package]]
+name = "six"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
 ]
 
 [[package]]
@@ -826,6 +900,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/f5/cd531b2d15a671a40c0f66cf06bc3570a12cd56eef98960068ebbad1bf5a/tzdata-2026.1.tar.gz", hash = "sha256:67658a1903c75917309e753fdc349ac0efd8c27db7a0cb406a25be4840f87f98", size = 197639, upload-time = "2026-04-03T11:25:22.002Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b0/70/d460bd685a170790ec89317e9bd33047988e4bce507b831f5db771e142de/tzdata-2026.1-py2.py3-none-any.whl", hash = "sha256:4b1d2be7ac37ceafd7327b961aa3a54e467efbdb563a23655fbfe0d39cfc42a9", size = 348952, upload-time = "2026-04-03T11:25:20.313Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
 ]
 
 [[package]]

--- a/frontend/app/(everything-else)/developers/page.tsx
+++ b/frontend/app/(everything-else)/developers/page.tsx
@@ -1,0 +1,235 @@
+import { Metadata } from "next";
+
+import Card from "@/components/basic/Card";
+import Code from "@/components/basic/Code";
+import Divider from "@/components/basic/Divider";
+import Heading from "@/components/basic/Heading";
+import Link from "@/components/basic/Link";
+import SubHeading from "@/components/basic/SubHeading";
+
+export const metadata: Metadata = {
+  title: "Developers | FoodAtlas Public API",
+  description:
+    "Programmatic access to the FoodAtlas knowledge graph. Authenticate with an API key, then call any /v1/ endpoint. Email aifs@ucdavis.edu to request a key.",
+};
+
+const API_BASE = "https://api.foodatlas.ai";
+const MAILTO =
+  "mailto:aifs@ucdavis.edu" +
+  "?subject=FoodAtlas%20API%20key%20request" +
+  "&body=Name%3A%0AAffiliation%3A%0AIntended%20use%3A%0A";
+
+const CURL_EXAMPLE = `curl -H "Authorization: Bearer YOUR_KEY" \\
+  ${API_BASE}/v1/foods/FA:0001`;
+
+const PYTHON_EXAMPLE = `import requests
+
+resp = requests.get(
+    "${API_BASE}/v1/triplets",
+    params={"head_id": "FA:0001", "relationship": "contains"},
+    headers={"Authorization": "Bearer YOUR_KEY"},
+)
+resp.raise_for_status()
+print(resp.json())`;
+
+const ENDPOINTS: Array<{ method: string; path: string; summary: string }> = [
+  { method: "GET", path: "/v1/foods", summary: "List foods (paginated, filterable)" },
+  { method: "GET", path: "/v1/foods/{id}", summary: "Get one food" },
+  {
+    method: "GET",
+    path: "/v1/foods/{id}/chemicals",
+    summary: "Chemicals contained in a food",
+  },
+  { method: "GET", path: "/v1/foods/{id}/taxonomy", summary: "IS_A ancestry" },
+  { method: "GET", path: "/v1/chemicals", summary: "List chemicals" },
+  { method: "GET", path: "/v1/chemicals/{id}", summary: "Get one chemical" },
+  {
+    method: "GET",
+    path: "/v1/chemicals/{id}/foods",
+    summary: "Foods containing a chemical",
+  },
+  {
+    method: "GET",
+    path: "/v1/chemicals/{id}/diseases",
+    summary: "Disease correlations (reduces|worsens)",
+  },
+  { method: "GET", path: "/v1/diseases", summary: "List diseases" },
+  { method: "GET", path: "/v1/diseases/{id}", summary: "Get one disease" },
+  {
+    method: "GET",
+    path: "/v1/diseases/{id}/chemicals",
+    summary: "Chemical correlations (reduces|worsens)",
+  },
+  {
+    method: "GET",
+    path: "/v1/triplets",
+    summary: "Knowledge-graph edges (head, relationship, tail)",
+  },
+  { method: "GET", path: "/v1/triplets/{id}", summary: "Get one triplet" },
+  {
+    method: "GET",
+    path: "/v1/attestations/{id}",
+    summary: "Raw evidence row backing a triplet",
+  },
+  { method: "GET", path: "/v1/search", summary: "Trigram autocomplete" },
+  { method: "GET", path: "/v1/stats", summary: "Aggregate counts" },
+  { method: "GET", path: "/v1/bundles", summary: "Released bulk-download bundles" },
+];
+
+const Developers = () => {
+  return (
+    <div>
+      <div>
+        <Heading type="h1">Developer API</Heading>
+        <SubHeading>
+          Programmatic access to the <i>FoodAtlas</i> knowledge graph
+        </SubHeading>
+        <p className="mt-10 text-lg leading-loose text-light-200">
+          The public API exposes the same food–chemical–disease graph that
+          powers this site, with stable resource-shaped responses suited for
+          research scripts. The interactive OpenAPI reference lives at{" "}
+          <Link href={`${API_BASE}/docs`}>{`${API_BASE}/docs`}</Link>.
+        </p>
+      </div>
+
+      <Divider />
+
+      <div>
+        <Heading type="h2" variant="boxed">
+          Get an API key
+        </Heading>
+      </div>
+      <div className="mt-8">
+        <Card>
+          <p className="text-lg font-light text-light-300">
+            Keys are issued by hand to keep the door open without inviting
+            abuse. Email{" "}
+            <Link href={MAILTO} isExternal={true}>
+              aifs@ucdavis.edu
+            </Link>{" "}
+            with your name, affiliation, and a one-line description of what
+            you&apos;re building. You&apos;ll usually hear back within a few
+            business days.
+          </p>
+          <p className="mt-4 text-lg font-light text-light-300">
+            Use is intended for academic and non-commercial research. Please
+            cite <i>FoodAtlas</i> in any published work.
+          </p>
+        </Card>
+      </div>
+
+      <div className="mt-20">
+        <Heading type="h2" variant="boxed">
+          Setup
+        </Heading>
+      </div>
+      <div className="mt-8">
+        <Card>
+          <div>
+            <Heading type="h3" className="text-xl">
+              Base URL
+            </Heading>
+            <div className="mt-2 flex flex-wrap items-center">
+              <p className="mr-3 text-lg font-light text-light-300">
+                All endpoints live under
+              </p>
+              <Code size="text-[1rem]">{API_BASE}</Code>
+            </div>
+          </div>
+          <div className="mt-6">
+            <Heading type="h3" className="text-xl">
+              Authentication
+            </Heading>
+            <p className="mt-3 text-lg font-light text-light-300">
+              Send your key in the <Code size="text-[1rem]">Authorization</Code>{" "}
+              header with the <Code size="text-[1rem]">Bearer</Code> scheme:
+            </p>
+            <pre className="mt-4 overflow-x-auto rounded bg-light-800 p-4 text-[0.95rem] text-light-100">
+              <code>{CURL_EXAMPLE}</code>
+            </pre>
+          </div>
+        </Card>
+      </div>
+
+      <div className="mt-20">
+        <Heading type="h2" variant="boxed">
+          Examples
+        </Heading>
+      </div>
+      <div className="mt-8 flex flex-col gap-6">
+        <Card>
+          <Heading type="h3" className="text-xl">
+            Python
+          </Heading>
+          <pre className="mt-4 overflow-x-auto rounded bg-light-800 p-4 text-[0.95rem] text-light-100">
+            <code>{PYTHON_EXAMPLE}</code>
+          </pre>
+        </Card>
+      </div>
+
+      <div className="mt-20">
+        <Heading type="h2" variant="boxed">
+          Endpoints
+        </Heading>
+      </div>
+      <div className="mt-8">
+        <Card>
+          <p className="mb-4 text-lg font-light text-light-300">
+            Full request/response schemas and an interactive console live at{" "}
+            <Link href={`${API_BASE}/docs`}>{`${API_BASE}/docs`}</Link>. Pagination
+            is offset-based:{" "}
+            <Code size="text-[1rem]">?page=&page_size=</Code> (max 100).
+          </p>
+          <div className="overflow-x-auto">
+            <table className="w-full text-left text-[0.95rem]">
+              <thead className="text-light-200">
+                <tr>
+                  <th className="py-2 pr-4 font-mono">Method</th>
+                  <th className="py-2 pr-4 font-mono">Path</th>
+                  <th className="py-2 font-mono">Summary</th>
+                </tr>
+              </thead>
+              <tbody className="font-light text-light-300">
+                {ENDPOINTS.map((e) => (
+                  <tr key={`${e.method} ${e.path}`} className="border-t border-light-800">
+                    <td className="py-2 pr-4 font-mono text-light-100">{e.method}</td>
+                    <td className="py-2 pr-4 font-mono">
+                      <Code size="text-[0.9rem]">{e.path}</Code>
+                    </td>
+                    <td className="py-2">{e.summary}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+      </div>
+
+      <div className="mt-20">
+        <Heading type="h2" variant="boxed">
+          Versioning &amp; terms
+        </Heading>
+      </div>
+      <div className="mt-8">
+        <Card>
+          <p className="text-lg font-light text-light-300">
+            Routes under <Code size="text-[1rem]">/v1/</Code> follow a stable
+            contract. Breaking changes ship under a new prefix
+            (<Code size="text-[1rem]">/v2/</Code>) — we will not change response
+            shapes within <Code size="text-[1rem]">/v1/</Code>.
+          </p>
+          <p className="mt-4 text-lg font-light text-light-300">
+            Bulk downloads of released data are available under{" "}
+            <Link href="/food-composition-downloads" isExternal={false}>
+              Downloads
+            </Link>{" "}
+            and via <Code size="text-[1rem]">/v1/bundles</Code>. Use those for
+            corpus-scale work rather than scraping the API.
+          </p>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+export default Developers;

--- a/frontend/components/navigation/Navbar.tsx
+++ b/frontend/components/navigation/Navbar.tsx
@@ -12,7 +12,7 @@ import { SearchContext } from "@/context/searchContext";
 
 const NAV_ITEMS = [
   { text: "Background", href: "/technical-background" },
-  // { text: "API", href: "/food-composition-api" },
+  { text: "API", href: "/developers" },
   { text: "Downloads", href: "/food-composition-downloads" },
   { text: "About", href: "/about" },
   { text: "Contact", href: "/contact" },

--- a/infra/aws/stacks/api_stack.py
+++ b/infra/aws/stacks/api_stack.py
@@ -90,6 +90,23 @@ class ApiStack(cdk.Stack):
             ),
         )
 
+        # Hashed public /v1/ API keys: a JSON object keyed by sha256(key) with
+        # {email, created, notes} metadata. Initial value is an empty object;
+        # new keys are issued via ``backend/api/scripts/issue_public_key.py``
+        # and pasted in with ``aws secretsmanager update-secret``. The API
+        # loads this at startup and refreshes every few minutes so adding a
+        # key never requires a redeploy.
+        public_keys_secret = secretsmanager.Secret(
+            self,
+            "ApiPublicKeysSecret",
+            secret_name="foodatlas/public-api-keys",
+            description=(
+                "Hashed public /v1/ API keys "
+                "({sha256(key): {email, created, notes}})."
+            ),
+            secret_string_value=cdk.SecretValue.unsafe_plain_text("{}"),
+        )
+
         task_definition = ecs.FargateTaskDefinition(
             self,
             "ApiTaskDefinition",
@@ -129,6 +146,8 @@ class ApiStack(cdk.Stack):
                 "KGC_BUCKET": kgc_bucket.bucket_name,
                 "API_DOWNLOADS_BUCKET": downloads_bucket.bucket_name,
                 "API_DOWNLOADS_REGION": cdk.Stack.of(self).region,
+                "API_PUBLIC_KEYS_SECRET_NAME": public_keys_secret.secret_name,
+                "API_AWS_REGION": cdk.Stack.of(self).region,
             },
             secrets={
                 "DB_USER": ecs.Secret.from_secrets_manager(db_secret, "username"),
@@ -142,6 +161,10 @@ class ApiStack(cdk.Stack):
 
         # Task role needs read access to KGC bucket for ad-hoc fetches
         kgc_bucket.grant_read(task_definition.task_role)
+
+        # Read access to the public-keys secret. The API polls this at runtime
+        # via boto3 so we cannot inject the value once at task start.
+        public_keys_secret.grant_read(task_definition.task_role)
 
         cert_arn = self.node.try_get_context("api_cert_arn")
         service_kwargs: dict[str, Any] = {
@@ -200,5 +223,17 @@ class ApiStack(cdk.Stack):
                 "Secrets Manager ARN for the API bearer token. Fetch the "
                 "value with: aws secretsmanager get-secret-value "
                 "--secret-id <arn> --query SecretString --output text"
+            ),
+        )
+
+        cdk.CfnOutput(
+            self,
+            "ApiPublicKeysSecretArn",
+            value=public_keys_secret.secret_arn,
+            description=(
+                "Secrets Manager ARN holding the JSON object of hashed "
+                "public /v1/ API keys. Issue new keys with "
+                "backend/api/scripts/issue_public_key.py and merge them in "
+                "with aws secretsmanager update-secret."
             ),
         )


### PR DESCRIPTION
## Summary
- New resource-oriented `/v1/*` surface (19 endpoints: foods, chemicals, diseases, triplets, attestations, search, stats, bundles, plus taxonomy + relationship projections) decoupled from the UI-shaped `/food/*` etc. routes the frontend still uses.
- Manual, email-gated key issuance. Keys are hashed (sha256) and stored in AWS Secrets Manager (`foodatlas/public-api-keys`); the API polls every 5 min so adding a key never requires a redeploy.
- Hardened OpenAPI (`bearerAuth` security scheme — `/docs` Authorize button now works); new `/developers` page on the frontend plus a navbar link, replacing the stale `/food-composition-api` entry.
- CDK creates the keys secret + grants the ECS task role `secretsmanager:GetSecretValue`. CD pipeline rolls the API image automatically on merge.
- 50 new tests; suite now 169 passing, 90.6% coverage.

## Test plan
- [ ] CI green (ruff, mypy, bandit, pytest at backend/api; eslint + tsc at frontend)
- [ ] After deploy: `GET /openapi.json` shows 19 `/v1/*` paths with `security: [{bearerAuth: []}]`
- [ ] `curl https://api.foodatlas.ai/v1/foods?q=strawberry` returns 401 without key
- [ ] Issue a key via `cd backend/api && uv run python scripts/issue_public_key.py`, paste the printed `aws secretsmanager update-secret` command, wait <5 min, then re-curl with `Authorization: Bearer <key>` and confirm 200 + flat data
- [ ] `https://www.foodatlas.ai/developers` renders and the navbar "API" link points at it
- [ ] Existing `/food/*`, `/chemical/*`, `/disease/*` routes return unchanged responses (frontend regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)