### PR TITLE
feat(api): per-key rate limiting on /v1/* (closes #186)

### DIFF
--- a/backend/api/src/app.py
+++ b/backend/api/src/app.py
@@ -9,6 +9,7 @@ from fastapi.openapi.utils import get_openapi
 from src.config import APISettings
 from src.dependencies import init_session_factory
 from src.public_keys import get_store, init_store
+from src.rate_limit import TokenBucketLimiter
 from src.routes import chemical, disease, download, food, metadata, resolve
 from src.routes import v1 as v1_routes
 
@@ -24,8 +25,10 @@ a key, use the contact form at https://www.foodatlas.ai/contact?api-access
 and provide your name, affiliation, and intended use.
 
 ### Rate limits
-No per-key limits are enforced today. Please be polite; we will reach out
-if usage looks abusive.
+Each key is limited to 60 requests per minute, with a burst capacity of 10
+(meaning short spikes up to 10 requests can land at once before throttling
+kicks in). Over-limit requests receive `429 Too Many Requests` with a
+`Retry-After` header indicating when capacity will be available again.
 
 ### Versioning & terms
 Endpoints under `/v1/` follow a stable contract. Use is intended for
@@ -67,6 +70,12 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    if settings.rate_limit_enabled and not settings.debug:
+        app.state.rate_limiter = TokenBucketLimiter(
+            sustained_per_min=settings.rate_limit_per_minute,
+            burst=settings.rate_limit_burst,
+        )
 
     @app.get("/health", tags=["health"])
     async def health() -> dict[str, str]:

--- a/backend/api/src/config.py
+++ b/backend/api/src/config.py
@@ -28,3 +28,9 @@ class APISettings(BaseSettings):
     public_keys_secret_name: str = ""
     public_keys_refresh_seconds: int = 300
     aws_region: str = "us-west-1"
+    # /v1/ per-API-key rate limit. The internal key (frontend SSR path)
+    # always bypasses. Disabled in debug mode and when
+    # ``rate_limit_enabled`` is False.
+    rate_limit_enabled: bool = True
+    rate_limit_per_minute: int = 60
+    rate_limit_burst: int = 10

--- a/backend/api/src/rate_limit.py
+++ b/backend/api/src/rate_limit.py
@@ -1,0 +1,83 @@
+"""Per-API-key rate limiting for the public /v1/ API.
+
+A small in-memory token-bucket limiter keyed off
+``request.state.api_key_email`` (populated by :func:`verify_v1_key`). The
+``"internal"`` sentinel — assigned to the frontend's SSR calls — always
+bypasses; every distinct public key gets its own bucket.
+
+Storage is per-process. When the API runs on more than one Fargate task
+(see issue #187), each task tracks its own buckets, so the effective
+cluster-wide rate is N× the configured per-task rate. Acceptable while
+the task count is small; swap to a Redis-backed limiter if/when that
+ceases to be true.
+
+Wired into the `/v1/` router as the second router-level dependency
+(after :func:`verify_v1_key`) in :mod:`src.routes.v1`.
+"""
+
+from __future__ import annotations
+
+import time
+from threading import Lock
+
+from fastapi import HTTPException, Request
+
+INTERNAL_KEY_EMAIL = "internal"
+
+
+class TokenBucketLimiter:
+    """Per-key token bucket with continuous refill.
+
+    ``sustained_per_min`` sets the long-term rate; ``burst`` is the
+    bucket capacity (the largest spike a single key can land before
+    being throttled). ``check(key)`` returns 0.0 when the request is
+    admitted and a positive ``retry_after`` (seconds) otherwise.
+    """
+
+    def __init__(self, sustained_per_min: int, burst: int) -> None:
+        if sustained_per_min <= 0 or burst <= 0:
+            raise ValueError("rate-limit settings must be positive")
+        self._refill_per_sec = sustained_per_min / 60.0
+        self._capacity = float(burst)
+        self._state: dict[str, tuple[float, float]] = {}
+        self._lock = Lock()
+
+    def check(self, key: str) -> float:
+        """Try to reserve one token for ``key``. Returns retry-after seconds."""
+        if key == INTERNAL_KEY_EMAIL:
+            return 0.0
+        now = time.monotonic()
+        with self._lock:
+            tokens, last = self._state.get(key, (self._capacity, now))
+            tokens = min(
+                self._capacity,
+                tokens + (now - last) * self._refill_per_sec,
+            )
+            if tokens >= 1.0:
+                self._state[key] = (tokens - 1.0, now)
+                return 0.0
+            need = 1.0 - tokens
+            self._state[key] = (tokens, now)
+            return need / self._refill_per_sec
+
+
+async def enforce_rate_limit(request: Request) -> None:
+    """Throttle /v1/* requests per API key. 429 on overage with Retry-After.
+
+    No-op when the app has no limiter installed (debug or feature-flagged
+    off), so this dependency is safe to declare unconditionally on the
+    /v1/ router.
+    """
+    limiter: TokenBucketLimiter | None = getattr(
+        request.app.state, "rate_limiter", None
+    )
+    if limiter is None:
+        return
+    key = getattr(request.state, "api_key_email", "anonymous")
+    retry_after = limiter.check(key)
+    if retry_after > 0.0:
+        raise HTTPException(
+            status_code=429,
+            detail="Rate limit exceeded",
+            headers={"Retry-After": str(max(1, int(retry_after) + 1))},
+        )

--- a/backend/api/src/rate_limit.py
+++ b/backend/api/src/rate_limit.py
@@ -7,7 +7,7 @@ bypasses; every distinct public key gets its own bucket.
 
 Storage is per-process. When the API runs on more than one Fargate task
 (see issue #187), each task tracks its own buckets, so the effective
-cluster-wide rate is N× the configured per-task rate. Acceptable while
+cluster-wide rate is N times the configured per-task rate. Acceptable while
 the task count is small; swap to a Redis-backed limiter if/when that
 ceases to be true.
 

--- a/backend/api/src/routes/v1/__init__.py
+++ b/backend/api/src/routes/v1/__init__.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter, Depends
 
 from src.dependencies import verify_v1_key
+from src.rate_limit import enforce_rate_limit
 
 from . import (
     attestations,
@@ -17,7 +18,7 @@ from . import (
 
 router = APIRouter(
     prefix="/v1",
-    dependencies=[Depends(verify_v1_key)],
+    dependencies=[Depends(verify_v1_key), Depends(enforce_rate_limit)],
     tags=["public-v1"],
 )
 router.include_router(foods.router)

--- a/backend/api/tests/test_rate_limit.py
+++ b/backend/api/tests/test_rate_limit.py
@@ -1,0 +1,163 @@
+"""Tests for the /v1/ token-bucket rate limiter."""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from fastapi import HTTPException, Request
+from fastapi.testclient import TestClient
+from src.app import create_app
+from src.config import APISettings
+from src.dependencies import get_db, get_settings, verify_v1_key
+from src.rate_limit import TokenBucketLimiter, enforce_rate_limit
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncGenerator
+
+
+class TestTokenBucketLimiter:
+    def test_allows_up_to_burst(self) -> None:
+        lim = TokenBucketLimiter(sustained_per_min=60, burst=3)
+        assert lim.check("a@x.edu") == 0.0
+        assert lim.check("a@x.edu") == 0.0
+        assert lim.check("a@x.edu") == 0.0
+
+    def test_throttles_past_burst(self) -> None:
+        lim = TokenBucketLimiter(sustained_per_min=60, burst=2)
+        lim.check("a@x.edu")
+        lim.check("a@x.edu")
+        retry_after = lim.check("a@x.edu")
+        assert retry_after > 0.0
+
+    def test_retry_after_reflects_refill_rate(self) -> None:
+        # 60/min = 1 token/sec, so retry_after for 1 missing token ~= 1s.
+        lim = TokenBucketLimiter(sustained_per_min=60, burst=1)
+        lim.check("a@x.edu")
+        retry_after = lim.check("a@x.edu")
+        assert 0.5 < retry_after < 1.5
+
+    def test_independent_buckets(self) -> None:
+        lim = TokenBucketLimiter(sustained_per_min=60, burst=1)
+        assert lim.check("a@x.edu") == 0.0
+        # Different key keeps its own bucket, still has a token.
+        assert lim.check("b@x.edu") == 0.0
+        # Original key is now empty.
+        assert lim.check("a@x.edu") > 0.0
+
+    def test_internal_key_bypasses(self) -> None:
+        lim = TokenBucketLimiter(sustained_per_min=60, burst=1)
+        for _ in range(100):
+            assert lim.check("internal") == 0.0
+
+    def test_refills_over_time(self) -> None:
+        # 600/min = 10 tokens/sec, so a 0.2s wait fully refills a burst-of-1.
+        lim = TokenBucketLimiter(sustained_per_min=600, burst=1)
+        lim.check("a@x.edu")
+        assert lim.check("a@x.edu") > 0.0
+        time.sleep(0.2)
+        assert lim.check("a@x.edu") == 0.0
+
+    def test_rejects_nonpositive_config(self) -> None:
+        with pytest.raises(ValueError):
+            TokenBucketLimiter(sustained_per_min=0, burst=10)
+        with pytest.raises(ValueError):
+            TokenBucketLimiter(sustained_per_min=60, burst=0)
+
+
+class TestEnforceRateLimitDependency:
+    @pytest.mark.asyncio
+    async def test_no_limiter_installed_is_noop(self) -> None:
+        request = MagicMock()
+        request.app.state = MagicMock(spec=[])  # no rate_limiter attribute
+        await enforce_rate_limit(request)
+
+    @pytest.mark.asyncio
+    async def test_allows_under_burst(self) -> None:
+        request = MagicMock()
+        request.app.state.rate_limiter = TokenBucketLimiter(
+            sustained_per_min=60, burst=3
+        )
+        request.state.api_key_email = "a@x.edu"
+        await enforce_rate_limit(request)
+        await enforce_rate_limit(request)
+        await enforce_rate_limit(request)
+
+    @pytest.mark.asyncio
+    async def test_raises_429_with_retry_after(self) -> None:
+        request = MagicMock()
+        request.app.state.rate_limiter = TokenBucketLimiter(
+            sustained_per_min=60, burst=1
+        )
+        request.state.api_key_email = "a@x.edu"
+        await enforce_rate_limit(request)
+        with pytest.raises(HTTPException) as exc_info:
+            await enforce_rate_limit(request)
+        assert exc_info.value.status_code == 429
+        assert "Retry-After" in exc_info.value.headers
+        assert int(exc_info.value.headers["Retry-After"]) >= 1
+
+    @pytest.mark.asyncio
+    async def test_internal_key_bypasses_in_dependency(self) -> None:
+        request = MagicMock()
+        request.app.state.rate_limiter = TokenBucketLimiter(
+            sustained_per_min=60, burst=1
+        )
+        request.state.api_key_email = "internal"
+        for _ in range(50):
+            await enforce_rate_limit(request)
+
+
+# -- HTTP-layer integration: 429 surfaces on /v1/ when limit is hit -----------
+
+
+def _enabled_settings() -> APISettings:
+    s = APISettings(**{"_env_file": None})
+    s.debug = False
+    s.key = "x"
+    s.rate_limit_enabled = True
+    s.rate_limit_per_minute = 60
+    s.rate_limit_burst = 2
+    s.public_keys_secret_name = ""
+    return s
+
+
+def _build_v1_client(settings: APISettings, mock_db: AsyncMock) -> TestClient:
+    app = create_app(settings)
+
+    async def _override_db() -> AsyncGenerator[AsyncMock]:
+        yield mock_db
+
+    async def _override_verify_v1(request: Request) -> None:
+        request.state.api_key_email = "alice@u.edu"
+
+    app.dependency_overrides[get_db] = _override_db
+    app.dependency_overrides[verify_v1_key] = _override_verify_v1
+    app.dependency_overrides[get_settings] = lambda: settings
+    return TestClient(app, raise_server_exceptions=False)
+
+
+class TestV1RateLimitHttp:
+    def test_third_request_429s(self) -> None:
+        mock_db = AsyncMock()
+        client = _build_v1_client(_enabled_settings(), mock_db)
+        with patch(
+            "src.repositories.v1.search.get_stats",
+            return_value={
+                "foods": 0,
+                "chemicals": 0,
+                "diseases": 0,
+                "publications": 0,
+                "connections": 0,
+            },
+            new_callable=AsyncMock,
+        ):
+            r1 = client.get("/v1/stats")
+            r2 = client.get("/v1/stats")
+            r3 = client.get("/v1/stats")
+        assert r1.status_code == 200
+        assert r2.status_code == 200
+        assert r3.status_code == 429
+        assert "Retry-After" in r3.headers


### PR DESCRIPTION
Closes #186.

## Summary
- Adds an in-memory token-bucket limiter (`src/rate_limit.py`) keyed off `request.state.api_key_email` (set by `verify_v1_key`). Default: 60 req/min sustained, burst of 10. Over-limit → `429` with `Retry-After`.
- Wired as a second router-level dependency on `/v1/`, after `verify_v1_key`, so the limiter has the resolved email/identity to bucket on.
- Configurable via `API_RATE_LIMIT_ENABLED`, `API_RATE_LIMIT_PER_MINUTE`, `API_RATE_LIMIT_BURST`. Disabled when `settings.debug` is true (local dev) and when explicitly off.
- `"internal"` sentinel (the frontend SSR path) always bypasses — internal traffic stays unmetered.
- Public API docs string in `app.py` updated to describe the policy instead of saying "no limits today".

## Storage scope (relevant to #187)
Buckets live in-process. With `desired_count=1` today, that's fine. When the API scales to >1 task (#187), each task tracks its own buckets — effective cluster-wide rate is N× per-task. That's acceptable for current scale; swap to Redis-backed if/when it matters.

## Tests
- `TestTokenBucketLimiter` — bucket math: burst, refill, independent keys, internal bypass, refill-over-time, config validation.
- `TestEnforceRateLimitDependency` — dependency behaviour: no-op when no limiter installed, 429 with `Retry-After`, internal bypass.
- `TestV1RateLimitHttp` — HTTP integration: third request to `/v1/stats` with burst=2 returns 429 with `Retry-After` set.

## Test plan
- [ ] CI green (ruff/mypy/bandit/pytest backend)
- [ ] After merge + deploy, replay the stress test from issue #186 — expect: `c=10` against `/v1/search` returns mostly 429s after the first ~10 requests; `Retry-After` header present
- [ ] Frontend SSR (`/food/...`, `/chemical/...`) keeps working — uses internal key path which bypasses