### PR TITLE
feat(api): bioactivity endpoints (/v1/ + internal SSR)

### DIFF
--- a/backend/api/src/app.py
+++ b/backend/api/src/app.py
@@ -10,7 +10,15 @@ from src.config import APISettings
 from src.dependencies import init_session_factory
 from src.public_keys import get_store, init_store
 from src.rate_limit import TokenBucketLimiter
-from src.routes import chemical, disease, download, food, metadata, resolve
+from src.routes import (
+    bioactivity,
+    chemical,
+    disease,
+    download,
+    food,
+    metadata,
+    resolve,
+)
 from src.routes import v1 as v1_routes
 
 PUBLIC_API_DESCRIPTION = """
@@ -89,6 +97,7 @@ def create_app(settings: APISettings | None = None) -> FastAPI:
     app.include_router(food.router)
     app.include_router(chemical.router)
     app.include_router(disease.router)
+    app.include_router(bioactivity.router)
     app.include_router(metadata.router)
     app.include_router(download.router)
     app.include_router(resolve.router)

--- a/backend/api/src/repositories/bioactivity.py
+++ b/backend/api/src/repositories/bioactivity.py
@@ -1,0 +1,146 @@
+"""Bioactivity entity repository (internal SSR consumer).
+
+Returns rich, UI-shaped payloads — full ``measurements``/``evidences`` JSONB,
+ambiguity_siblings, etc. The flat /v1/ surface lives in
+``repositories.v1.bioactivity``.
+"""
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from .formatting import format_external_ids
+
+ROWS_PER_PAGE = 10
+
+
+async def get_metadata(session: AsyncSession, common_name: str) -> dict[str, object]:
+    """Bioactivity metadata for the detail page."""
+    result = await session.execute(
+        text("""
+            SELECT common_name, foodatlas_id AS id, entity_type,
+                   scientific_name, synonyms, external_ids, description,
+                   ambiguity_siblings
+            FROM mv_bioactivity_entities WHERE common_name = :name
+        """),
+        {"name": common_name},
+    )
+    data = [dict(row._mapping) for row in result]
+    for row in data:
+        row["external_ids"] = format_external_ids(row.get("external_ids"))
+    return {"data": data, "metadata": {"row_count": len(data)}}
+
+
+async def get_chemicals(
+    session: AsyncSession, common_name: str, page: int = 1
+) -> dict[str, object]:
+    """Chemicals measured against this bioactivity, with raw assay JSONB."""
+    offset = ROWS_PER_PAGE * (page - 1)
+    result = await session.execute(
+        text("""
+            SELECT chemical_foodatlas_id AS id, chemical_name AS name,
+                   measurement_count, measurements
+            FROM mv_chemical_bioactivity_measurement
+            WHERE bioactivity_name = :name
+            ORDER BY measurement_count DESC
+            OFFSET :offset ROWS FETCH FIRST :limit ROWS ONLY
+        """),
+        {"name": common_name, "offset": offset, "limit": ROWS_PER_PAGE},
+    )
+    data = [dict(r._mapping) for r in result]
+
+    count_result = await session.execute(
+        text(
+            "SELECT COUNT(*) FROM mv_chemical_bioactivity_measurement"
+            " WHERE bioactivity_name = :name"
+        ),
+        {"name": common_name},
+    )
+    total_rows = count_result.scalar() or 0
+    return _page_payload(data, page, total_rows)
+
+
+async def get_foods(
+    session: AsyncSession,
+    common_name: str,
+    page: int = 1,
+    exhibit_type: str = "all",
+) -> dict[str, object]:
+    """Foods exhibiting this bioactivity, with direct/inherited filter."""
+    offset = ROWS_PER_PAGE * (page - 1)
+    where = "bioactivity_name = :name"
+    params: dict[str, object] = {
+        "name": common_name,
+        "offset": offset,
+        "limit": ROWS_PER_PAGE,
+    }
+    if exhibit_type in ("direct", "inherited"):
+        where += " AND exhibit_type = :et"
+        params["et"] = exhibit_type
+
+    result = await session.execute(
+        text(f"""
+            SELECT food_foodatlas_id AS id, food_name AS name,
+                   exhibit_type, via_chemical_id, via_chemical_name,
+                   efficacy_pred, evidence_count, evidences
+            FROM mv_food_bioactivity_exhibits
+            WHERE {where}
+            ORDER BY evidence_count DESC
+            OFFSET :offset ROWS FETCH FIRST :limit ROWS ONLY
+        """),
+        params,
+    )
+    data = [dict(r._mapping) for r in result]
+
+    count_params = {k: v for k, v in params.items() if k in ("name", "et")}
+    count_result = await session.execute(
+        text(f"SELECT COUNT(*) FROM mv_food_bioactivity_exhibits WHERE {where}"),
+        count_params,
+    )
+    total_rows = count_result.scalar() or 0
+    return _page_payload(data, page, total_rows)
+
+
+async def get_diseases(
+    session: AsyncSession, common_name: str, page: int = 1
+) -> dict[str, object]:
+    """Diseases associated with this bioactivity, with target ids + evidences."""
+    offset = ROWS_PER_PAGE * (page - 1)
+    result = await session.execute(
+        text("""
+            SELECT disease_foodatlas_id AS id, disease_name AS name,
+                   polarity, target_ids, evidence_count, evidences
+            FROM mv_bioactivity_disease_association
+            WHERE bioactivity_name = :name
+            ORDER BY evidence_count DESC
+            OFFSET :offset ROWS FETCH FIRST :limit ROWS ONLY
+        """),
+        {"name": common_name, "offset": offset, "limit": ROWS_PER_PAGE},
+    )
+    data = [dict(r._mapping) for r in result]
+
+    count_result = await session.execute(
+        text(
+            "SELECT COUNT(*) FROM mv_bioactivity_disease_association"
+            " WHERE bioactivity_name = :name"
+        ),
+        {"name": common_name},
+    )
+    total_rows = count_result.scalar() or 0
+    return _page_payload(data, page, total_rows)
+
+
+def _page_payload(data: list, page: int, total_rows: int) -> dict[str, object]:
+    """Wrap rows in the SSR payload shape (mirrors other internal repos)."""
+    total_pages = (total_rows + ROWS_PER_PAGE - 1) // ROWS_PER_PAGE if total_rows else 0
+    offset = ROWS_PER_PAGE * (page - 1)
+    return {
+        "data": data,
+        "metadata": {
+            "row_count": len(data),
+            "rows_per_page": ROWS_PER_PAGE,
+            "current_row": offset + 1,
+            "current_page": page,
+            "total_rows": total_rows,
+            "total_pages": total_pages,
+        },
+    }

--- a/backend/api/src/repositories/v1/bioactivity.py
+++ b/backend/api/src/repositories/v1/bioactivity.py
@@ -1,0 +1,193 @@
+"""Bioactivity queries for /v1/.
+
+Surfaces three MVs that the DB layer materialises:
+
+- ``mv_chemical_bioactivity_measurement`` — r5 assay rows
+- ``mv_food_bioactivity_exhibits``        — r6 direct/inherited rows
+- ``mv_bioactivity_disease_association``  — r7 polarity + target rows
+
+For ``BioactivityMeasurementRow`` we expose the *first* measurement's
+potency/Hill-curve so the row stays flat; ``measurement_count`` signals
+when more detail lives in the SSR-only endpoint.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from sqlalchemy import text
+
+from .pagination import offset as _offset
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+_MEASUREMENT_SELECT = """
+    chemical_foodatlas_id AS chemical_id,
+    chemical_name,
+    bioactivity_foodatlas_id AS bioactivity_id,
+    bioactivity_name,
+    measurement_count,
+    COALESCE(measurements->0->'potency', '{}'::jsonb) AS potency,
+    COALESCE(measurements->0->'hill_curve', '{}'::jsonb) AS hill_curve,
+    COALESCE(
+        (
+            SELECT array_agg(DISTINCT tid)
+            FROM jsonb_array_elements(measurements) AS m,
+                 jsonb_array_elements_text(
+                     COALESCE(m->'target_ids', '[]'::jsonb)
+                 ) AS tid
+        ),
+        ARRAY[]::text[]
+    ) AS target_ids,
+    measurements->0->>'evidence_source' AS evidence_source,
+    measurements->0->>'evidence_type' AS evidence_type
+"""
+
+
+async def list_measurements(
+    session: AsyncSession,
+    *,
+    chemical_id: str | None = None,
+    bioactivity_id: str | None = None,
+    page: int = 1,
+    page_size: int = 50,
+) -> tuple[list[dict], int]:
+    """List chemical-bioactivity measurements from either side."""
+    if chemical_id is not None:
+        where = "chemical_foodatlas_id = :v"
+        order = "bioactivity_name"
+        params: dict[str, object] = {"v": chemical_id}
+    elif bioactivity_id is not None:
+        where = "bioactivity_foodatlas_id = :v"
+        order = "chemical_name"
+        params = {"v": bioactivity_id}
+    else:
+        return [], 0
+
+    count_result = await session.execute(
+        text(f"SELECT COUNT(*) FROM mv_chemical_bioactivity_measurement WHERE {where}"),
+        params,
+    )
+    total = int(count_result.scalar() or 0)
+
+    params["limit"] = page_size
+    params["offset"] = _offset(page, page_size)
+    sql = (
+        f"SELECT {_MEASUREMENT_SELECT} "
+        f"FROM mv_chemical_bioactivity_measurement WHERE {where} "
+        f"ORDER BY {order} OFFSET :offset ROWS FETCH FIRST :limit ROWS ONLY"
+    )
+    list_result = await session.execute(text(sql), params)
+    rows = [dict(r._mapping) for r in list_result]
+    return rows, total
+
+
+_EXHIBIT_SELECT = """
+    food_foodatlas_id AS food_id,
+    food_name,
+    bioactivity_foodatlas_id AS bioactivity_id,
+    bioactivity_name,
+    exhibit_type,
+    via_chemical_id,
+    via_chemical_name,
+    efficacy_pred,
+    evidence_count
+"""
+
+
+async def list_exhibits(
+    session: AsyncSession,
+    *,
+    food_id: str | None = None,
+    bioactivity_id: str | None = None,
+    exhibit_type: str = "all",
+    page: int = 1,
+    page_size: int = 50,
+) -> tuple[list[dict], int]:
+    """List food-bioactivity exhibits with optional direct/inherited filter."""
+    where: list[str] = []
+    params: dict[str, object] = {}
+    order = "evidence_count DESC"
+    if food_id is not None:
+        where.append("food_foodatlas_id = :v")
+        params["v"] = food_id
+        order = "bioactivity_name"
+    elif bioactivity_id is not None:
+        where.append("bioactivity_foodatlas_id = :v")
+        params["v"] = bioactivity_id
+        order = "food_name"
+    else:
+        return [], 0
+    if exhibit_type in ("direct", "inherited"):
+        where.append("exhibit_type = :et")
+        params["et"] = exhibit_type
+
+    where_sql = " AND ".join(where)
+
+    count_result = await session.execute(
+        text(f"SELECT COUNT(*) FROM mv_food_bioactivity_exhibits WHERE {where_sql}"),
+        params,
+    )
+    total = int(count_result.scalar() or 0)
+
+    params["limit"] = page_size
+    params["offset"] = _offset(page, page_size)
+    sql = (
+        f"SELECT {_EXHIBIT_SELECT} "
+        f"FROM mv_food_bioactivity_exhibits WHERE {where_sql} "
+        f"ORDER BY {order} OFFSET :offset ROWS FETCH FIRST :limit ROWS ONLY"
+    )
+    list_result = await session.execute(text(sql), params)
+    rows = [dict(r._mapping) for r in list_result]
+    return rows, total
+
+
+_ASSOCIATION_SELECT = """
+    bioactivity_foodatlas_id AS bioactivity_id,
+    bioactivity_name,
+    disease_foodatlas_id AS disease_id,
+    disease_name,
+    polarity,
+    COALESCE(target_ids, ARRAY[]::text[]) AS target_ids,
+    evidence_count
+"""
+
+
+async def list_associations(
+    session: AsyncSession,
+    *,
+    bioactivity_id: str | None = None,
+    disease_id: str | None = None,
+    page: int = 1,
+    page_size: int = 50,
+) -> tuple[list[dict], int]:
+    """List bioactivity-disease associations from either side."""
+    if bioactivity_id is not None:
+        where = "bioactivity_foodatlas_id = :v"
+        order = "disease_name"
+        params: dict[str, object] = {"v": bioactivity_id}
+    elif disease_id is not None:
+        where = "disease_foodatlas_id = :v"
+        order = "bioactivity_name"
+        params = {"v": disease_id}
+    else:
+        return [], 0
+
+    count_result = await session.execute(
+        text(f"SELECT COUNT(*) FROM mv_bioactivity_disease_association WHERE {where}"),
+        params,
+    )
+    total = int(count_result.scalar() or 0)
+
+    params["limit"] = page_size
+    params["offset"] = _offset(page, page_size)
+    sql = (
+        f"SELECT {_ASSOCIATION_SELECT} "
+        f"FROM mv_bioactivity_disease_association WHERE {where} "
+        f"ORDER BY {order} OFFSET :offset ROWS FETCH FIRST :limit ROWS ONLY"
+    )
+    list_result = await session.execute(text(sql), params)
+    rows = [dict(r._mapping) for r in list_result]
+    return rows, total

--- a/backend/api/src/repositories/v1/entities.py
+++ b/backend/api/src/repositories/v1/entities.py
@@ -22,6 +22,7 @@ _ENTITY_TABLE: dict[str, str] = {
     "food": "mv_food_entities",
     "chemical": "mv_chemical_entities",
     "disease": "mv_disease_entities",
+    "bioactivity": "mv_bioactivity_entities",
 }
 
 _ENTITY_SELECT: dict[str, str] = {
@@ -35,6 +36,10 @@ _ENTITY_SELECT: dict[str, str] = {
     ),
     "disease": (
         "foodatlas_id AS id, common_name, scientific_name, synonyms, external_ids"
+    ),
+    "bioactivity": (
+        "foodatlas_id AS id, common_name, scientific_name, synonyms, "
+        "external_ids, description"
     ),
 }
 
@@ -71,6 +76,7 @@ async def list_entities(
         )
         where.append(f":cls = ANY({col})")
         params["cls"] = classification
+    # bioactivity and disease have no classification column; ignore the filter.
 
     where_sql = " WHERE " + " AND ".join(where) if where else ""
 

--- a/backend/api/src/repositories/v1/serializers.py
+++ b/backend/api/src/repositories/v1/serializers.py
@@ -165,9 +165,80 @@ class Taxonomy(BaseModel):
 class SearchHit(BaseModel):
     id: str
     common_name: str
-    entity_type: Literal["food", "chemical", "disease"]
+    entity_type: Literal["food", "chemical", "disease", "bioactivity"]
     scientific_name: str = ""
     associations: int = 0
+
+
+class BioactivitySummary(BaseModel):
+    id: str
+    common_name: str
+    scientific_name: str = ""
+
+
+class Bioactivity(BioactivitySummary):
+    synonyms: list[str] = Field(default_factory=list)
+    external_ids: dict[str, list[str]] = Field(default_factory=dict)
+    description: str = ""
+
+
+class HillCurve(BaseModel):
+    """Hill-equation coefficients from a chemical-bioactivity assay."""
+
+    zero_activity: float | None = None
+    infinite_activity: float | None = None
+    log_ac50: float | None = None
+    hill_slope: float | None = None
+
+
+class Potency(BaseModel):
+    value: float | None = None
+    unit: str | None = None
+
+
+class BioactivityMeasurementRow(BaseModel):
+    """Flat row for /v1/chemicals/{id}/bioactivities and the reverse."""
+
+    chemical_id: str
+    chemical_name: str
+    bioactivity_id: str
+    bioactivity_name: str
+    measurement_count: int = 0
+    potency: Potency = Field(default_factory=Potency)
+    hill_curve: HillCurve = Field(default_factory=HillCurve)
+    target_ids: list[str] = Field(default_factory=list)
+    evidence_source: str | None = None
+    evidence_type: str | None = None
+
+
+class BioactivityExhibitRow(BaseModel):
+    """Flat row for /v1/foods/{id}/bioactivities and the reverse.
+
+    ``exhibit_type`` is ``direct`` or ``inherited``; inherited rows expose the
+    bridging chemical via ``via_chemical_id`` / ``via_chemical_name``.
+    """
+
+    food_id: str
+    food_name: str
+    bioactivity_id: str
+    bioactivity_name: str
+    exhibit_type: Literal["direct", "inherited"]
+    via_chemical_id: str | None = None
+    via_chemical_name: str | None = None
+    efficacy_pred: float | None = None
+    evidence_count: int = 0
+
+
+class BioactivityDiseaseRow(BaseModel):
+    """Flat row for /v1/bioactivities/{id}/diseases and the reverse."""
+
+    bioactivity_id: str
+    bioactivity_name: str
+    disease_id: str
+    disease_name: str
+    polarity: str | None = None
+    target_ids: list[str] = Field(default_factory=list)
+    evidence_count: int = 0
 
 
 class Stats(BaseModel):

--- a/backend/api/src/routes/bioactivity.py
+++ b/backend/api/src/routes/bioactivity.py
@@ -1,0 +1,49 @@
+"""Bioactivity entity API routes (internal SSR consumer)."""
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.dependencies import get_db, verify_api_key
+from src.repositories import bioactivity
+
+router = APIRouter(
+    prefix="/bioactivity",
+    dependencies=[Depends(verify_api_key)],
+    include_in_schema=False,
+)
+
+
+@router.get("/metadata")
+async def bioactivity_metadata(
+    common_name: str = Query(...),
+    db: AsyncSession = Depends(get_db),
+):
+    return await bioactivity.get_metadata(db, common_name)
+
+
+@router.get("/chemicals")
+async def bioactivity_chemicals(
+    common_name: str = Query(...),
+    page: int = Query(1),
+    db: AsyncSession = Depends(get_db),
+):
+    return await bioactivity.get_chemicals(db, common_name, page)
+
+
+@router.get("/foods")
+async def bioactivity_foods(
+    common_name: str = Query(...),
+    page: int = Query(1),
+    exhibit_type: str = Query("all"),
+    db: AsyncSession = Depends(get_db),
+):
+    return await bioactivity.get_foods(db, common_name, page, exhibit_type)
+
+
+@router.get("/diseases")
+async def bioactivity_diseases(
+    common_name: str = Query(...),
+    page: int = Query(1),
+    db: AsyncSession = Depends(get_db),
+):
+    return await bioactivity.get_diseases(db, common_name, page)

--- a/backend/api/src/routes/v1/__init__.py
+++ b/backend/api/src/routes/v1/__init__.py
@@ -7,6 +7,7 @@ from src.rate_limit import enforce_rate_limit
 
 from . import (
     attestations,
+    bioactivities,
     bundles,
     chemicals,
     diseases,
@@ -24,6 +25,7 @@ router = APIRouter(
 router.include_router(foods.router)
 router.include_router(chemicals.router)
 router.include_router(diseases.router)
+router.include_router(bioactivities.router)
 router.include_router(triplets.router)
 router.include_router(attestations.router)
 router.include_router(search.router)

--- a/backend/api/src/routes/v1/bioactivities.py
+++ b/backend/api/src/routes/v1/bioactivities.py
@@ -1,0 +1,131 @@
+"""Public bioactivity endpoints (/v1/bioactivities)."""
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.dependencies import get_db
+from src.repositories.v1 import bioactivity, entities
+from src.repositories.v1.pagination import build_page, clamp_page_size
+from src.repositories.v1.serializers import (
+    Bioactivity,
+    BioactivityDiseaseRow,
+    BioactivityExhibitRow,
+    BioactivityMeasurementRow,
+    BioactivitySummary,
+    ItemResponse,
+    ListResponse,
+)
+
+router = APIRouter(prefix="/bioactivities")
+
+_VALID_EXHIBIT_TYPES = {"all", "direct", "inherited"}
+
+
+@router.get(
+    "",
+    response_model=ListResponse[BioactivitySummary],
+    summary="List bioactivities",
+)
+async def list_bioactivities(
+    q: str = Query(""),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> ListResponse[BioactivitySummary]:
+    size = clamp_page_size(page_size)
+    rows, total = await entities.list_entities(
+        db, "bioactivity", q=q, page=page, page_size=size
+    )
+    return ListResponse[BioactivitySummary](
+        data=[BioactivitySummary(**r) for r in rows],
+        page=build_page(page, size, total),
+    )
+
+
+@router.get(
+    "/{bioactivity_id}",
+    response_model=ItemResponse[Bioactivity],
+    responses={404: {"description": "Bioactivity not found"}},
+)
+async def get_bioactivity(
+    bioactivity_id: str, db: AsyncSession = Depends(get_db)
+) -> ItemResponse[Bioactivity]:
+    row = await entities.get_entity(db, "bioactivity", entity_id=bioactivity_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail="Bioactivity not found")
+    return ItemResponse[Bioactivity](data=Bioactivity(**row))
+
+
+@router.get(
+    "/{bioactivity_id}/chemicals",
+    response_model=ListResponse[BioactivityMeasurementRow],
+    summary="Chemicals measured against this bioactivity",
+)
+async def bioactivity_chemicals(
+    bioactivity_id: str,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> ListResponse[BioactivityMeasurementRow]:
+    size = clamp_page_size(page_size)
+    rows, total = await bioactivity.list_measurements(
+        db, bioactivity_id=bioactivity_id, page=page, page_size=size
+    )
+    return ListResponse[BioactivityMeasurementRow](
+        data=[BioactivityMeasurementRow(**r) for r in rows],
+        page=build_page(page, size, total),
+    )
+
+
+@router.get(
+    "/{bioactivity_id}/foods",
+    response_model=ListResponse[BioactivityExhibitRow],
+    summary="Foods exhibiting this bioactivity",
+)
+async def bioactivity_foods(
+    bioactivity_id: str,
+    exhibit_type: str = Query(
+        "all", description="'direct', 'inherited', or 'all' (default)"
+    ),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> ListResponse[BioactivityExhibitRow]:
+    if exhibit_type not in _VALID_EXHIBIT_TYPES:
+        raise HTTPException(
+            status_code=422,
+            detail="exhibit_type must be one of direct, inherited, all",
+        )
+    size = clamp_page_size(page_size)
+    rows, total = await bioactivity.list_exhibits(
+        db,
+        bioactivity_id=bioactivity_id,
+        exhibit_type=exhibit_type,
+        page=page,
+        page_size=size,
+    )
+    return ListResponse[BioactivityExhibitRow](
+        data=[BioactivityExhibitRow(**r) for r in rows],
+        page=build_page(page, size, total),
+    )
+
+
+@router.get(
+    "/{bioactivity_id}/diseases",
+    response_model=ListResponse[BioactivityDiseaseRow],
+    summary="Diseases associated with this bioactivity",
+)
+async def bioactivity_diseases(
+    bioactivity_id: str,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> ListResponse[BioactivityDiseaseRow]:
+    size = clamp_page_size(page_size)
+    rows, total = await bioactivity.list_associations(
+        db, bioactivity_id=bioactivity_id, page=page, page_size=size
+    )
+    return ListResponse[BioactivityDiseaseRow](
+        data=[BioactivityDiseaseRow(**r) for r in rows],
+        page=build_page(page, size, total),
+    )

--- a/backend/api/src/routes/v1/chemicals.py
+++ b/backend/api/src/routes/v1/chemicals.py
@@ -7,9 +7,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.dependencies import get_db
 from src.repositories import taxonomy as taxonomy_repo
-from src.repositories.v1 import entities, relationships
+from src.repositories.v1 import bioactivity, entities, relationships
 from src.repositories.v1.pagination import build_page, clamp_page_size
 from src.repositories.v1.serializers import (
+    BioactivityMeasurementRow,
     Chemical,
     ChemicalSummary,
     CompositionRow,
@@ -124,3 +125,24 @@ async def chemical_taxonomy(
         raise HTTPException(status_code=404, detail="Chemical not found")
     payload = await taxonomy_repo.get_taxonomy(db, entity["common_name"], "chemical")
     return ItemResponse[Taxonomy](data=Taxonomy(**cast("dict", payload["data"])))
+
+
+@router.get(
+    "/{chemical_id}/bioactivities",
+    response_model=ListResponse[BioactivityMeasurementRow],
+    summary="Bioactivities measured against this chemical",
+)
+async def chemical_bioactivities(
+    chemical_id: str,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> ListResponse[BioactivityMeasurementRow]:
+    size = clamp_page_size(page_size)
+    rows, total = await bioactivity.list_measurements(
+        db, chemical_id=chemical_id, page=page, page_size=size
+    )
+    return ListResponse[BioactivityMeasurementRow](
+        data=[BioactivityMeasurementRow(**r) for r in rows],
+        page=build_page(page, size, total),
+    )

--- a/backend/api/src/routes/v1/diseases.py
+++ b/backend/api/src/routes/v1/diseases.py
@@ -7,9 +7,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.dependencies import get_db
 from src.repositories import taxonomy as taxonomy_repo
-from src.repositories.v1 import entities, relationships
+from src.repositories.v1 import bioactivity, entities, relationships
 from src.repositories.v1.pagination import build_page, clamp_page_size
 from src.repositories.v1.serializers import (
+    BioactivityDiseaseRow,
     CorrelationRow,
     Disease,
     DiseaseSummary,
@@ -90,3 +91,24 @@ async def disease_taxonomy(
         raise HTTPException(status_code=404, detail="Disease not found")
     payload = await taxonomy_repo.get_taxonomy(db, entity["common_name"], "disease")
     return ItemResponse[Taxonomy](data=Taxonomy(**cast("dict", payload["data"])))
+
+
+@router.get(
+    "/{disease_id}/bioactivities",
+    response_model=ListResponse[BioactivityDiseaseRow],
+    summary="Bioactivities associated with this disease",
+)
+async def disease_bioactivities(
+    disease_id: str,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> ListResponse[BioactivityDiseaseRow]:
+    size = clamp_page_size(page_size)
+    rows, total = await bioactivity.list_associations(
+        db, disease_id=disease_id, page=page, page_size=size
+    )
+    return ListResponse[BioactivityDiseaseRow](
+        data=[BioactivityDiseaseRow(**r) for r in rows],
+        page=build_page(page, size, total),
+    )

--- a/backend/api/src/routes/v1/foods.py
+++ b/backend/api/src/routes/v1/foods.py
@@ -7,9 +7,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from src.dependencies import get_db
 from src.repositories import taxonomy as taxonomy_repo
-from src.repositories.v1 import entities, relationships
+from src.repositories.v1 import bioactivity, entities, relationships
 from src.repositories.v1.pagination import build_page, clamp_page_size
 from src.repositories.v1.serializers import (
+    BioactivityExhibitRow,
     CompositionRow,
     Food,
     FoodSummary,
@@ -17,6 +18,8 @@ from src.repositories.v1.serializers import (
     ListResponse,
     Taxonomy,
 )
+
+_VALID_EXHIBIT_TYPES = {"all", "direct", "inherited"}
 
 router = APIRouter(prefix="/foods")
 
@@ -92,3 +95,36 @@ async def food_taxonomy(
         raise HTTPException(status_code=404, detail="Food not found")
     payload = await taxonomy_repo.get_taxonomy(db, entity["common_name"], "food")
     return ItemResponse[Taxonomy](data=Taxonomy(**cast("dict", payload["data"])))
+
+
+@router.get(
+    "/{food_id}/bioactivities",
+    response_model=ListResponse[BioactivityExhibitRow],
+    summary="Bioactivities this food exhibits",
+)
+async def food_bioactivities(
+    food_id: str,
+    exhibit_type: str = Query(
+        "all", description="'direct', 'inherited', or 'all' (default)"
+    ),
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=100),
+    db: AsyncSession = Depends(get_db),
+) -> ListResponse[BioactivityExhibitRow]:
+    if exhibit_type not in _VALID_EXHIBIT_TYPES:
+        raise HTTPException(
+            status_code=422,
+            detail="exhibit_type must be one of direct, inherited, all",
+        )
+    size = clamp_page_size(page_size)
+    rows, total = await bioactivity.list_exhibits(
+        db,
+        food_id=food_id,
+        exhibit_type=exhibit_type,
+        page=page,
+        page_size=size,
+    )
+    return ListResponse[BioactivityExhibitRow](
+        data=[BioactivityExhibitRow(**r) for r in rows],
+        page=build_page(page, size, total),
+    )

--- a/backend/api/tests/test_repo_bioactivity.py
+++ b/backend/api/tests/test_repo_bioactivity.py
@@ -1,0 +1,117 @@
+"""Tests for src.repositories.bioactivity (internal SSR repository)."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from src.repositories.bioactivity import (
+    get_chemicals,
+    get_diseases,
+    get_foods,
+    get_metadata,
+)
+
+
+def _make_row(**kwargs: object) -> MagicMock:
+    row = MagicMock()
+    row._mapping = kwargs
+    return row
+
+
+def _iter_result(rows: list[MagicMock]) -> MagicMock:
+    result = MagicMock()
+    result.__iter__ = lambda self: iter(rows)
+    return result
+
+
+def _scalar_result(value: int) -> MagicMock:
+    result = MagicMock()
+    result.scalar.return_value = value
+    return result
+
+
+class TestGetMetadata:
+    @pytest.mark.asyncio
+    async def test_returns_data_and_count(self) -> None:
+        row = _make_row(
+            common_name="anti-inflammatory",
+            id="bio1",
+            entity_type="bioactivity",
+            scientific_name="",
+            synonyms=[],
+            external_ids={},
+            description="reduces inflammation",
+            ambiguity_siblings=[],
+        )
+        session = AsyncMock()
+        session.execute.return_value = _iter_result([row])
+
+        result = await get_metadata(session, "anti-inflammatory")
+
+        assert result["metadata"]["row_count"] == 1
+        assert result["data"][0]["description"] == "reduces inflammation"
+
+
+class TestGetChemicals:
+    @pytest.mark.asyncio
+    async def test_returns_paginated(self) -> None:
+        row = _make_row(id="c1", name="quercetin", measurement_count=2, measurements=[])
+        session = AsyncMock()
+        session.execute.side_effect = [_iter_result([row]), _scalar_result(1)]
+
+        result = await get_chemicals(session, "anti-inflammatory", page=1)
+
+        assert result["data"][0]["name"] == "quercetin"
+        assert result["metadata"]["total_rows"] == 1
+        assert result["metadata"]["total_pages"] == 1
+
+
+class TestGetFoods:
+    @pytest.mark.asyncio
+    async def test_filters_by_exhibit_type(self) -> None:
+        row = _make_row(
+            id="f1",
+            name="strawberry",
+            exhibit_type="direct",
+            via_chemical_id=None,
+            via_chemical_name=None,
+            efficacy_pred=None,
+            evidence_count=1,
+            evidences=[],
+        )
+        session = AsyncMock()
+        session.execute.side_effect = [_iter_result([row]), _scalar_result(1)]
+
+        result = await get_foods(session, "antioxidant", exhibit_type="direct")
+
+        # The list query should carry the et param.
+        list_params = session.execute.call_args_list[0][0][1]
+        assert list_params["et"] == "direct"
+        assert result["data"][0]["exhibit_type"] == "direct"
+
+    @pytest.mark.asyncio
+    async def test_all_exhibit_type_skips_filter(self) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = [_iter_result([]), _scalar_result(0)]
+        await get_foods(session, "antioxidant", exhibit_type="all")
+        list_params = session.execute.call_args_list[0][0][1]
+        assert "et" not in list_params
+
+
+class TestGetDiseases:
+    @pytest.mark.asyncio
+    async def test_returns_targets(self) -> None:
+        row = _make_row(
+            id="d1",
+            name="asthma",
+            polarity=None,
+            target_ids=["UniProt:P1"],
+            evidence_count=1,
+            evidences=[],
+        )
+        session = AsyncMock()
+        session.execute.side_effect = [_iter_result([row]), _scalar_result(1)]
+
+        result = await get_diseases(session, "anti-inflammatory")
+
+        assert result["data"][0]["target_ids"] == ["UniProt:P1"]
+        assert result["metadata"]["total_rows"] == 1

--- a/backend/api/tests/test_repo_bioactivity_v1.py
+++ b/backend/api/tests/test_repo_bioactivity_v1.py
@@ -1,0 +1,154 @@
+"""Tests for src.repositories.v1.bioactivity (3 MV-backed list endpoints)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from src.repositories.v1 import bioactivity
+
+
+def _row(**kwargs: object) -> MagicMock:
+    r = MagicMock()
+    r._mapping = kwargs
+    for key, val in kwargs.items():
+        setattr(r, key, val)
+    return r
+
+
+def _iter_result(rows: list[MagicMock]) -> MagicMock:
+    result = MagicMock()
+    result.__iter__ = lambda self: iter(rows)
+    return result
+
+
+def _scalar_result(value: int) -> MagicMock:
+    result = MagicMock()
+    result.scalar.return_value = value
+    return result
+
+
+class TestListMeasurements:
+    @pytest.mark.asyncio
+    async def test_filter_by_chemical_id(self) -> None:
+        row = _row(
+            chemical_id="c1",
+            chemical_name="quercetin",
+            bioactivity_id="bio1",
+            bioactivity_name="anti-inflammatory",
+            measurement_count=2,
+            potency={"value": 5.0, "unit": "uM"},
+            hill_curve={
+                "zero_activity": 0.5,
+                "infinite_activity": -50.0,
+                "log_ac50": -5.0,
+                "hill_slope": 1.0,
+            },
+            target_ids=["UniProt:P1"],
+            evidence_source="PubChem AID:1",
+            evidence_type="In vitro",
+        )
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(1), _iter_result([row])]
+        rows, total = await bioactivity.list_measurements(session, chemical_id="c1")
+        assert total == 1
+        assert rows[0]["bioactivity_name"] == "anti-inflammatory"
+
+    @pytest.mark.asyncio
+    async def test_filter_by_bioactivity_id(self) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(0), _iter_result([])]
+        rows, total = await bioactivity.list_measurements(
+            session, bioactivity_id="bio1"
+        )
+        assert total == 0
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_no_filter_returns_empty(self) -> None:
+        session = AsyncMock()
+        rows, total = await bioactivity.list_measurements(session)
+        assert rows == [] and total == 0
+        session.execute.assert_not_called()
+
+
+class TestListExhibits:
+    @pytest.mark.asyncio
+    async def test_filter_by_food_id(self) -> None:
+        row = _row(
+            food_id="f1",
+            food_name="strawberry",
+            bioactivity_id="bio1",
+            bioactivity_name="antioxidant",
+            exhibit_type="direct",
+            via_chemical_id=None,
+            via_chemical_name=None,
+            efficacy_pred=None,
+            evidence_count=1,
+        )
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(1), _iter_result([row])]
+        rows, total = await bioactivity.list_exhibits(session, food_id="f1")
+        assert total == 1
+        assert rows[0]["exhibit_type"] == "direct"
+
+    @pytest.mark.asyncio
+    async def test_filter_exhibit_type_direct(self) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(0), _iter_result([])]
+        await bioactivity.list_exhibits(session, food_id="f1", exhibit_type="direct")
+        # First execute is the count query; verify ``et`` param was bound.
+        count_params = session.execute.call_args_list[0][0][1]
+        assert count_params["et"] == "direct"
+
+    @pytest.mark.asyncio
+    async def test_invalid_exhibit_type_falls_through_to_all(self) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(0), _iter_result([])]
+        await bioactivity.list_exhibits(session, food_id="f1", exhibit_type="bogus")
+        count_params = session.execute.call_args_list[0][0][1]
+        # 'bogus' is not in {direct, inherited}; no et filter applied.
+        assert "et" not in count_params
+
+    @pytest.mark.asyncio
+    async def test_no_filter_returns_empty(self) -> None:
+        session = AsyncMock()
+        rows, total = await bioactivity.list_exhibits(session)
+        assert rows == [] and total == 0
+        session.execute.assert_not_called()
+
+
+class TestListAssociations:
+    @pytest.mark.asyncio
+    async def test_filter_by_bioactivity_id(self) -> None:
+        row = _row(
+            bioactivity_id="bio1",
+            bioactivity_name="anti-inflammatory",
+            disease_id="d1",
+            disease_name="asthma",
+            polarity=None,
+            target_ids=["UniProt:P1"],
+            evidence_count=1,
+        )
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(1), _iter_result([row])]
+        rows, total = await bioactivity.list_associations(
+            session, bioactivity_id="bio1"
+        )
+        assert total == 1
+        assert rows[0]["disease_name"] == "asthma"
+
+    @pytest.mark.asyncio
+    async def test_filter_by_disease_id(self) -> None:
+        session = AsyncMock()
+        session.execute.side_effect = [_scalar_result(0), _iter_result([])]
+        rows, total = await bioactivity.list_associations(session, disease_id="d1")
+        assert total == 0
+        assert rows == []
+
+    @pytest.mark.asyncio
+    async def test_no_filter_returns_empty(self) -> None:
+        session = AsyncMock()
+        rows, total = await bioactivity.list_associations(session)
+        assert rows == [] and total == 0
+        session.execute.assert_not_called()

--- a/backend/api/tests/test_routes_bioactivity.py
+++ b/backend/api/tests/test_routes_bioactivity.py
@@ -1,0 +1,88 @@
+"""Tests for /bioactivity internal SSR routes."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import patch
+
+if TYPE_CHECKING:
+    from unittest.mock import AsyncMock
+
+    from fastapi.testclient import TestClient
+
+
+_META_SAMPLE = {
+    "data": [
+        {
+            "common_name": "anti-inflammatory",
+            "id": "bio1",
+            "entity_type": "bioactivity",
+            "scientific_name": "",
+            "synonyms": [],
+            "external_ids": {},
+            "description": "reduces inflammation",
+            "ambiguity_siblings": [],
+        }
+    ],
+    "metadata": {"row_count": 1},
+}
+
+_PAGED = {
+    "data": [{"id": "x1", "name": "x"}],
+    "metadata": {
+        "row_count": 1,
+        "rows_per_page": 10,
+        "current_row": 1,
+        "current_page": 1,
+        "total_rows": 1,
+        "total_pages": 1,
+    },
+}
+
+
+class TestBioactivityMetadata:
+    def test_returns_data(self, client: TestClient, mock_db: AsyncMock) -> None:
+        with patch(
+            "src.repositories.bioactivity.get_metadata", return_value=_META_SAMPLE
+        ):
+            resp = client.get(
+                "/bioactivity/metadata", params={"common_name": "anti-inflammatory"}
+            )
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"][0]["entity_type"] == "bioactivity"
+
+    def test_missing_param_returns_422(self, client: TestClient) -> None:
+        resp = client.get("/bioactivity/metadata")
+        assert resp.status_code == 422
+
+
+class TestBioactivityChemicals:
+    def test_returns_paged(self, client: TestClient, mock_db: AsyncMock) -> None:
+        with patch("src.repositories.bioactivity.get_chemicals", return_value=_PAGED):
+            resp = client.get(
+                "/bioactivity/chemicals", params={"common_name": "anti-inflammatory"}
+            )
+        assert resp.status_code == 200
+        assert resp.json()["metadata"]["total_rows"] == 1
+
+
+class TestBioactivityFoods:
+    def test_returns_paged(self, client: TestClient, mock_db: AsyncMock) -> None:
+        with patch("src.repositories.bioactivity.get_foods", return_value=_PAGED):
+            resp = client.get(
+                "/bioactivity/foods",
+                params={"common_name": "antioxidant", "exhibit_type": "direct"},
+            )
+        assert resp.status_code == 200
+        assert resp.json()["data"][0]["id"] == "x1"
+
+
+class TestBioactivityDiseases:
+    def test_returns_paged(self, client: TestClient, mock_db: AsyncMock) -> None:
+        with patch("src.repositories.bioactivity.get_diseases", return_value=_PAGED):
+            resp = client.get(
+                "/bioactivity/diseases", params={"common_name": "anti-inflammatory"}
+            )
+        assert resp.status_code == 200
+        assert resp.json()["metadata"]["total_pages"] == 1

--- a/backend/api/tests/test_routes_bioactivity_v1.py
+++ b/backend/api/tests/test_routes_bioactivity_v1.py
@@ -1,0 +1,241 @@
+"""Tests for /v1/bioactivities routes and the cross-entity sub-routes."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from unittest.mock import AsyncMock, patch
+
+if TYPE_CHECKING:
+    from fastapi.testclient import TestClient
+
+
+# -- /v1/bioactivities ------------------------------------------------------
+
+
+class TestListBioactivities:
+    def test_returns_paginated_envelope(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.entities.list_entities",
+            return_value=(
+                [
+                    {
+                        "id": "bio1",
+                        "common_name": "anti-inflammatory",
+                        "scientific_name": "",
+                    }
+                ],
+                1,
+            ),
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/bioactivities")
+        assert resp.status_code == 200
+        body = resp.json()
+        assert body["data"][0]["id"] == "bio1"
+        assert body["page"]["total"] == 1
+
+
+class TestGetBioactivity:
+    def test_returns_detail(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.entities.get_entity",
+            return_value={
+                "id": "bio1",
+                "common_name": "anti-inflammatory",
+                "scientific_name": "",
+                "synonyms": [],
+                "external_ids": {},
+                "description": "reduces inflammation",
+            },
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/bioactivities/bio1")
+        assert resp.status_code == 200
+        assert resp.json()["data"]["description"] == "reduces inflammation"
+
+    def test_404_when_missing(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.entities.get_entity",
+            return_value=None,
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/bioactivities/missing")
+        assert resp.status_code == 404
+
+
+class TestBioactivityChemicals:
+    def test_returns_measurement_rows(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.bioactivity.list_measurements",
+            return_value=(
+                [
+                    {
+                        "chemical_id": "c1",
+                        "chemical_name": "quercetin",
+                        "bioactivity_id": "bio1",
+                        "bioactivity_name": "anti-inflammatory",
+                        "measurement_count": 1,
+                        "potency": {"value": 5.0, "unit": "uM"},
+                        "hill_curve": {
+                            "zero_activity": 0.5,
+                            "infinite_activity": -50.0,
+                            "log_ac50": -5.0,
+                            "hill_slope": 1.0,
+                        },
+                        "target_ids": ["UniProt:P1"],
+                        "evidence_source": "PubChem AID:1",
+                        "evidence_type": "In vitro",
+                    }
+                ],
+                1,
+            ),
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/bioactivities/bio1/chemicals")
+        assert resp.status_code == 200
+        assert resp.json()["data"][0]["chemical_name"] == "quercetin"
+
+
+class TestBioactivityFoods:
+    def test_returns_exhibit_rows(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.bioactivity.list_exhibits",
+            return_value=(
+                [
+                    {
+                        "food_id": "f1",
+                        "food_name": "strawberry",
+                        "bioactivity_id": "bio1",
+                        "bioactivity_name": "anti-inflammatory",
+                        "exhibit_type": "direct",
+                        "via_chemical_id": None,
+                        "via_chemical_name": None,
+                        "efficacy_pred": None,
+                        "evidence_count": 1,
+                    }
+                ],
+                1,
+            ),
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/bioactivities/bio1/foods?exhibit_type=direct")
+        assert resp.status_code == 200
+        assert resp.json()["data"][0]["exhibit_type"] == "direct"
+
+    def test_rejects_invalid_exhibit_type(self, client: TestClient) -> None:
+        resp = client.get("/v1/bioactivities/bio1/foods?exhibit_type=bogus")
+        assert resp.status_code == 422
+
+
+class TestBioactivityDiseases:
+    def test_returns_association_rows(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.bioactivity.list_associations",
+            return_value=(
+                [
+                    {
+                        "bioactivity_id": "bio1",
+                        "bioactivity_name": "anti-inflammatory",
+                        "disease_id": "d1",
+                        "disease_name": "asthma",
+                        "polarity": None,
+                        "target_ids": ["UniProt:P1"],
+                        "evidence_count": 1,
+                    }
+                ],
+                1,
+            ),
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/bioactivities/bio1/diseases")
+        assert resp.status_code == 200
+        assert resp.json()["data"][0]["disease_name"] == "asthma"
+
+
+# -- Cross-entity sub-routes ------------------------------------------------
+
+
+class TestChemicalBioactivities:
+    def test_returns_measurement_rows(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.bioactivity.list_measurements",
+            return_value=(
+                [
+                    {
+                        "chemical_id": "c1",
+                        "chemical_name": "quercetin",
+                        "bioactivity_id": "bio1",
+                        "bioactivity_name": "anti-inflammatory",
+                        "measurement_count": 1,
+                        "potency": {"value": 5.0, "unit": "uM"},
+                        "hill_curve": {},
+                        "target_ids": [],
+                        "evidence_source": None,
+                        "evidence_type": None,
+                    }
+                ],
+                1,
+            ),
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/chemicals/c1/bioactivities")
+        assert resp.status_code == 200
+        assert resp.json()["data"][0]["bioactivity_name"] == "anti-inflammatory"
+
+
+class TestFoodBioactivities:
+    def test_returns_exhibit_rows(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.bioactivity.list_exhibits",
+            return_value=(
+                [
+                    {
+                        "food_id": "f1",
+                        "food_name": "strawberry",
+                        "bioactivity_id": "bio1",
+                        "bioactivity_name": "antioxidant",
+                        "exhibit_type": "inherited",
+                        "via_chemical_id": "c1",
+                        "via_chemical_name": "quercetin",
+                        "efficacy_pred": None,
+                        "evidence_count": 2,
+                    }
+                ],
+                1,
+            ),
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/foods/f1/bioactivities?exhibit_type=inherited")
+        assert resp.status_code == 200
+        row = resp.json()["data"][0]
+        assert row["exhibit_type"] == "inherited"
+        assert row["via_chemical_name"] == "quercetin"
+
+    def test_rejects_invalid_exhibit_type(self, client: TestClient) -> None:
+        resp = client.get("/v1/foods/f1/bioactivities?exhibit_type=bogus")
+        assert resp.status_code == 422
+
+
+class TestDiseaseBioactivities:
+    def test_returns_association_rows(self, client: TestClient) -> None:
+        with patch(
+            "src.repositories.v1.bioactivity.list_associations",
+            return_value=(
+                [
+                    {
+                        "bioactivity_id": "bio1",
+                        "bioactivity_name": "anti-inflammatory",
+                        "disease_id": "d1",
+                        "disease_name": "asthma",
+                        "polarity": None,
+                        "target_ids": [],
+                        "evidence_count": 0,
+                    }
+                ],
+                1,
+            ),
+            new_callable=AsyncMock,
+        ):
+            resp = client.get("/v1/diseases/d1/bioactivities")
+        assert resp.status_code == 200
+        assert resp.json()["data"][0]["disease_name"] == "asthma"


### PR DESCRIPTION
## Summary

Phase 2 (API layer) for bioactivity integration. Adds public \`/v1/\` endpoints + internal SSR routes for the Next.js frontend, all backed by the MVs introduced in #202.

## What landed

**Public \`/v1/\`** (six endpoints, schemas, paged):
- \`GET /v1/bioactivities\` — list with \`q\` search
- \`GET /v1/bioactivities/{id}\` — detail
- \`GET /v1/bioactivities/{id}/{chemicals,foods,diseases}\`
- \`GET /v1/chemicals/{id}/bioactivities\` — Hill-curve measurements
- \`GET /v1/foods/{id}/bioactivities\` with \`exhibit_type=direct|inherited|all\`
- \`GET /v1/diseases/{id}/bioactivities\`

**Internal SSR** (\`/bioactivity/{metadata,chemicals,foods,diseases}\`, not in \`/docs\`) returns rich JSONB \`measurements\`/\`evidences\` for the Next.js detail page.

**Schemas** in \`serializers.py\`: \`BioactivitySummary\`, \`Bioactivity\`, \`Potency\`, \`HillCurve\`, \`BioactivityMeasurementRow\`, \`BioactivityExhibitRow\`, \`BioactivityDiseaseRow\`. \`SearchHit.entity_type\` literal widened to include \`bioactivity\`.

## Design notes

- **\`BioactivityMeasurementRow\` surfaces the first measurement's potency + Hill curve** plus a \`measurement_count\`. Power users who need every assay row use the SSR endpoint (or a future /v2 paginates per-measurement).
- **\`exhibit_type=all\`** is the default for the food/bioactivity endpoints; \`direct\` and \`inherited\` are explicit filters; anything else returns 422.
- **\`polarity\` propagates as nullable** until Pranav adds improves/degrades.

## Dependencies

- Built against the MVs from #202 (DB layer) — that PR can land independently; this PR queries MV table names via raw SQL.
- Contract: #201

## Test plan

- [x] 212 tests pass; 92% coverage; new bioactivity modules at 96-100%
- [ ] After #202 lands: hit \`curl localhost:8000/v1/bioactivities | jq\` against a populated DB

🤖 Generated with [Claude Code](https://claude.com/claude-code)