### PR TITLE
feat(infra): auto-scale API and bump capacity (closes #187)

### DIFF
--- a/infra/aws/stacks/api_stack.py
+++ b/infra/aws/stacks/api_stack.py
@@ -113,11 +113,15 @@ class ApiStack(cdk.Stack):
             ),
         )
 
+        # 0.5 vCPU / 1 GB — the smallest Fargate tier (0.25/512) was
+        # starvation-prone under any concurrent load (see stress-test in
+        # issue #187). One step up gives headroom without changing cost
+        # category materially.
         task_definition = ecs.FargateTaskDefinition(
             self,
             "ApiTaskDefinition",
-            cpu=256,
-            memory_limit_mib=512,
+            cpu=512,
+            memory_limit_mib=1024,
             runtime_platform=ecs.RuntimePlatform(
                 cpu_architecture=ecs.CpuArchitecture.X86_64,
                 operating_system_family=ecs.OperatingSystemFamily.LINUX,
@@ -176,7 +180,11 @@ class ApiStack(cdk.Stack):
         service_kwargs: dict[str, Any] = {
             "cluster": self.cluster,
             "task_definition": task_definition,
-            "desired_count": 1,
+            # Baseline of 2 tasks gives HA across deploys (min_healthy=100
+            # means rolling deploys never drop below this) and ~headroom
+            # for one task's worth of measured saturation (~50 RPS).
+            # Autoscaling configured below takes us up to 6 if load grows.
+            "desired_count": 2,
             "min_healthy_percent": 100,
             "public_load_balancer": True,
             "assign_public_ip": True,
@@ -211,6 +219,24 @@ class ApiStack(cdk.Stack):
             timeout=Duration.seconds(5),
             healthy_threshold_count=2,
             unhealthy_threshold_count=3,
+        )
+
+        # Auto-scale on ALB request rate. Target 1800 req/min/task (= 30
+        # RPS/task) — about half of the per-task saturation measured in
+        # the stress test (issue #187), giving us a buffer before
+        # latency degrades. Scale-out is aggressive (1 min cooldown);
+        # scale-in is conservative (3 min) so transient dips don't churn
+        # tasks.
+        scaling = self.service.service.auto_scale_task_count(
+            min_capacity=2,
+            max_capacity=6,
+        )
+        scaling.scale_on_request_count(
+            "ApiRequestRateScaling",
+            requests_per_target=1800,
+            target_group=self.service.target_group,
+            scale_in_cooldown=Duration.seconds(180),
+            scale_out_cooldown=Duration.seconds(60),
         )
 
         scheme = "https" if cert_arn else "http"

--- a/infra/aws/tests/test_api_stack.py
+++ b/infra/aws/tests/test_api_stack.py
@@ -60,10 +60,52 @@ def test_task_definition_has_correct_cpu_and_memory() -> None:
         "AWS::ECS::TaskDefinition",
         Match.object_like(
             {
-                "Cpu": "256",
-                "Memory": "512",
+                "Cpu": "512",
+                "Memory": "1024",
                 "NetworkMode": "awsvpc",
                 "RequiresCompatibilities": ["FARGATE"],
+            },
+        ),
+    )
+
+
+def test_service_baseline_desired_count_is_two() -> None:
+    template = _synth()
+    template.has_resource_properties(
+        "AWS::ECS::Service",
+        Match.object_like({"DesiredCount": 2}),
+    )
+
+
+def test_autoscaling_configured_min_two_max_six() -> None:
+    template = _synth()
+    template.has_resource_properties(
+        "AWS::ApplicationAutoScaling::ScalableTarget",
+        Match.object_like(
+            {
+                "MinCapacity": 2,
+                "MaxCapacity": 6,
+                "ServiceNamespace": "ecs",
+            },
+        ),
+    )
+
+
+def test_autoscaling_targets_alb_request_rate() -> None:
+    template = _synth()
+    template.has_resource_properties(
+        "AWS::ApplicationAutoScaling::ScalingPolicy",
+        Match.object_like(
+            {
+                "PolicyType": "TargetTrackingScaling",
+                "TargetTrackingScalingPolicyConfiguration": Match.object_like(
+                    {
+                        "TargetValue": 1800,
+                        "PredefinedMetricSpecification": Match.object_like(
+                            {"PredefinedMetricType": "ALBRequestCountPerTarget"},
+                        ),
+                    },
+                ),
             },
         ),
     )


### PR DESCRIPTION
Closes #187.

## Summary
- **Task size**: `cpu=256, memory_limit_mib=512` → `cpu=512, memory_limit_mib=1024`. The smallest Fargate tier (0.25 vCPU) was starvation-prone under any concurrent load — see the stress-test numbers in #187.
- **Baseline**: `desired_count=1` → `desired_count=2`. HA across rolling deploys (`min_healthy_percent=100` keeps at least 2 healthy during deploys) and one task's worth of headroom before autoscale kicks in.
- **Autoscale**: 2 → 6 tasks on `ALBRequestCountPerTarget`, target **1800 req/min/task (= 30 RPS/task)**. That's ~half of the per-task saturation point measured in #187 (50–90 RPS), so we scale out *before* latency degrades. Scale-out cooldown 60s (responsive), scale-in 180s (conservative — don't churn on dips).

## Cost impact
At 2 tasks × (0.5 vCPU + 1 GB) baseline, on-demand Fargate in us-west-1: roughly **\$28–32/month** vs. ~$7 for the current 1 × (0.25 + 0.5). Scaling to the max 6 tasks would briefly land around \$85/month. Numbers are best-effort — confirm in the next billing cycle.

## Tests
- `test_task_definition_has_correct_cpu_and_memory` — updated assertion for 512/1024.
- `test_service_baseline_desired_count_is_two` (new) — confirms `DesiredCount=2`.
- `test_autoscaling_configured_min_two_max_six` (new) — confirms the `AWS::ApplicationAutoScaling::ScalableTarget` is wired with the expected bounds.
- `test_autoscaling_targets_alb_request_rate` (new) — confirms the policy is `TargetTrackingScaling` against `ALBRequestCountPerTarget` with `TargetValue=1800`.

## Test plan
- [ ] CI green
- [ ] CDK deploys via GHA on merge to `main`. ECS rolling deploy keeps `min_healthy_percent=100` — no downtime.
- [ ] After deploy, `aws ecs describe-services --cluster FoodAtlasApiStack-* --services *` shows `desiredCount=2`, two running tasks at 512/1024.
- [ ] Re-run stress test from #186/#187 at `c=100` against `/v1/search`. Expect: tasks scale out within 2-3 min, p95 stays under 2s once scaled.
- [ ] CloudWatch metric `RequestCountPerTarget` is visible on the ALB target group dashboard.