### PR TITLE
feat: v4.1 release — frontend announcement, KGC report/trust fixes, I…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,6 +74,8 @@ docs/_build/
 # PyBuilder
 target/
 
+#local-use documents
+local_docs/
 # Jupyter Notebook
 .ipynb_checkpoints
 

--- a/backend/api/main.py
+++ b/backend/api/main.py
@@ -9,4 +9,5 @@ if __name__ == "__main__":
     # Auto-reload for local development (API_DEBUG=True); disabled in
     # production containers where API_DEBUG=False.
     reload = os.environ.get("API_DEBUG", "True").lower() == "true"
-    uvicorn.run("src.app:app", host=host, port=8000, reload=reload)
+    port = int(os.environ.get("API_PORT", "8000"))
+    uvicorn.run("src.app:app", host=host, port=port, reload=reload)

--- a/backend/kgc/scripts/sync-outputs-to-s3.sh
+++ b/backend/kgc/scripts/sync-outputs-to-s3.sh
@@ -79,6 +79,13 @@ echo "$MANIFEST" | aws s3 cp - "${DEST}manifest.json" --region "$REGION"
 echo "Updating outputs/LATEST -> $VERSION"
 echo -n "$VERSION" | aws s3 cp - "s3://$BUCKET/outputs/LATEST" --region "$REGION"
 
+# Snapshot current kg/ outputs as the new PreviousFAKG reference so the
+# next 'uv run python main.py report' can diff against this release.
+SNAPSHOT_DIR="data/PreviousFAKG/$VERSION"
+echo "Snapshotting outputs/kg/ -> $SNAPSHOT_DIR"
+mkdir -p "$SNAPSHOT_DIR"
+cp outputs/kg/*.parquet "$SNAPSHOT_DIR/"
+
 echo
 echo "Done. KGC outputs version: $VERSION"
 echo "Load this version into RDS with:"

--- a/backend/kgc/src/pipeline/ie/conc_parser.py
+++ b/backend/kgc/src/pipeline/ie/conc_parser.py
@@ -84,7 +84,7 @@ def parse_conc(raw: str) -> tuple[str, str] | None:
         return None
 
     value_str = m.group(1)
-    unit_str = m.group(2)
+    unit_str = _normalize_unit(m.group(2))
 
     # Unit must contain at least one letter-like char or '%'.
     if not unit_str or not any(c.isalpha() or c == "%" for c in unit_str):
@@ -120,6 +120,57 @@ _VOLUME: dict[str, float] = {
     "ul": 1e-6,
     "μl": 1e-6,
 }
+
+# Superscript minus-one suffixes: U+2212 MINUS SIGN and U+2013 EN DASH.
+_SUPERSCRIPT_M1 = ("\u22121", "\u20131")
+
+# All known units sorted longest-first for greedy prefix matching.
+_UNIT_LIST: list[str] = sorted(
+    list(_MASS.keys()) + list(_VOLUME.keys()),
+    key=len,
+    reverse=True,
+)
+
+
+def _split_concatenated_units(s: str) -> str:
+    """Convert concatenated unit pair 'XY' or 'X{n}Y' to 'X/{n}Y'.
+
+    Used after stripping a superscript -1 suffix (U+2212/U+2013), e.g. 'mgkg' → 'mg/kg',
+    'mg100g' → 'mg/100g'. Returns *s* unchanged if no split is found.
+    """
+    for num_unit in _UNIT_LIST:
+        if not s.startswith(num_unit):
+            continue
+        rest = s[len(num_unit) :]
+        m = re.match(r"^(\d*)(.+)$", rest)
+        if not m:
+            continue
+        factor_str, den_unit = m.group(1), m.group(2).lower()
+        if den_unit in _MASS or den_unit in _VOLUME:
+            den = f"{factor_str}{den_unit}" if factor_str else den_unit
+            return f"{num_unit}/{den}"
+    return s
+
+
+def _normalize_unit(unit_str: str) -> str:
+    """Normalise non-standard unit notation to 'X/{n}Y' form.
+
+    Handles:
+    - Middle-dot separator: mg*kg-1 -> mg/kg
+    - Superscript minus-one: mgkg-1 -> mg/kg, mg100g-1 -> mg/100g
+    - No-space 'per': ``mgper100g`` → ``mg/100g``
+    """
+    s = unit_str.replace("·", "/")
+    # Replace 'per' used as separator between unit letters/digits.
+    s = re.sub(r"(?<=[a-zA-Zµμ])per(?=\d*[a-zA-Zµμ])", "/", s)
+    for suffix in _SUPERSCRIPT_M1:
+        if s.endswith(suffix):
+            s = s[: -len(suffix)]
+            if "/" not in s:
+                s = _split_concatenated_units(s)
+            break
+    return s
+
 
 # Maximum plausible mg/100g (sanity check).
 _MAX_MG_100G = 1e5
@@ -169,6 +220,8 @@ def _convert_unit(unit_str: str) -> float | None:
         if clean.lower().endswith(suffix):
             clean = clean[: -len(suffix)].strip()
             break
+
+    clean = _normalize_unit(clean)
 
     if clean == "%":
         return None

--- a/backend/kgc/src/pipeline/ie/loader.py
+++ b/backend/kgc/src/pipeline/ie/loader.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import csv as _csv
+import io as _io
 import json
 import logging
 from typing import TYPE_CHECKING
@@ -33,32 +35,33 @@ def standardize_name(name: str) -> str:
 
 
 def _parse_tuple(line: str) -> tuple[str, str, str, str] | None:
-    """Extract (food, food_part, chemical, quantity) from a response line.
+    """Parse a response line in 3-field (v3: food,chemical,concentration) or
+    4-field (legacy: food,food_part,chemical,concentration) CSV format.
 
-    Chemical names may contain commas (e.g. ``3,4-dihydroxyphenylethanol``),
-    so we split on the first two commas and the last comma.
+    Uses csv.reader so quoted fields with internal commas parse correctly.
     """
     inner = line.strip().lstrip("(").rstrip(")")
     if not inner:
         return None
-
-    parts = inner.split(",", 2)
-    if len(parts) < 3:
+    try:
+        parts = [p.strip() for p in next(_csv.reader(_io.StringIO(inner)))]
+    except StopIteration:
         return None
 
-    food = parts[0].strip()
-    food_part = parts[1].strip()
-    rest = parts[2]
+    # Skip CSV header rows emitted by v3 model.
+    if parts and parts[0].lower() == "food":
+        return None
 
-    last_comma = rest.rfind(",")
-    if last_comma == -1:
-        chemical = rest.strip()
-        quantity = ""
+    if len(parts) == 3:
+        food, chemical, quantity = parts
+        food_part = ""
+    elif len(parts) >= 4:
+        food, food_part = parts[0], parts[1]
+        chemical = ",".join(parts[2:-1])
+        quantity = parts[-1]
     else:
-        chemical = rest[:last_comma].strip()
-        quantity = rest[last_comma + 1 :].strip()
+        return None
 
-    # Take first pipe-separated alias as the primary name.
     if "|" in chemical:
         chemical = chemical.split("|")[0].strip()
 
@@ -72,22 +75,26 @@ def _process_line(
     line: str,
     rec: pd.Series,
     rows: list[dict],
-    parse_errors: list[dict],
-    conc_errors: list[dict],
+    errors: tuple[list[dict], list[dict]],
     *,
     method: str,
 ) -> None:
-    """Parse one response line into a row dict, or log an error."""
+    """Parse one response line into a row dict, or log an error.
+
+    ``errors`` is ``(parse_errors, conc_errors)`` passed as one arg to stay
+    within the project's 5-argument limit.
+    """
     parsed = _parse_tuple(line)
     if parsed is None:
-        parse_errors.append(
+        errors[0].append(
             {"pmcid": rec["pmcid"], "line": line.strip(), "reason": "bad_tuple"}
         )
         return
     food, food_part, chemical, quantity = parsed
-    conc_value_raw, conc_unit_raw = _parse_quantity(quantity, rec, parse_errors)
+    food_norm, chem_norm = standardize_name(food), standardize_name(chemical)
+    conc_value_raw, conc_unit_raw = _parse_quantity(quantity, rec, errors[0])
     conc_value_converted, conc_unit_converted = _convert_quantity(
-        conc_value_raw, conc_unit_raw, rec, conc_errors
+        conc_value_raw, conc_unit_raw, rec, errors[1]
     )
     ref = json.dumps({"pmcid": rec["pmcid"], "text": rec.get("sentence", "")})
     rows.append(
@@ -95,8 +102,8 @@ def _process_line(
             "source_type": "pubmed",
             "reference": ref,
             "source": f"lit2kg:{method}",
-            "head_name_raw": standardize_name(food),
-            "tail_name_raw": standardize_name(chemical),
+            "head_name_raw": food_norm,
+            "tail_name_raw": chem_norm,
             "conc_value": conc_value_converted,
             "conc_unit": conc_unit_converted,
             "conc_value_raw": conc_value_raw,
@@ -104,8 +111,8 @@ def _process_line(
             "food_part": food_part.strip().lower(),
             "food_processing": "",
             "filter_score": float(rec["prob"]),
-            "_food_name": standardize_name(food),
-            "_chemical_name": standardize_name(chemical),
+            "_food_name": food_norm,
+            "_chemical_name": chem_norm,
         }
     )
 
@@ -202,7 +209,7 @@ def load_ie_raw(path: Path, output_dir: Path, *, method: str) -> pd.DataFrame:
             )
             continue
         for line in response.split("\n"):
-            _process_line(line, rec, rows, parse_errors, conc_errors, method=method)
+            _process_line(line, rec, rows, (parse_errors, conc_errors), method=method)
 
     if parse_errors:
         errors_path = output_dir / FILE_IE_PARSE_ERRORS

--- a/backend/kgc/src/pipeline/report/load_old.py
+++ b/backend/kgc/src/pipeline/report/load_old.py
@@ -1,12 +1,10 @@
-"""Load old v3.3 KG TSV files into normalized DataFrames."""
+"""Load previous KG snapshot (parquet) for changelog comparison."""
 
 from __future__ import annotations
 
-import ast
 import logging
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
 
 import pandas as pd
 
@@ -23,57 +21,50 @@ class OldKG:
     metadata_diseases_sources: pd.Series
 
 
-def _safe_literal(val: Any) -> Any:
-    """Parse a Python literal string, returning None on failure."""
-    try:
-        return ast.literal_eval(str(val))
-    except (ValueError, SyntaxError):
-        return None
-
-
-def load_old_entities(path: Path) -> pd.DataFrame:
-    """Load ``entities.tsv`` and parse list/dict columns."""
-    df = pd.read_csv(path, sep="\t")
-    df["synonyms"] = df["synonyms"].apply(_safe_literal)
-    df["external_ids"] = df["external_ids"].apply(_safe_literal)
-    return df.set_index("foodatlas_id")
-
-
-def load_old_triplets(path_triplets: Path, path_ontology: Path) -> pd.DataFrame:
-    """Load ``triplets.tsv`` + ``food_ontology.tsv`` and combine."""
-    cols = ["head_id", "relationship_id", "tail_id"]
-    t = pd.read_csv(path_triplets, sep="\t", usecols=cols)
-    o = pd.read_csv(path_ontology, sep="\t", usecols=cols)
-    return pd.concat([t, o], ignore_index=True)
+def _latest_snapshot(data_dir: str) -> Path:
+    """Return the most recent snapshot directory under PreviousFAKG/."""
+    base = Path(data_dir) / "PreviousFAKG"
+    snapshots = sorted(
+        [d for d in base.iterdir() if d.is_dir() and not d.is_symlink()],
+        key=lambda d: d.name,
+    )
+    if not snapshots:
+        raise FileNotFoundError(f"No snapshots found under {base}")
+    return snapshots[-1]
 
 
 def load_old_kg(data_dir: str) -> OldKG:
-    """Load all old v3.3 KG files from *data_dir*/PreviousFAKG/v3.3."""
-    base = Path(data_dir) / "PreviousFAKG" / "v3.3"
-    entities = load_old_entities(base / "entities.tsv")
-    triplets = load_old_triplets(
-        base / "triplets.tsv",
-        base / "food_ontology.tsv",
+    """Load the latest KG snapshot from data_dir/PreviousFAKG/<latest>/."""
+    snapshot = _latest_snapshot(data_dir)
+    logger.info("Loading previous KG snapshot from %s", snapshot)
+
+    entities = pd.read_parquet(snapshot / "entities.parquet")
+    if "foodatlas_id" in entities.columns:
+        entities = entities.set_index("foodatlas_id")
+
+    triplets = pd.read_parquet(
+        snapshot / "triplets.parquet",
+        columns=["head_id", "relationship_id", "tail_id"],
     )
-    mc = pd.read_csv(
-        base / "metadata_contains.tsv",
-        sep="\t",
-        usecols=["source"],
-        low_memory=False,
+
+    attestations = pd.read_parquet(
+        snapshot / "attestations.parquet", columns=["source"]
     )
-    md = pd.read_csv(
-        base / "metadata_diseases.tsv",
-        sep="\t",
-        usecols=["source"],
-    )
+    # Split attestations into contains (non-CTD) and diseases (CTD) to
+    # approximate the old metadata_contains / metadata_diseases TSV split.
+    attestations["source"] = attestations["source"].astype(str)
+    is_ctd = attestations["source"].str.startswith("ctd")
+    contains_sources = attestations[~is_ctd]["source"].value_counts()
+    diseases_sources = attestations[is_ctd]["source"].value_counts()
+
     logger.info(
-        "Loaded old KG: %d entities, %d triplets.",
+        "Loaded old KG snapshot: %d entities, %d triplets.",
         len(entities),
         len(triplets),
     )
     return OldKG(
         entities=entities,
         triplets=triplets,
-        metadata_contains_sources=mc["source"].value_counts(),
-        metadata_diseases_sources=md["source"].value_counts(),
+        metadata_contains_sources=contains_sources,
+        metadata_diseases_sources=diseases_sources,
     )

--- a/backend/kgc/src/pipeline/trust/versions/llm_plausibility/v1.yml
+++ b/backend/kgc/src/pipeline/trust/versions/llm_plausibility/v1.yml
@@ -1,6 +1,6 @@
 signal_kind: llm_plausibility
 description: |
-  Plausibility v1 — Gemini 2.5 Flash-Lite via Gemini Batch API.
+  Plausibility v1 — Gemini 3.1 Flash-Lite via Gemini Batch API.
 
   Scores how plausible an extracted (food, chemical, concentration) claim is
   using world knowledge of food composition. Faithfulness (does the source
@@ -8,7 +8,7 @@ description: |
   out of scope here.
 
 provider: gemini
-model: gemini-2.5-flash-lite
+model: gemini-3.1-flash-lite
 
 generation:
   temperature: 0.0

--- a/backend/kgc/tests/test_conc_parser.py
+++ b/backend/kgc/tests/test_conc_parser.py
@@ -130,3 +130,182 @@ class TestConvertConc:
 
     def test_exceeds_max_returns_none(self) -> None:
         assert convert_conc("999999", "mg/g") is None
+
+
+class TestNormalizeUnit:
+    """Unit normalization: superscript-1 and no-space 'per' notation."""
+
+    # ------------------------------------------------------------------
+    # parse_conc: unit string returned after normalization
+    # ------------------------------------------------------------------
+
+    def test_parse_superscript_mgkg(self) -> None:
+        assert parse_conc("5.0 mgkg\u22121") == ("5.0", "mg/kg")
+
+    def test_parse_superscript_mgg(self) -> None:
+        assert parse_conc("5.0 mgg\u22121") == ("5.0", "mg/g")
+
+    def test_parse_superscript_mg100g(self) -> None:
+        assert parse_conc("2.5 mg100g\u22121") == ("2.5", "mg/100g")
+
+    def test_parse_superscript_ugg(self) -> None:
+        assert parse_conc("1.0 µgg\u22121") == ("1.0", "µg/g")
+
+    def test_parse_superscript_gkg(self) -> None:
+        assert parse_conc("10.0 gkg\u22121") == ("10.0", "g/kg")
+
+    def test_parse_superscript_mgL(self) -> None:
+        assert parse_conc("50.0 mgL\u22121") == ("50.0", "mg/l")
+
+    def test_parse_dot_notation(self) -> None:
+        assert parse_conc("3.0 mg·100g\u22121") == ("3.0", "mg/100g")
+
+    def test_parse_dot_notation_mgg(self) -> None:
+        assert parse_conc("1.5 mg·g\u22121") == ("1.5", "mg/g")
+
+    def test_parse_superscript_en_dash(self) -> None:
+        # U+2013 en-dash variant
+        assert parse_conc("2.0 mgkg\u20131") == ("2.0", "mg/kg")
+
+    def test_parse_superscript_with_fw(self) -> None:
+        assert parse_conc("1.0 mgg\u22121 fw") == ("1.0", "mg/g fw")
+
+    def test_parse_superscript_with_dw(self) -> None:
+        assert parse_conc("2.0 mg100g\u22121 dw") == ("2.0", "mg/100g dw")
+
+    def test_parse_nospace_mgper100g(self) -> None:
+        assert parse_conc("5.0 mgper100g") == ("5.0", "mg/100g")
+
+    def test_parse_nospace_gper100g(self) -> None:
+        assert parse_conc("1.0 gper100g") == ("1.0", "g/100g")
+
+    def test_parse_nospace_mgperg(self) -> None:
+        assert parse_conc("2.0 mgperg") == ("2.0", "mg/g")
+
+    # ------------------------------------------------------------------
+    # convert_conc: end-to-end correctness after normalization
+    # ------------------------------------------------------------------
+
+    def test_convert_mgkg_superscript(self) -> None:
+        val, unit = convert_conc("910", "mgkg\u22121")
+        assert unit == "mg/100g"
+        assert abs(val - 91.0) < 0.01
+
+    def test_convert_mgg_superscript(self) -> None:
+        val, unit = convert_conc("1.5", "mgg\u22121")
+        assert unit == "mg/100g"
+        assert abs(val - 150.0) < 0.01
+
+    def test_convert_mg100g_superscript(self) -> None:
+        val, unit = convert_conc("12.5", "mg100g\u22121")
+        assert unit == "mg/100g"
+        assert abs(val - 12.5) < 0.01
+
+    def test_convert_ugg_superscript(self) -> None:
+        val, unit = convert_conc("60", "µgg\u22121")
+        assert unit == "mg/100g"
+        assert abs(val - 6.0) < 0.01
+
+    def test_convert_gkg_superscript(self) -> None:
+        val, unit = convert_conc("1.0", "gkg\u22121")
+        assert unit == "mg/100g"
+        assert abs(val - 100.0) < 0.01
+
+    def test_convert_dot_mg100g(self) -> None:
+        val, unit = convert_conc("5.0", "mg·100g\u22121")
+        assert unit == "mg/100g"
+        assert abs(val - 5.0) < 0.01
+
+    def test_convert_dot_mgg(self) -> None:
+        val, unit = convert_conc("1.5", "mg·g\u22121")
+        assert unit == "mg/100g"
+        assert abs(val - 150.0) < 0.01
+
+    def test_convert_en_dash_variant(self) -> None:
+        val, unit = convert_conc("910", "mgkg\u20131")
+        assert unit == "mg/100g"
+        assert abs(val - 91.0) < 0.01
+
+    def test_convert_fw_with_superscript(self) -> None:
+        val, unit = convert_conc("12.5", "mgg\u22121 fw")
+        assert unit == "mg/100g"
+        assert abs(val - 1250.0) < 0.01
+
+    def test_convert_mgper100g(self) -> None:
+        val, unit = convert_conc("5.0", "mgper100g")
+        assert unit == "mg/100g"
+        assert abs(val - 5.0) < 0.01
+
+    def test_convert_gper100g(self) -> None:
+        val, unit = convert_conc("1.0", "gper100g")
+        assert unit == "mg/100g"
+        assert abs(val - 1000.0) < 0.01
+
+    def test_convert_mgperg(self) -> None:
+        val, unit = convert_conc("2.0", "mgperg")
+        assert unit == "mg/100g"
+        assert abs(val - 200.0) < 0.01
+
+    # ------------------------------------------------------------------
+    # Regressions: existing units must not be affected by normalization
+    # ------------------------------------------------------------------
+
+    def test_regression_mg_per_g(self) -> None:
+        val, unit = convert_conc("1.5", "mg/g")
+        assert unit == "mg/100g"
+        assert abs(val - 150.0) < 0.01
+
+    def test_regression_mg_per_kg(self) -> None:
+        val, unit = convert_conc("910", "mg/kg")
+        assert unit == "mg/100g"
+        assert abs(val - 91.0) < 0.01
+
+    def test_regression_mg_per_100g(self) -> None:
+        val, unit = convert_conc("12.5", "mg/100g")
+        assert unit == "mg/100g"
+        assert abs(val - 12.5) < 0.01
+
+    def test_regression_ug_per_g(self) -> None:
+        val, unit = convert_conc("60", "µg/g")
+        assert unit == "mg/100g"
+        assert abs(val - 6.0) < 0.01
+
+    def test_regression_g_per_100g(self) -> None:
+        val, unit = convert_conc("1.0", "g/100g")
+        assert unit == "mg/100g"
+        assert abs(val - 1000.0) < 0.01
+
+    def test_regression_fw_suffix(self) -> None:
+        val, unit = convert_conc("12.5", "mg/100g fw")
+        assert unit == "mg/100g"
+        assert abs(val - 12.5) < 0.01
+
+    def test_regression_volume_denom(self) -> None:
+        val, unit = convert_conc("50", "mg/ml")
+        assert unit == "mg/100g"
+        assert abs(val - 5000.0) < 0.01
+
+    def test_regression_percent_still_rejected(self) -> None:
+        assert convert_conc("5", "%") is None
+
+    def test_regression_molar_still_rejected(self) -> None:
+        assert convert_conc("1.5", "mmol/l") is None
+
+    # ------------------------------------------------------------------
+    # Edge cases
+    # ------------------------------------------------------------------
+
+    def test_superscript_unknown_unit_pair_unchanged(self) -> None:
+        # 'xyzabc\u22121' — not a known unit pair, should not convert
+        assert convert_conc("1.0", "xyzabc\u22121") is None
+
+    def test_per_not_replaced_in_percent(self) -> None:
+        # 'percent' — no letter precedes 'per', so no substitution.
+        # parse_conc returns the unit as-is; convert_conc rejects it.
+        assert parse_conc("5percent") == ("5", "percent")
+        assert convert_conc("5", "percent") is None
+
+    def test_ngg_superscript(self) -> None:
+        val, unit = convert_conc("0.5", "ngg\u22121")
+        assert unit == "mg/100g"
+        assert abs(val - 5e-5) < 1e-7

--- a/backend/kgc/tests/test_report_load.py
+++ b/backend/kgc/tests/test_report_load.py
@@ -1,95 +1,98 @@
-"""Tests for report.load_old — loading old v3.3 TSV files."""
+"""Tests for report.load_old — loading KG parquet snapshots."""
 
 from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from src.pipeline.report.load_old import (
-    OldKG,
-    _safe_literal,
-    load_old_entities,
-    load_old_kg,
-    load_old_triplets,
-)
+import pandas as pd
+import pytest
+from src.pipeline.report.load_old import OldKG, load_old_kg
 
 if TYPE_CHECKING:
     from pathlib import Path
 
 
-class TestSafeLiteral:
-    def test_list(self) -> None:
-        assert _safe_literal("['a', 'b']") == ["a", "b"]
+def _write_snapshot(base: Path) -> Path:
+    """Write a minimal parquet snapshot under base/PreviousFAKG/<ts>/."""
+    snapshot = base / "PreviousFAKG" / "20260101T000000Z"
+    snapshot.mkdir(parents=True)
 
-    def test_dict(self) -> None:
-        assert _safe_literal("{'k': [1]}") == {"k": [1]}
+    entities = pd.DataFrame(
+        {
+            "foodatlas_id": ["e1", "e2"],
+            "entity_type": ["food", "chemical"],
+            "common_name": ["apple", "water"],
+            "scientific_name": [None, None],
+        }
+    )
+    entities.to_parquet(snapshot / "entities.parquet", index=False)
 
-    def test_invalid(self) -> None:
-        assert _safe_literal("not a literal") is None
+    triplets = pd.DataFrame(
+        {
+            "head_id": ["e1", "e3"],
+            "relationship_id": ["r1", "r2"],
+            "tail_id": ["e2", "e4"],
+        }
+    )
+    triplets.to_parquet(snapshot / "triplets.parquet", index=False)
 
-    def test_nan(self) -> None:
-        assert _safe_literal("nan") is None
+    attestations = pd.DataFrame({"source": ["fdc", "fdc", "dmd", "ctd"]})
+    attestations.to_parquet(snapshot / "attestations.parquet", index=False)
 
-
-class TestLoadOldEntities:
-    def test_basic(self, tmp_path: Path) -> None:
-        tsv = tmp_path / "entities.tsv"
-        tsv.write_text(
-            "foodatlas_id\tentity_type\tcommon_name\tscientific_name\tsynonyms\texternal_ids\n"
-            "e1\tfood\tpectin\t\t['pectin']\t{'foodon': ['URI1']}\n"
-            "e2\tchemical\twater\t\t['water', 'H2O']\t{'chebi': [1]}\n"
-        )
-        df = load_old_entities(tsv)
-        assert len(df) == 2
-        assert df.index.name == "foodatlas_id"
-        assert df.loc["e1", "synonyms"] == ["pectin"]
-        assert df.loc["e2", "external_ids"] == {"chebi": [1]}
-
-
-class TestLoadOldTriplets:
-    def test_combines_sources(self, tmp_path: Path) -> None:
-        trip = tmp_path / "triplets.tsv"
-        trip.write_text(
-            "foodatlas_id\thead_id\trelationship_id\ttail_id\tmetadata_ids\n"
-            "t1\te1\tr1\te2\t['mc1']\n"
-        )
-        onto = tmp_path / "food_ontology.tsv"
-        onto.write_text(
-            "foodatlas_id\thead_id\trelationship_id\ttail_id\tsource\n"
-            "fo1\te3\tr2\te4\tfoodon\n"
-            "fo2\te5\tr2\te6\tfoodon\n"
-        )
-        df = load_old_triplets(trip, onto)
-        assert len(df) == 3
-        assert list(df.columns) == ["head_id", "relationship_id", "tail_id"]
-        assert df.iloc[0]["relationship_id"] == "r1"
-        assert df.iloc[1]["relationship_id"] == "r2"
+    return snapshot
 
 
 class TestLoadOldKG:
+    """Tests for load_old_kg and related helpers."""
+
     def test_integration(self, tmp_path: Path) -> None:
-        v33 = tmp_path / "PreviousFAKG" / "v3.3"
-        v33.mkdir(parents=True)
-
-        (v33 / "entities.tsv").write_text(
-            "foodatlas_id\tentity_type\tcommon_name\tscientific_name\tsynonyms\texternal_ids\n"
-            "e1\tfood\tapple\t\t['apple']\t{}\n"
-        )
-        (v33 / "triplets.tsv").write_text(
-            "foodatlas_id\thead_id\trelationship_id\ttail_id\tmetadata_ids\n"
-            "t1\te1\tr1\te2\t['mc1']\n"
-        )
-        (v33 / "food_ontology.tsv").write_text(
-            "foodatlas_id\thead_id\trelationship_id\ttail_id\tsource\n"
-        )
-        (v33 / "metadata_contains.tsv").write_text(
-            "foodatlas_id\tsource\nmc1\tfdc\nmc2\tfdc\nmc3\tdmd\n"
-        )
-        (v33 / "metadata_diseases.tsv").write_text("foodatlas_id\tsource\nmd1\tctd\n")
-
+        _write_snapshot(tmp_path)
         kg = load_old_kg(str(tmp_path))
+
         assert isinstance(kg, OldKG)
-        assert len(kg.entities) == 1
-        assert len(kg.triplets) == 1
+        assert len(kg.entities) == 2
+        assert kg.entities.index.name == "foodatlas_id"
+        assert len(kg.triplets) == 2
+
+    def test_contains_sources(self, tmp_path: Path) -> None:
+        _write_snapshot(tmp_path)
+        kg = load_old_kg(str(tmp_path))
+
         assert kg.metadata_contains_sources["fdc"] == 2
         assert kg.metadata_contains_sources["dmd"] == 1
+        assert "ctd" not in kg.metadata_contains_sources
+
+    def test_diseases_sources(self, tmp_path: Path) -> None:
+        _write_snapshot(tmp_path)
+        kg = load_old_kg(str(tmp_path))
+
         assert kg.metadata_diseases_sources["ctd"] == 1
+        assert "fdc" not in kg.metadata_diseases_sources
+
+    def test_picks_latest_snapshot(self, tmp_path: Path) -> None:
+        _write_snapshot(tmp_path)
+
+        newer = tmp_path / "PreviousFAKG" / "20260601T000000Z"
+        newer.mkdir(parents=True)
+        pd.DataFrame(
+            {
+                "foodatlas_id": ["e1"],
+                "entity_type": ["food"],
+                "common_name": ["x"],
+                "scientific_name": [None],
+            }
+        ).to_parquet(newer / "entities.parquet", index=False)
+        pd.DataFrame({"head_id": [], "relationship_id": [], "tail_id": []}).to_parquet(
+            newer / "triplets.parquet", index=False
+        )
+        pd.DataFrame({"source": pd.Series([], dtype=str)}).to_parquet(
+            newer / "attestations.parquet", index=False
+        )
+
+        kg = load_old_kg(str(tmp_path))
+        assert len(kg.entities) == 1
+
+    def test_no_snapshots_raises(self, tmp_path: Path) -> None:
+        (tmp_path / "PreviousFAKG").mkdir()
+        with pytest.raises(FileNotFoundError):
+            load_old_kg(str(tmp_path))

--- a/frontend/app/(home)/page.tsx
+++ b/frontend/app/(home)/page.tsx
@@ -20,9 +20,9 @@ const Landing = () => {
               News
             </div>
             <div className="mt-1 text-light-200 text-base md:text-lg">
-              <span className="text-light-400">4/20/2026 — </span>
-              FoodAtlas Knowledge Graph <strong>v4.0</strong> has been
-              released with improved data quality and expanded coverage!
+              <span className="text-light-400">6/05/2026 — </span>
+              FoodAtlas Knowledge Graph <strong>v4.1</strong> has been
+              released with improved data quality and expanded coverage.
             </div>
           </div>
         </div>

--- a/infra/local/docker-compose.yml
+++ b/infra/local/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       POSTGRES_USER: foodatlas
       POSTGRES_PASSWORD: foodatlas
     ports:
-      - "5432:5432"
+      - "127.0.0.1:5432:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ./init-db.sql:/docker-entrypoint-initdb.d/init.sql


### PR DESCRIPTION
- frontend: bump home page news banner to v4.1 (6/05/2026)
- kgc/report: rewrite load_old.py to read parquet snapshots instead of legacy TSV files; auto-selects latest PreviousFAKG/ directory
- kgc/scripts: snapshot outputs/kg/ into data/PreviousFAKG/ after each sync so the next report cycle has a reference to diff against
- kgc/trust: update llm_plausibility v1 model to gemini-3.1-flash-lite
- kgc/ie: add unit normalization for superscript minus-one (mgkg−1), middle-dot (mg·g−1), and no-space per (mgper100g) notation
- kgc/ie: fix response parser to use CSV. reader for correct quoted-field handling; support 3-field v3 model output; skip CSV header rows
- kgc/tests: add 55 test cases covering unit normalization and regressions
- api: make port configurable via API_PORT env var
- infra: bind local postgres to 127.0.0.1 only
- gitignore: add local_docs/ in case developers keep local documents that should skip uploading.