### PR TITLE
feat(developers): route API-key requests through the contact form

### DIFF
--- a/backend/api/src/app.py
+++ b/backend/api/src/app.py
@@ -20,8 +20,8 @@ external integration.
 
 ### Authentication
 All `/v1/` requests must include `Authorization: Bearer <key>`. To request
-a key, email aifs@ucdavis.edu with your name, affiliation, and intended
-use.
+a key, use the contact form at https://www.foodatlas.ai/contact?api-access
+and provide your name, affiliation, and intended use.
 
 ### Rate limits
 No per-key limits are enforced today. Please be polite; we will reach out

--- a/frontend/__tests__/developers.test.tsx
+++ b/frontend/__tests__/developers.test.tsx
@@ -1,0 +1,22 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import Developers from "@/app/(everything-else)/developers/page";
+
+describe("Developers page", () => {
+  it("links API-key requests to /contact?api-access", () => {
+    render(<Developers />);
+
+    const link = screen.getByRole("link", { name: /request access via the contact form/i });
+    expect(link).toHaveAttribute("href", "/contact?api-access");
+  });
+
+  it("contains no mailto: links", () => {
+    render(<Developers />);
+
+    const links = screen.getAllByRole("link");
+    for (const link of links) {
+      expect(link.getAttribute("href")).not.toMatch(/^mailto:/);
+    }
+  });
+});

--- a/frontend/app/(everything-else)/contact/page.tsx
+++ b/frontend/app/(everything-else)/contact/page.tsx
@@ -16,7 +16,7 @@ interface ContactPageProps {
 }
 
 const Contact = ({ searchParams }: ContactPageProps) => {
-  const isApiAccressRequest = searchParams.hasOwnProperty("api-access");
+  const isApiAccessRequest = searchParams.hasOwnProperty("api-access");
 
   return (
     <div>
@@ -38,7 +38,7 @@ const Contact = ({ searchParams }: ContactPageProps) => {
           </p>
         </div>
         <div className="md:w-1/2">
-          <ContactForm isApiAccressRequest={isApiAccressRequest} />
+          <ContactForm isApiAccessRequest={isApiAccessRequest} />
         </div>
       </div>
     </div>

--- a/frontend/app/(everything-else)/developers/page.tsx
+++ b/frontend/app/(everything-else)/developers/page.tsx
@@ -10,14 +10,10 @@ import SubHeading from "@/components/basic/SubHeading";
 export const metadata: Metadata = {
   title: "Developers | FoodAtlas Public API",
   description:
-    "Programmatic access to the FoodAtlas knowledge graph. Authenticate with an API key, then call any /v1/ endpoint. Email aifs@ucdavis.edu to request a key.",
+    "Programmatic access to the FoodAtlas knowledge graph. Authenticate with an API key, then call any /v1/ endpoint. Request a key via the contact form.",
 };
 
 const API_BASE = "https://api.foodatlas.ai";
-const MAILTO =
-  "mailto:aifs@ucdavis.edu" +
-  "?subject=FoodAtlas%20API%20key%20request" +
-  "&body=Name%3A%0AAffiliation%3A%0AIntended%20use%3A%0A";
 
 const CURL_EXAMPLE = `curl -H "Authorization: Bearer YOUR_KEY" \\
   ${API_BASE}/v1/foods/FA:0001`;
@@ -103,9 +99,9 @@ const Developers = () => {
         <Card>
           <p className="text-lg font-light text-light-300">
             Keys are issued by hand to keep the door open without inviting
-            abuse. Email{" "}
-            <Link href={MAILTO} isExternal={true}>
-              aifs@ucdavis.edu
+            abuse.{" "}
+            <Link href="/contact?api-access" isExternal={false}>
+              Request access via the contact form
             </Link>{" "}
             with your name, affiliation, and a one-line description of what
             you&apos;re building. You&apos;ll usually hear back within a few

--- a/frontend/components/contact/ContactForm.tsx
+++ b/frontend/components/contact/ContactForm.tsx
@@ -17,15 +17,15 @@ import Card from "@/components/basic/Card";
 import { twMerge } from "tailwind-merge";
 
 interface ContactFormProps {
-  isApiAccressRequest: boolean;
+  isApiAccessRequest: boolean;
 }
 
-const ContactForm = ({ isApiAccressRequest }: ContactFormProps) => {
+const ContactForm = ({ isApiAccessRequest }: ContactFormProps) => {
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [affiliation, setAffiliation] = useState("");
   const [topic, setTopic] = useState(
-    isApiAccressRequest ? "API Access Request" : "General Inquiry"
+    isApiAccessRequest ? "API Access Request" : "General Inquiry"
   );
   const [message, setMessage] = useState("");
 


### PR DESCRIPTION
## Summary
- Swap the `mailto:aifs@ucdavis.edu` on `/developers` for an internal `Link` to `/contact?api-access`. The contact form already had an "API Access Request" topic and the `?api-access` URL preselects it via the existing Next.js Route Handler (Resend → `EMAIL_TO`). No new backend endpoint, no schema change.
- Fix typo `isApiAccressRequest` → `isApiAccessRequest` in `ContactForm.tsx` + its parent page while files were open.
- Update the OpenAPI description in `backend/api/src/app.py` to point researchers at the contact-form URL instead of email.
- New `frontend/__tests__/developers.test.tsx` asserts the request link points at `/contact?api-access` and no `mailto:` href is rendered.

Builds on #180 (currently on dev, not yet promoted to main). Key issuance itself remains the same manual flow — `backend/api/scripts/issue_public_key.py` after a contact-form submission lands.

## Test plan
- [ ] CI green (ruff/mypy/bandit/pytest backend; eslint/tsc/vitest frontend)
- [ ] Submitting the contact form at `/contact?api-access` delivers an email via Resend with topic "API Access Request"
- [ ] `/developers` no longer renders any `mailto:` link; the request link points at `/contact?api-access`

🤖 Generated with [Claude Code](https://claude.com/claude-code)