### PR TITLE
chore(api): hide internal routes from /docs; fix license metadata

### DIFF
--- a/backend/api/src/app.py
+++ b/backend/api/src/app.py
@@ -15,9 +15,7 @@ from src.routes import v1 as v1_routes
 
 PUBLIC_API_DESCRIPTION = """
 FoodAtlas exposes its food-chemical-disease knowledge graph through a
-versioned public REST API under `/v1/`. Internal UI routes (e.g. `/food/`,
-`/chemical/`) are not part of the public contract; use `/v1/` for any
-external integration.
+versioned public REST API under `/v1/`.
 
 ### Authentication
 All `/v1/` requests must include `Authorization: Bearer <key>`. To request
@@ -77,7 +75,7 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
             burst=settings.rate_limit_burst,
         )
 
-    @app.get("/health", tags=["health"])
+    @app.get("/health", tags=["health"], include_in_schema=False)
     async def health() -> dict[str, str]:
         """Liveness probe for the ALB target group (no auth required)."""
         return {"status": "ok"}

--- a/backend/api/src/app.py
+++ b/backend/api/src/app.py
@@ -29,9 +29,11 @@ kicks in). Over-limit requests receive `429 Too Many Requests` with a
 `Retry-After` header indicating when capacity will be available again.
 
 ### Versioning & terms
-Endpoints under `/v1/` follow a stable contract. Use is intended for
-academic and non-commercial research. Cite FoodAtlas in any published work
-that uses this data.
+Endpoints under `/v1/` follow a stable contract. FoodAtlas is a publicly
+funded research project (USDA-NSF); its data and code are released under
+the Apache 2.0 license, which permits both academic and commercial use.
+A citation in any published work that uses this data is appreciated but
+not required.
 """.strip()
 
 
@@ -57,7 +59,10 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
         version="1.0.0",
         description=PUBLIC_API_DESCRIPTION,
         contact={"name": "FoodAtlas Team", "email": "aifs@ucdavis.edu"},
-        license_info={"name": "Academic use only"},
+        license_info={
+            "name": "Apache License 2.0",
+            "url": "https://www.apache.org/licenses/LICENSE-2.0",
+        },
         lifespan=lifespan,
     )
 

--- a/backend/api/src/routes/chemical.py
+++ b/backend/api/src/routes/chemical.py
@@ -6,7 +6,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.dependencies import get_db, verify_api_key
 from src.repositories import chemical, taxonomy
 
-router = APIRouter(prefix="/chemical", dependencies=[Depends(verify_api_key)])
+router = APIRouter(
+    prefix="/chemical",
+    dependencies=[Depends(verify_api_key)],
+    include_in_schema=False,
+)
 
 
 @router.get("/metadata")

--- a/backend/api/src/routes/disease.py
+++ b/backend/api/src/routes/disease.py
@@ -6,7 +6,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.dependencies import get_db, verify_api_key
 from src.repositories import disease, taxonomy
 
-router = APIRouter(prefix="/disease", dependencies=[Depends(verify_api_key)])
+router = APIRouter(
+    prefix="/disease",
+    dependencies=[Depends(verify_api_key)],
+    include_in_schema=False,
+)
 
 
 @router.get("/metadata")

--- a/backend/api/src/routes/download.py
+++ b/backend/api/src/routes/download.py
@@ -6,7 +6,10 @@ from src.config import APISettings
 from src.dependencies import get_settings, verify_api_key
 from src.repositories import downloads
 
-router = APIRouter(dependencies=[Depends(verify_api_key)])
+router = APIRouter(
+    dependencies=[Depends(verify_api_key)],
+    include_in_schema=False,
+)
 
 
 @router.get("/download")

--- a/backend/api/src/routes/food.py
+++ b/backend/api/src/routes/food.py
@@ -11,7 +11,11 @@ from src.repositories import food, taxonomy
 if TYPE_CHECKING:
     from src.repositories.trust_filter import TrustMode
 
-router = APIRouter(prefix="/food", dependencies=[Depends(verify_api_key)])
+router = APIRouter(
+    prefix="/food",
+    dependencies=[Depends(verify_api_key)],
+    include_in_schema=False,
+)
 
 _VALID_TRUST_MODES = ("default", "show_all", "low_only")
 

--- a/backend/api/src/routes/metadata.py
+++ b/backend/api/src/routes/metadata.py
@@ -6,7 +6,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from src.dependencies import get_db, verify_api_key
 from src.repositories import search as search_repo
 
-router = APIRouter(prefix="/metadata", dependencies=[Depends(verify_api_key)])
+router = APIRouter(
+    prefix="/metadata",
+    dependencies=[Depends(verify_api_key)],
+    include_in_schema=False,
+)
 
 
 @router.get("/search")

--- a/backend/api/src/routes/resolve.py
+++ b/backend/api/src/routes/resolve.py
@@ -6,7 +6,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.dependencies import get_db, verify_api_key
 
-router = APIRouter(prefix="/resolve", dependencies=[Depends(verify_api_key)])
+router = APIRouter(
+    prefix="/resolve",
+    dependencies=[Depends(verify_api_key)],
+    include_in_schema=False,
+)
 
 
 @router.get("")


### PR DESCRIPTION
Two related cleanups to what's advertised at `api.foodatlas.ai/docs` and in `/openapi.json`.

## 1. Hide internal routes from /docs and /openapi.json
Adds `include_in_schema=False` to the six internal routers (`/food`, `/chemical`, `/disease`, `/metadata`, `/resolve`, `/download`) and to the `/health` liveness endpoint.

These routes still work — they continue to be auth'd by the internal `API_KEY` (`verify_api_key`) and serve the frontend SSR path. They're just no longer enumerated in the public docs.

Before: 34 paths in `/openapi.json` (15 internal + 19 `/v1/*`).
After: 19 paths (all `/v1/*`).

The internal routes already 401 any non-internal Bearer token, so public-key holders can't call them. The leak this closes is purely *discoverability* — endpoints showing up in the public docs page even though no public caller could use them.

## 2. Align OpenAPI license metadata with the actual repo license
The OpenAPI description said *"academic and non-commercial research"* and `license_info` advertised *"Academic use only"*, but:
- `LICENSE` in the repo root: **Apache 2.0**
- `frontend/app/(everything-else)/food-composition-api/page.tsx:29-34`: states the data is released under **Apache 2.0**
- `frontend/app/(everything-else)/food-composition-downloads/page.tsx:53-58`: same

So the API was the odd one out, and the "non-commercial" claim contradicted what the project actually licenses under. This commit aligns the three:
- `license_info` → `Apache License 2.0` + url
- Description notes the project is publicly funded (USDA-NSF) and that the license permits both academic and commercial use; citation appreciated but not required

## Test plan
- [ ] CI green
- [ ] After deploy, `curl https://api.foodatlas.ai/openapi.json | jq '.paths | keys'` shows only `/v1/*`
- [ ] `/docs` page renders the Apache 2.0 license link and lists only the public surface
- [ ] Frontend keeps working (calls internal routes directly with the internal key — schema visibility doesn't affect runtime)