### PR TITLE
fix(infra): rename API_PUBLIC_KEYS_RESOURCE_ID → API_PUBLIC_KEYS_SECRET_NAME

### DIFF
--- a/infra/aws/stacks/api_stack.py
+++ b/infra/aws/stacks/api_stack.py
@@ -152,7 +152,7 @@ class ApiStack(cdk.Stack):
                 "KGC_BUCKET": kgc_bucket.bucket_name,
                 "API_DOWNLOADS_BUCKET": downloads_bucket.bucket_name,
                 "API_DOWNLOADS_REGION": cdk.Stack.of(self).region,
-                "API_PUBLIC_KEYS_RESOURCE_ID": public_keys_secret.secret_name,
+                "API_PUBLIC_KEYS_SECRET_NAME": public_keys_secret.secret_name,
                 "API_AWS_REGION": cdk.Stack.of(self).region,
             },
             secrets={


### PR DESCRIPTION
## Summary
- CDK passed the public-keys secret name as `API_PUBLIC_KEYS_RESOURCE_ID`, but `APISettings.public_keys_secret_name` (env_prefix=`API_`) reads `API_PUBLIC_KEYS_SECRET_NAME`. The names never matched, so `settings.public_keys_secret_name = ""` in prod, `get_store()` returned `None`, and every `/v1/` public-key auth attempt 401'd.
- Internal-key path (`settings.key`) was unaffected — the frontend, `/resolve`, `/download`, etc. kept working. That masked the bug from #180.
- One-line rename in `infra/aws/stacks/api_stack.py`. The module-level constant `PUBLIC_KEYS_RESOURCE_ID` is intentionally named without "secret"/"name" to avoid bandit B105/B106 false-positives — leaving that alone.

## How discovered
Issued a stress-test public key, registered the sha256 hash in Secrets Manager (`030635937737/us-west-1/foodatlas/public-api-keys`), still got 401. ECS task definition `FoodAtlasApiStackApiTaskDefinition:9` showed `API_PUBLIC_KEYS_RESOURCE_ID=foodatlas/public-api-keys` — i.e. the env var the container received was not the one `APISettings` reads.

## Test plan
- [ ] CI green
- [ ] CDK deploys via GHA on merge to `main`
- [ ] After deploy, `curl -H "Authorization: Bearer <plaintext>" https://api.foodatlas.ai/v1/stats` returns `200` (using the stress-test key already in the secret)