### PR TITLE
docs: clarify local data-loading paths, AWS onboarding, and IE output format

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -32,12 +32,59 @@ PostgreSQL 16 listens on port 5432, database `foodatlas` (user/password: `foodat
 
 ### 2. Load knowledge graph data
 
+`uv run python main.py load` (run from `backend/db`) drops and recreates the schema, then loads KGC parquet from `backend/kgc/outputs/kg` (override with `--parquet-dir`). How you get that parquet depends on your role:
+
+#### Public developers — load the released data
+
+Download the latest data bundle from [foodatlas.ai/food-composition-downloads](https://www.foodatlas.ai/food-composition-downloads), unzip it (it expands to a `foodatlas-<version>/` folder of parquet files), and load it. No AWS account needed.
+
 ```bash
+cd backend/db
+uv run python main.py load --parquet-dir /path/to/foodatlas-<version>
+```
+
+This deploys the prebuilt knowledge graph locally. It does **not** include the raw source data, so you can't regenerate the KG from scratch — if you need that, [contact the FoodAtlas team](https://www.foodatlas.ai/contact).
+
+#### Internal developers (AWS access)
+
+The flows below need AWS credentials with read access to the KGC S3 bucket. One-time setup:
+
+1. Install the [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html).
+2. **Get access** — contact the FoodAtlas admin to be provisioned a login. They'll give you the SSO start URL + account ID + region (or static access keys). Read-only S3 access is enough for the pull scripts here; deploying infrastructure needs broader access (see [`infra/README.md`](infra/README.md)).
+3. Configure and sign in:
+   ```bash
+   aws configure sso            # or `aws configure` for static keys
+   aws sso login                # if using SSO
+   aws sts get-caller-identity  # verify you're authenticated
+   ```
+
+Once authenticated, choose one of the two paths below.
+
+**Pull a prebuilt KG** (fast — skip the pipeline). Download the latest published KG outputs and load them:
+
+```bash
+# Pulls outputs/<version>/kg/ into backend/kgc/data/PreviousFAKG/<version>/
+# (the script prints the exact <version> path it wrote)
+backend/kgc/scripts/pull-from-s3.sh
+
+cd backend/db
+uv run python main.py load --parquet-dir ../kgc/data/PreviousFAKG/<version>
+```
+
+**Build the KG yourself** (when changing the KGC/IE pipeline). Pull the source data, run the pipeline, then load:
+
+```bash
+# 1. Pull source data into backend/kgc/data/ (run from repo root)
+backend/kgc/scripts/pull-data-from-s3.sh
+
+# 2. Run the KGC pipeline to produce backend/kgc/outputs/kg (see backend/kgc/README.md)
+
+# 3. Load it
 cd backend/db
 uv run python main.py load
 ```
 
-Drops and recreates the schema from the SQLAlchemy models, then loads KGC parquet output. See [`backend/kgc/README.md`](backend/kgc/README.md) to generate the parquet locally, or [`infra/README.md`](infra/README.md) to pull a published version from S3.
+To load into the **production** database instead of local Postgres, see [`infra/README.md`](infra/README.md).
 
 ### 3. Start the API
 

--- a/backend/db/README.md
+++ b/backend/db/README.md
@@ -9,13 +9,19 @@ Requires a running PostgreSQL instance (see [root README](../../README.md) for D
 ```bash
 uv sync
 
-# Load KGC parquet output into the database (drops + recreates schema)
+# Load KGC parquet output into the database (drops + recreates schema).
+# Defaults to reading backend/kgc/outputs/kg.
 uv run python main.py load
+
+# Load from a downloaded release bundle (or any other parquet dir).
+uv run python main.py load --parquet-dir /path/to/foodatlas-<version>
 
 # Rebuild materialized views from existing base tables (skip parquet
 # read + base inserts). Use when iterating on materializer logic.
 uv run python main.py refresh
 ```
+
+To load the latest **published** data with no AWS account, see the "Load the latest released bundle" option in [`DEVELOPER.md`](../../DEVELOPER.md) — it fetches the public bundle and points `--parquet-dir` at it.
 
 ## Production
 

--- a/backend/ie/README.md
+++ b/backend/ie/README.md
@@ -2,7 +2,7 @@
 
 End-to-end pipeline for extracting food–chemical relationships from the biomedical literature. Starting from a list of food terms, the pipeline searches PubMed/PMC, filters candidate sentences with a fine-tuned BioBERT classifier, and extracts structured triplets (`food, food_part, chemical, concentration`) using an LLM via the OpenAI Batch API.
 
-The output TSV is consumed by KGC's `ie` stage (see [`backend/kgc/src/pipeline/ie/`](../kgc/src/pipeline/ie/)).
+The output (`extraction_predicted.json`) is consumed by KGC's `ie` stage (see [`backend/kgc/src/pipeline/ie/`](../kgc/src/pipeline/ie/)).
 
 ---
 
@@ -66,7 +66,7 @@ For a full monthly run, the canonical orchestrator is [`infra/local/scripts/run_
 | 0 | `CORPUS` | `src/pipeline/corpus/` | Refresh the local BioC-PMC corpus and the `PMC-ids.csv` mapping |
 | 1 | `SEARCH` | `src/pipeline/search/` | Query PubMed for each food term, retrieve and fuzzy-match sentences from BioC-PMC |
 | 2 | `FILTERING` | `src/pipeline/filtering/` | BioBERT binary classifier (GPU) + threshold + dedup against historical predictions |
-| 3 | `EXTRACTION` | `src/pipeline/extraction/` | Submit filtered sentences to the OpenAI Batch API; parse responses into `extraction_predicted.tsv` |
+| 3 | `EXTRACTION` | `src/pipeline/extraction/` | Submit filtered sentences to the OpenAI Batch API; parse responses into `extraction_predicted.json` (a TSV is written first, then converted) |
 
 Per-stage runners live at `src/pipeline/<stage>/runner.py`. The top-level `IERunner` (`src/pipeline/runner.py`) dispatches them in order.
 

--- a/backend/kgc/README.md
+++ b/backend/kgc/README.md
@@ -62,7 +62,7 @@ The `trust` stage additionally needs `GOOGLE_API_KEY` set in the **root** `.env`
 | 0 | `ingest` | Parse external sources into standardized parquet (`nodes`, `edges`, `xrefs`) per source |
 | 1 | `entities` | Subtree filter + multi-pass entity resolution (food, chemical, disease) |
 | 2 | `triplets` | Build ontology `is_a` (food/chemical/disease) + composition (`food → chemical`) + chemical–disease correlation triplets from ingest edges |
-| 3 | `ie` | Fold IE TSV output (from `backend/ie/`) into the KG: parse concentrations, resolve raw food/chemical names, attach attestations |
+| 3 | `ie` | Fold IE output (from `backend/ie/`) into the KG: parse concentrations, resolve raw food/chemical names, attach attestations |
 | 4 | `enrichment` | Chemical/food classification (ChEBI/FoodOn-driven), grouping, common names, synonym display, flavor descriptions |
 | 5 | `trust` | Per-attestation trustworthiness signals (e.g. LLM plausibility judge). Reads attestations + evidence, runs the configured judge, writes `trust_signals.parquet`. Requires `GOOGLE_API_KEY` for the v1 Gemini provider. Configured via `pipeline.stages.trust` in the config JSON. |
 
@@ -74,7 +74,7 @@ The `trust` stage additionally needs `GOOGLE_API_KEY` set in the **root** `.env`
 
 - **EntityRunner**: Loads ingest sources → filters ontology subtrees → multi-pass resolution (primary from authoritative sources; secondary linked via xrefs; unlinked entities created) → saves entities + lookup tables.
 - **TripletRunner**: Loads ingest sources → walks ingest edges to build typed triplets (`food_food`, `food_chemical`, `chemical_chemical`, `chemical_disease`, `disease_disease`) → writes `triplets.parquet` + per-triplet `evidence.parquet` and `attestations.parquet`.
-- **IERunner**: Reads `backend/ie/outputs/extraction/<date>/extraction_predicted.tsv`, parses concentrations, resolves food/chemical names against the entity LUTs, and folds new triplets + attestations into the KG. Ambiguous resolutions are written separately to `attestations_ambiguous.parquet`.
+- **IERunner**: Reads `backend/ie/outputs/extraction/<date>/extraction_predicted.json`, parses concentrations, resolves food/chemical names against the entity LUTs, and folds new triplets + attestations into the KG. Ambiguous resolutions are written separately to `attestations_ambiguous.parquet`.
 - **Enrichment**: Adds derived attributes (chemical classification, food classification, synonym display, flavors) and grouping artifacts. Writes outputs into `outputs/kg/intermediate/` and back-fills entity rows.
 - **TrustRunner**: Per-attestation trustworthiness signals (v1 LLM-plausibility judge using Gemini 2.5 Flash-Lite; future: faithfulness, range checks). Reads attestations + evidence, runs the configured judge, writes `trust_signals.parquet`. Configured under `pipeline.stages.trust` in the config JSON; needs `GOOGLE_API_KEY` for the v1 Gemini provider. The DB loader upserts these into a separate `TrustBase` table so signals survive `db load` rebuilds. See `scripts/spot_check_food.py` for ad-hoc per-food calibration runs that bypass the persistent parquet.
 

--- a/backend/kgc/src/pipeline/ie/runner.py
+++ b/backend/kgc/src/pipeline/ie/runner.py
@@ -69,7 +69,7 @@ class IERunner:
     def _discover_ie_files(self) -> list[tuple[str, Path]]:
         """Scan ie_raw_dir for extraction files with model metadata.
 
-        Each subdirectory should contain ``extraction_predicted.tsv``
+        Each subdirectory should contain ``extraction_predicted.json``
         and optionally ``run_info.json`` with a ``model`` key.
         Returns a list of ``(method, path)`` pairs.
         """


### PR DESCRIPTION
## Summary

Documentation-only pass on the local-setup story. Closes the gap where a first-time developer following the root README → DEVELOPER.md couldn't actually get the latest data into a local stack, and corrects an IE output-format mismatch found along the way.

## What changed

**`DEVELOPER.md` — "Load knowledge graph data" reworked into role-based paths:**
- **Public developers** — download the released bundle from [foodatlas.ai/food-composition-downloads](https://www.foodatlas.ai/food-composition-downloads), unzip, and `load --parquet-dir`. No AWS account. Notes it's a prebuilt KG (no raw source data) and to contact the team if raw data is needed.
- **Internal developers (AWS access)** — a one-time AWS access setup block (install CLI → "contact the admin" for the grant → `aws configure sso` / `aws sso login` / verify), then two paths: **pull a prebuilt KG** (`pull-from-s3.sh`) or **build it** (`pull-data-from-s3.sh` → run KGC → load).
- Documents the `--parquet-dir` flag and separates the production RDS load (`run-data-load.sh`, deploy-time, not local) from local setup.

**IE output format `.tsv` → `.json` (docs/docstring only):**
- IE writes a TSV first, then converts it to `extraction_predicted.json`, which is what KGC's `ie` stage actually consumes (the discovery glob already reads `.json`). Corrected the stale `.tsv` references in `backend/kgc/src/pipeline/ie/runner.py` (docstring), `backend/kgc/README.md`, and `backend/ie/README.md`.

**`backend/db/README.md`** — note the default parquet dir and add a `--parquet-dir` example.

## Notes

- No behavior change: four Markdown files plus one Python docstring.
- `data/download.sh` is intentionally no longer referenced in DEVELOPER.md (public devs use the released bundle; raw-data access is gated).

## Related follow-ups (not resolved here)

- #193 — retire `data/download.sh` in favor of `pull-data-from-s3.sh`
- #194 — rename misleading `tsv` loop variable in `kgc/.../ie/runner.py`
- #195 — KG built without IE outputs is silently ontology-only; no way to fetch prebuilt IE outputs