### PR TITLE
feat(bioactivity): cross-entity sections on chemical/food/disease pages

### DIFF
--- a/frontend/__tests__/bioactivity-sections.test.tsx
+++ b/frontend/__tests__/bioactivity-sections.test.tsx
@@ -13,16 +13,25 @@ vi.mock("@/utils/fetching", () => ({
   getBioactivityChemicals: vi.fn(),
   getBioactivityFoods: vi.fn(),
   getBioactivityDiseases: vi.fn(),
+  getChemicalBioactivities: vi.fn(),
+  getFoodBioactivities: vi.fn(),
+  getDiseaseBioactivities: vi.fn(),
 }));
 
 import {
   getBioactivityChemicals,
   getBioactivityDiseases,
   getBioactivityFoods,
+  getChemicalBioactivities,
+  getDiseaseBioactivities,
+  getFoodBioactivities,
 } from "@/utils/fetching";
 import BioactivityChemicalsSection from "@/components/entities/bioactivity/BioactivityChemicalsSection";
 import BioactivityFoodsSection from "@/components/entities/bioactivity/BioactivityFoodsSection";
 import BioactivityDiseasesSection from "@/components/entities/bioactivity/BioactivityDiseasesSection";
+import ChemicalBioactivitiesSection from "@/components/entities/bioactivity/ChemicalBioactivitiesSection";
+import FoodBioactivitiesSection from "@/components/entities/bioactivity/FoodBioactivitiesSection";
+import DiseaseBioactivitiesSection from "@/components/entities/bioactivity/DiseaseBioactivitiesSection";
 
 async function renderAsync(node: Promise<JSX.Element>) {
   render(await node);
@@ -140,5 +149,65 @@ describe("BioactivityDiseasesSection", () => {
     );
     expect(screen.getByText(/asthma/i)).toBeInTheDocument();
     expect(screen.getByText(/UniProt:P18054/)).toBeInTheDocument();
+  });
+});
+
+describe("ChemicalBioactivitiesSection", () => {
+  it("renders linked bioactivity rows", async () => {
+    vi.mocked(getChemicalBioactivities).mockResolvedValueOnce({
+      data: [
+        {
+          id: "bio1",
+          name: "anti-inflammatory",
+          measurement_count: 2,
+          measurements: [],
+        },
+      ],
+      metadata: { total_rows: 1 },
+    });
+    await renderAsync(
+      ChemicalBioactivitiesSection({ commonName: "quercetin" })
+    );
+    const link = screen.getByRole("link", { name: /anti-inflammatory/i });
+    expect(link).toHaveAttribute("href", "/bioactivity/anti-inflammatory");
+  });
+});
+
+describe("FoodBioactivitiesSection", () => {
+  it("links bioactivities and shows direct/inherited split", async () => {
+    vi.mocked(getFoodBioactivities).mockResolvedValueOnce({
+      data: [
+        {
+          id: "bio1",
+          name: "anti-inflammatory",
+          exhibit_type: "inherited",
+          via_chemical_id: "c1",
+          via_chemical_name: "quercetin",
+          efficacy_pred: null,
+          evidence_count: 1,
+        },
+      ],
+      metadata: { total_rows: 1 },
+    });
+    await renderAsync(
+      FoodBioactivitiesSection({ commonName: "strawberry" })
+    );
+    expect(
+      screen.getByRole("link", { name: /anti-inflammatory/i })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/0 direct, 1 inherited/)).toBeInTheDocument();
+  });
+});
+
+describe("DiseaseBioactivitiesSection", () => {
+  it("renders empty state when no associations", async () => {
+    vi.mocked(getDiseaseBioactivities).mockResolvedValueOnce({
+      data: [],
+      metadata: { total_rows: 0 },
+    });
+    await renderAsync(DiseaseBioactivitiesSection({ commonName: "asthma" }));
+    expect(
+      screen.getByText(/no bioactivity associations recorded/i)
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/__tests__/bioactivity-sections.test.tsx
+++ b/frontend/__tests__/bioactivity-sections.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import type {
+  BioactivityChemicalRow,
+  BioactivityDiseaseRow,
+  BioactivityFoodRow,
+} from "@/types";
+
+// Mock the fetcher module before importing the components so the dynamic
+// `await getX(...)` calls in the async server components are deterministic.
+vi.mock("@/utils/fetching", () => ({
+  getBioactivityChemicals: vi.fn(),
+  getBioactivityFoods: vi.fn(),
+  getBioactivityDiseases: vi.fn(),
+}));
+
+import {
+  getBioactivityChemicals,
+  getBioactivityDiseases,
+  getBioactivityFoods,
+} from "@/utils/fetching";
+import BioactivityChemicalsSection from "@/components/entities/bioactivity/BioactivityChemicalsSection";
+import BioactivityFoodsSection from "@/components/entities/bioactivity/BioactivityFoodsSection";
+import BioactivityDiseasesSection from "@/components/entities/bioactivity/BioactivityDiseasesSection";
+
+async function renderAsync(node: Promise<JSX.Element>) {
+  render(await node);
+}
+
+describe("BioactivityChemicalsSection", () => {
+  it("renders empty state when no measurements", async () => {
+    vi.mocked(getBioactivityChemicals).mockResolvedValueOnce({
+      data: [],
+      metadata: { total_rows: 0 },
+    });
+    await renderAsync(
+      BioactivityChemicalsSection({ commonName: "anti-inflammatory" })
+    );
+    expect(
+      screen.getByText(/no chemical-bioactivity measurements/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders rows with first-measurement potency", async () => {
+    const rows: BioactivityChemicalRow[] = [
+      {
+        id: "c1",
+        name: "quercetin",
+        measurement_count: 2,
+        measurements: [
+          {
+            attestation_id: "ba1",
+            bioactivity_metadata_id: "BAM000001",
+            source_assay_id: "PubChem AID:1",
+            target_ids: ["UniProt:P1"],
+            potency: { value: 5.0119, unit: "uM" },
+            hill_curve: {
+              zero_activity: 0.5,
+              infinite_activity: -50,
+              log_ac50: -5.3,
+              hill_slope: 1.0,
+            },
+            evidence_source: "PubChem AID:1",
+            evidence_type: "In vitro",
+          },
+        ],
+      },
+    ];
+    vi.mocked(getBioactivityChemicals).mockResolvedValueOnce({
+      data: rows,
+      metadata: { total_rows: 1 },
+    });
+    await renderAsync(
+      BioactivityChemicalsSection({ commonName: "anti-inflammatory" })
+    );
+    expect(screen.getByText(/quercetin/i)).toBeInTheDocument();
+    expect(screen.getByText(/5.012 uM/)).toBeInTheDocument();
+  });
+});
+
+describe("BioactivityFoodsSection", () => {
+  it("renders direct/inherited counts and via-chemical column", async () => {
+    const rows: BioactivityFoodRow[] = [
+      {
+        id: "f1",
+        name: "strawberry",
+        exhibit_type: "inherited",
+        via_chemical_id: "c1",
+        via_chemical_name: "quercetin",
+        efficacy_pred: null,
+        evidence_count: 2,
+        evidences: [],
+      },
+    ];
+    vi.mocked(getBioactivityFoods).mockResolvedValueOnce({
+      data: rows,
+      metadata: { total_rows: 1 },
+    });
+    await renderAsync(
+      BioactivityFoodsSection({ commonName: "anti-inflammatory" })
+    );
+    expect(screen.getByText(/strawberry/i)).toBeInTheDocument();
+    expect(screen.getAllByText(/quercetin/i).length).toBeGreaterThan(0);
+    expect(screen.getByText(/0 direct, 1 inherited/)).toBeInTheDocument();
+  });
+});
+
+describe("BioactivityDiseasesSection", () => {
+  it("renders empty state when no associations", async () => {
+    vi.mocked(getBioactivityDiseases).mockResolvedValueOnce({
+      data: [],
+      metadata: { total_rows: 0 },
+    });
+    await renderAsync(
+      BioactivityDiseasesSection({ commonName: "anti-inflammatory" })
+    );
+    expect(
+      screen.getByText(/no disease associations recorded/i)
+    ).toBeInTheDocument();
+  });
+
+  it("renders target ids when present", async () => {
+    const rows: BioactivityDiseaseRow[] = [
+      {
+        id: "d1",
+        name: "asthma",
+        polarity: null,
+        target_ids: ["UniProt:P18054"],
+        evidence_count: 1,
+        evidences: [],
+      },
+    ];
+    vi.mocked(getBioactivityDiseases).mockResolvedValueOnce({
+      data: rows,
+      metadata: { total_rows: 1 },
+    });
+    await renderAsync(
+      BioactivityDiseasesSection({ commonName: "anti-inflammatory" })
+    );
+    expect(screen.getByText(/asthma/i)).toBeInTheDocument();
+    expect(screen.getByText(/UniProt:P18054/)).toBeInTheDocument();
+  });
+});

--- a/frontend/app/(everything-else)/bioactivity/[slug]/page.tsx
+++ b/frontend/app/(everything-else)/bioactivity/[slug]/page.tsx
@@ -1,0 +1,62 @@
+import { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { Suspense } from "react";
+
+import BioactivityChemicalsSection from "@/components/entities/bioactivity/BioactivityChemicalsSection";
+import BioactivityFoodsSection from "@/components/entities/bioactivity/BioactivityFoodsSection";
+import BioactivityDiseasesSection from "@/components/entities/bioactivity/BioactivityDiseasesSection";
+import HeaderSection from "@/components/entities/HeaderSection";
+import HeaderSectionSuspense from "@/components/entities/HeaderSectionSuspense";
+import MetainformationSection from "@/components/entities/MetainformationSection";
+import MetainformationSuspense from "@/components/entities/MetainformationSuspense";
+import { getMetaData } from "@/utils/fetching";
+import { decodeSpace, toTitleCase } from "@/utils/utils";
+
+interface BioactivityPageProps {
+  params: { slug: string };
+}
+
+export async function generateMetadata({
+  params,
+}: BioactivityPageProps): Promise<Metadata> {
+  const { slug } = params;
+  const commonName = decodeSpace(decodeURIComponent(slug));
+
+  const metaData = await getMetaData(commonName, "bioactivity");
+  if (!metaData) notFound();
+
+  return {
+    title: `${toTitleCase(metaData.common_name)} — Bioactivity Profile`,
+    description: `Chemical measurements, food sources, and disease associations for the ${toTitleCase(
+      metaData.common_name
+    )} bioactivity.`,
+  };
+}
+
+const BioactivityPage = async ({ params }: BioactivityPageProps) => {
+  const { slug } = params;
+  const commonName = decodeSpace(decodeURIComponent(slug));
+  const entityType = "bioactivity";
+
+  return (
+    <div>
+      <Suspense fallback={<HeaderSectionSuspense entityType={entityType} />}>
+        <HeaderSection commonName={commonName} entityType={entityType} />
+      </Suspense>
+      <div className="mt-12 flex flex-col gap-20">
+        <Suspense fallback={<MetainformationSuspense entityType={entityType} />}>
+          <MetainformationSection
+            commonName={commonName}
+            entityType={entityType}
+          />
+        </Suspense>
+        <BioactivityChemicalsSection commonName={commonName} />
+        <BioactivityFoodsSection commonName={commonName} />
+        <BioactivityDiseasesSection commonName={commonName} />
+      </div>
+    </div>
+  );
+};
+
+BioactivityPage.displayName = "BioactivityPage";
+export default BioactivityPage;

--- a/frontend/app/(everything-else)/chemical/[slug]/page.tsx
+++ b/frontend/app/(everything-else)/chemical/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from "next";
 
 import ChemicalCompositionSection from "@/components/entities/chemical/ChemicalCompositionSection";
 import ChemicalCorrelationSection from "@/components/entities/chemical/ChemicalCorrelationSection";
+import ChemicalBioactivitiesSection from "@/components/entities/bioactivity/ChemicalBioactivitiesSection";
 import MetainformationSection from "@/components/entities/MetainformationSection";
 import HeaderSection from "@/components/entities/HeaderSection";
 import HeaderSectionSuspense from "@/components/entities/HeaderSectionSuspense";
@@ -56,6 +57,8 @@ const ChemicalPage = async ({ params }: ChemicalPageProps) => {
         </Suspense>
         {/* correlation */}
         <ChemicalCorrelationSection commonName={commonName} />
+        {/* bioactivities */}
+        <ChemicalBioactivitiesSection commonName={commonName} />
       </div>
     </div>
   );

--- a/frontend/app/(everything-else)/disease/[slug]/page.tsx
+++ b/frontend/app/(everything-else)/disease/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { notFound } from "next/navigation";
 import { Suspense } from "react";
 
 import DiseaseCorrelationsSection from "@/components/entities/disease/DiseaseCorrelationsSection";
+import DiseaseBioactivitiesSection from "@/components/entities/bioactivity/DiseaseBioactivitiesSection";
 import HeaderSection from "@/components/entities/HeaderSection";
 import MetainformationSection from "@/components/entities/MetainformationSection";
 import HeaderSectionSuspense from "@/components/entities/HeaderSectionSuspense";
@@ -57,6 +58,8 @@ const DiseasePage = async ({ params }: DiseasePageProps) => {
         {/* <Suspense fallback={<DiseaseCorrelationsSection commonName={commonName} />}> */}
         <DiseaseCorrelationsSection commonName={commonName} />
         {/* </Suspense> */}
+        {/* bioactivities */}
+        <DiseaseBioactivitiesSection commonName={commonName} />
       </div>
     </div>
   );

--- a/frontend/app/(everything-else)/food/[slug]/page.tsx
+++ b/frontend/app/(everything-else)/food/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { Metadata } from "next";
 import { notFound } from "next/navigation";
 
 import FoodCompositionSection from "@/components/entities/food/FoodCompositionSection";
+import FoodBioactivitiesSection from "@/components/entities/bioactivity/FoodBioactivitiesSection";
 import HeaderSection from "@/components/entities/HeaderSection";
 import HeaderSectionSuspense from "@/components/entities/HeaderSectionSuspense";
 import MetainformationSection from "@/components/entities/MetainformationSection";
@@ -61,6 +62,8 @@ const FoodPage = async ({ params }: FoodPageProps) => {
         </Suspense>
         {/* composition */}
         <FoodCompositionSection commonName={commonName} />
+        {/* bioactivities */}
+        <FoodBioactivitiesSection commonName={commonName} />
       </div>
     </div>
   );

--- a/frontend/components/entities/EntityAmbiguityBanner.tsx
+++ b/frontend/components/entities/EntityAmbiguityBanner.tsx
@@ -6,7 +6,7 @@ import { AmbiguitySibling } from "@/types/Metadata";
 import { encodeSpace } from "@/utils/utils";
 
 interface EntityAmbiguityBannerProps {
-  entityType: "food" | "chemical" | "disease";
+  entityType: "food" | "chemical" | "disease" | "bioactivity";
   siblings: AmbiguitySibling[] | undefined | null;
 }
 

--- a/frontend/components/entities/HeaderSection.tsx
+++ b/frontend/components/entities/HeaderSection.tsx
@@ -2,6 +2,7 @@ import Badge from "@/components/basic/Badge";
 import FoodIcon from "@/components/icons/FoodIcon";
 import ChemicalIcon from "@/components/icons/ChemicalIcon";
 import DiseaseIcon from "@/components/icons/DiseaseIcon";
+import BioactivityIcon from "@/components/icons/BioactivityIcon";
 import Heading from "@/components/basic/Heading";
 import EntityAmbiguityBanner from "@/components/entities/EntityAmbiguityBanner";
 import { getMetaData } from "@/utils/fetching";
@@ -11,17 +12,20 @@ const colorScheme = {
   chemical: "text-cyan-600 border-cyan-600 bg-cyan-600/10 shadow-cyan-600/50",
   disease:
     "text-purple-500 border-purple-500 bg-purple-500/10 shadow-purple-500/50",
+  bioactivity:
+    "text-emerald-500 border-emerald-500 bg-emerald-500/10 shadow-emerald-500/50",
 };
 
 const icon = {
   food: <FoodIcon color="#d97706" />,
   chemical: <ChemicalIcon color="#0891b2" />,
   disease: <DiseaseIcon color="#a855f7" />,
+  bioactivity: <BioactivityIcon color="#10b981" />,
 };
 
 interface HeaderSectionProps {
   commonName: string;
-  entityType: "food" | "chemical" | "disease";
+  entityType: "food" | "chemical" | "disease" | "bioactivity";
 }
 
 const HeaderSection = async ({

--- a/frontend/components/entities/HeaderSectionSuspense.tsx
+++ b/frontend/components/entities/HeaderSectionSuspense.tsx
@@ -2,6 +2,7 @@ import Badge from "@/components/basic/Badge";
 import FoodIcon from "@/components/icons/FoodIcon";
 import ChemicalIcon from "@/components/icons/ChemicalIcon";
 import DiseaseIcon from "@/components/icons/DiseaseIcon";
+import BioactivityIcon from "@/components/icons/BioactivityIcon";
 import LoadingCard from "@/components/basic/LoadingCard";
 
 const colorScheme = {
@@ -9,16 +10,19 @@ const colorScheme = {
   chemical: "text-cyan-600 border-cyan-600 bg-cyan-600/10 shadow-cyan-600/50",
   disease:
     "text-purple-500 border-purple-500 bg-purple-500/10 shadow-purple-500/50",
+  bioactivity:
+    "text-emerald-500 border-emerald-500 bg-emerald-500/10 shadow-emerald-500/50",
 };
 
 const icon = {
   food: <FoodIcon color="#d97706" />,
   chemical: <ChemicalIcon color="#0891b2" />,
   disease: <DiseaseIcon color="#a855f7" />,
+  bioactivity: <BioactivityIcon color="#10b981" />,
 };
 
 interface HeaderSectionSuspenseProps {
-  entityType: "food" | "chemical" | "disease";
+  entityType: "food" | "chemical" | "disease" | "bioactivity";
 }
 
 const HeaderSectionSuspense = async ({

--- a/frontend/components/entities/MetainformationSection.tsx
+++ b/frontend/components/entities/MetainformationSection.tsx
@@ -130,11 +130,25 @@ const MetainformationSection = async ({
             {data?.synonyms && data.synonyms.length > 0 && (
               <Synonyms synonyms={data.synonyms} />
             )}
-            {/* taxonomy */}
-            <TaxonomySection
-              commonName={commonName}
-              entityType={entityType}
-            />
+            {/* description (bioactivity only — other entities don't carry one) */}
+            {data?.description && (
+              <Card>
+                <Heading
+                  type="h4"
+                  className="font-mono italic text-light-400 text-xs"
+                >
+                  Description
+                </Heading>
+                <p className="mt-3">{data.description}</p>
+              </Card>
+            )}
+            {/* taxonomy — bioactivity has no taxonomy (each MeSH is independent) */}
+            {entityType !== "bioactivity" && (
+              <TaxonomySection
+                commonName={commonName}
+                entityType={entityType}
+              />
+            )}
           </div>
         </div>
         {/* identifiers container */}

--- a/frontend/components/entities/bioactivity/BioactivityChemicalsSection.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityChemicalsSection.tsx
@@ -1,0 +1,105 @@
+import Card from "@/components/basic/Card";
+import Heading from "@/components/basic/Heading";
+import { getBioactivityChemicals } from "@/utils/fetching";
+import { BioactivityChemicalRow } from "@/types";
+
+interface Props {
+  commonName: string;
+}
+
+function formatPotency(
+  potency: { value: number | null; unit: string | null } | undefined | null
+): string {
+  if (!potency || potency.value === null || potency.value === undefined) {
+    return "—";
+  }
+  const unit = potency.unit ?? "";
+  return `${potency.value.toFixed(3)}${unit ? ` ${unit}` : ""}`;
+}
+
+function formatHill(
+  curve:
+    | {
+        zero_activity: number | null;
+        infinite_activity: number | null;
+        log_ac50: number | null;
+        hill_slope: number | null;
+      }
+    | undefined
+    | null
+): string {
+  if (
+    !curve ||
+    (curve.zero_activity === null &&
+      curve.infinite_activity === null &&
+      curve.log_ac50 === null &&
+      curve.hill_slope === null)
+  ) {
+    return "—";
+  }
+  const parts = [
+    ["A0", curve.zero_activity],
+    ["A∞", curve.infinite_activity],
+    ["log AC50", curve.log_ac50],
+    ["Hill", curve.hill_slope],
+  ]
+    .filter(([, v]) => v !== null && v !== undefined)
+    .map(([k, v]) => `${k}=${(v as number).toFixed(2)}`);
+  return parts.join(", ");
+}
+
+const BioactivityChemicalsSection = async ({ commonName }: Props) => {
+  const payload = await getBioactivityChemicals(commonName);
+  const rows: BioactivityChemicalRow[] = payload.data ?? [];
+  const totalRows: number = payload.metadata?.total_rows ?? 0;
+
+  return (
+    <div className="flex flex-col gap-7">
+      <Heading type="h2" variant="boxed">
+        Chemicals Measured
+      </Heading>
+      <Card>
+        <p className="mb-4 text-sm text-light-400">
+          {totalRows === 0
+            ? "No chemical-bioactivity measurements available yet."
+            : `${totalRows} chemical${
+                totalRows === 1 ? "" : "s"
+              } measured against this bioactivity.`}
+        </p>
+        {rows.length > 0 && (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-light-50/10 text-left font-mono text-xs italic text-light-400">
+                <th className="py-2 pr-4">Chemical</th>
+                <th className="py-2 pr-4">Measurements</th>
+                <th className="py-2 pr-4">Potency (first)</th>
+                <th className="py-2">Hill curve (first)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => {
+                const first = row.measurements?.[0];
+                return (
+                  <tr
+                    key={row.id}
+                    className="border-b border-light-50/[0.05] align-top"
+                  >
+                    <td className="py-2 pr-4 capitalize break-all">{row.name}</td>
+                    <td className="py-2 pr-4">{row.measurement_count}</td>
+                    <td className="py-2 pr-4">{formatPotency(first?.potency)}</td>
+                    <td className="py-2 font-mono text-xs">
+                      {formatHill(first?.hill_curve)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+BioactivityChemicalsSection.displayName = "BioactivityChemicalsSection";
+export default BioactivityChemicalsSection;

--- a/frontend/components/entities/bioactivity/BioactivityDiseasesSection.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityDiseasesSection.tsx
@@ -1,0 +1,59 @@
+import Card from "@/components/basic/Card";
+import Heading from "@/components/basic/Heading";
+import { getBioactivityDiseases } from "@/utils/fetching";
+import { BioactivityDiseaseRow } from "@/types";
+
+interface Props {
+  commonName: string;
+}
+
+const BioactivityDiseasesSection = async ({ commonName }: Props) => {
+  const payload = await getBioactivityDiseases(commonName);
+  const rows: BioactivityDiseaseRow[] = payload.data ?? [];
+  const totalRows: number = payload.metadata?.total_rows ?? 0;
+
+  return (
+    <div className="flex flex-col gap-7">
+      <Heading type="h2" variant="boxed">
+        Associated Diseases
+      </Heading>
+      <Card>
+        <p className="mb-4 text-sm text-light-400">
+          {totalRows === 0
+            ? "No disease associations recorded for this bioactivity yet."
+            : `${totalRows} disease association${totalRows === 1 ? "" : "s"}.`}
+        </p>
+        {rows.length > 0 && (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-light-50/10 text-left font-mono text-xs italic text-light-400">
+                <th className="py-2 pr-4">Disease</th>
+                <th className="py-2 pr-4">Targets</th>
+                <th className="py-2">Evidence count</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr
+                  key={row.id}
+                  className="border-b border-light-50/[0.05] align-top"
+                >
+                  <td className="py-2 pr-4 capitalize break-all">{row.name}</td>
+                  <td className="py-2 pr-4 font-mono text-xs break-all">
+                    {row.target_ids.length === 0
+                      ? "—"
+                      : row.target_ids.join(", ")}
+                  </td>
+                  <td className="py-2">{row.evidence_count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+BioactivityDiseasesSection.displayName = "BioactivityDiseasesSection";
+export default BioactivityDiseasesSection;

--- a/frontend/components/entities/bioactivity/BioactivityFoodsSection.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityFoodsSection.tsx
@@ -1,0 +1,65 @@
+import Card from "@/components/basic/Card";
+import Heading from "@/components/basic/Heading";
+import { getBioactivityFoods } from "@/utils/fetching";
+import { BioactivityFoodRow } from "@/types";
+
+interface Props {
+  commonName: string;
+}
+
+const BioactivityFoodsSection = async ({ commonName }: Props) => {
+  const payload = await getBioactivityFoods(commonName, 1, "all");
+  const rows: BioactivityFoodRow[] = payload.data ?? [];
+  const totalRows: number = payload.metadata?.total_rows ?? 0;
+
+  const directCount = rows.filter((r) => r.exhibit_type === "direct").length;
+  const inheritedCount = rows.filter(
+    (r) => r.exhibit_type === "inherited"
+  ).length;
+
+  return (
+    <div className="flex flex-col gap-7">
+      <Heading type="h2" variant="boxed">
+        Foods Exhibiting
+      </Heading>
+      <Card>
+        <p className="mb-4 text-sm text-light-400">
+          {totalRows === 0
+            ? "No foods exhibit this bioactivity yet."
+            : `${totalRows} food${totalRows === 1 ? "" : "s"} exhibit this bioactivity (` +
+              `${directCount} direct, ${inheritedCount} inherited).`}
+        </p>
+        {rows.length > 0 && (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-light-50/10 text-left font-mono text-xs italic text-light-400">
+                <th className="py-2 pr-4">Food</th>
+                <th className="py-2 pr-4">Type</th>
+                <th className="py-2 pr-4">Via chemical</th>
+                <th className="py-2">Evidence count</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, idx) => (
+                <tr
+                  key={`${row.id}-${row.exhibit_type}-${idx}`}
+                  className="border-b border-light-50/[0.05] align-top"
+                >
+                  <td className="py-2 pr-4 capitalize break-all">{row.name}</td>
+                  <td className="py-2 pr-4 lowercase">{row.exhibit_type}</td>
+                  <td className="py-2 pr-4 capitalize break-all">
+                    {row.via_chemical_name ?? "—"}
+                  </td>
+                  <td className="py-2">{row.evidence_count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+BioactivityFoodsSection.displayName = "BioactivityFoodsSection";
+export default BioactivityFoodsSection;

--- a/frontend/components/entities/bioactivity/ChemicalBioactivitiesSection.tsx
+++ b/frontend/components/entities/bioactivity/ChemicalBioactivitiesSection.tsx
@@ -1,0 +1,84 @@
+import Card from "@/components/basic/Card";
+import Heading from "@/components/basic/Heading";
+import Link from "@/components/basic/Link";
+import { encodeSpace } from "@/utils/utils";
+import { getChemicalBioactivities } from "@/utils/fetching";
+import { BioactivityMeasurement } from "@/types";
+
+interface Props {
+  commonName: string;
+}
+
+interface Row {
+  id: string;
+  name: string;
+  measurement_count: number;
+  measurements: BioactivityMeasurement[];
+}
+
+const ChemicalBioactivitiesSection = async ({ commonName }: Props) => {
+  const payload = await getChemicalBioactivities(commonName);
+  const rows: Row[] = payload.data ?? [];
+  const totalRows: number = payload.metadata?.total_rows ?? 0;
+
+  return (
+    <div className="flex flex-col gap-7">
+      <Heading type="h2" variant="boxed">
+        Bioactivities
+      </Heading>
+      <Card>
+        <p className="mb-4 text-sm text-light-400">
+          {totalRows === 0
+            ? "No bioactivity measurements recorded for this chemical."
+            : `${totalRows} bioactivit${
+                totalRows === 1 ? "y" : "ies"
+              } measured against this chemical.`}
+        </p>
+        {rows.length > 0 && (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-light-50/10 text-left font-mono text-xs italic text-light-400">
+                <th className="py-2 pr-4">Bioactivity</th>
+                <th className="py-2 pr-4">Measurements</th>
+                <th className="py-2">First potency</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => {
+                const first = row.measurements?.[0];
+                const potency =
+                  first?.potency?.value !== null &&
+                  first?.potency?.value !== undefined
+                    ? `${first.potency.value.toFixed(3)}${
+                        first.potency.unit ? ` ${first.potency.unit}` : ""
+                      }`
+                    : "—";
+                return (
+                  <tr
+                    key={row.id}
+                    className="border-b border-light-50/[0.05] align-top"
+                  >
+                    <td className="py-2 pr-4 capitalize break-all">
+                      <Link
+                        href={`/bioactivity/${encodeURIComponent(
+                          encodeSpace(row.name)
+                        )}`}
+                      >
+                        {row.name}
+                      </Link>
+                    </td>
+                    <td className="py-2 pr-4">{row.measurement_count}</td>
+                    <td className="py-2">{potency}</td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+ChemicalBioactivitiesSection.displayName = "ChemicalBioactivitiesSection";
+export default ChemicalBioactivitiesSection;

--- a/frontend/components/entities/bioactivity/DiseaseBioactivitiesSection.tsx
+++ b/frontend/components/entities/bioactivity/DiseaseBioactivitiesSection.tsx
@@ -1,0 +1,78 @@
+import Card from "@/components/basic/Card";
+import Heading from "@/components/basic/Heading";
+import Link from "@/components/basic/Link";
+import { encodeSpace } from "@/utils/utils";
+import { getDiseaseBioactivities } from "@/utils/fetching";
+
+interface Props {
+  commonName: string;
+}
+
+interface Row {
+  id: string;
+  name: string;
+  polarity: string | null;
+  target_ids: string[];
+  evidence_count: number;
+}
+
+const DiseaseBioactivitiesSection = async ({ commonName }: Props) => {
+  const payload = await getDiseaseBioactivities(commonName);
+  const rows: Row[] = payload.data ?? [];
+  const totalRows: number = payload.metadata?.total_rows ?? 0;
+
+  return (
+    <div className="flex flex-col gap-7">
+      <Heading type="h2" variant="boxed">
+        Bioactivities
+      </Heading>
+      <Card>
+        <p className="mb-4 text-sm text-light-400">
+          {totalRows === 0
+            ? "No bioactivity associations recorded for this disease."
+            : `${totalRows} bioactivit${
+                totalRows === 1 ? "y" : "ies"
+              } associated with this disease.`}
+        </p>
+        {rows.length > 0 && (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-light-50/10 text-left font-mono text-xs italic text-light-400">
+                <th className="py-2 pr-4">Bioactivity</th>
+                <th className="py-2 pr-4">Targets</th>
+                <th className="py-2">Evidence</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr
+                  key={row.id}
+                  className="border-b border-light-50/[0.05] align-top"
+                >
+                  <td className="py-2 pr-4 capitalize break-all">
+                    <Link
+                      href={`/bioactivity/${encodeURIComponent(
+                        encodeSpace(row.name)
+                      )}`}
+                    >
+                      {row.name}
+                    </Link>
+                  </td>
+                  <td className="py-2 pr-4 font-mono text-xs break-all">
+                    {row.target_ids.length === 0
+                      ? "—"
+                      : row.target_ids.join(", ")}
+                  </td>
+                  <td className="py-2">{row.evidence_count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+DiseaseBioactivitiesSection.displayName = "DiseaseBioactivitiesSection";
+export default DiseaseBioactivitiesSection;

--- a/frontend/components/entities/bioactivity/FoodBioactivitiesSection.tsx
+++ b/frontend/components/entities/bioactivity/FoodBioactivitiesSection.tsx
@@ -1,0 +1,82 @@
+import Card from "@/components/basic/Card";
+import Heading from "@/components/basic/Heading";
+import Link from "@/components/basic/Link";
+import { encodeSpace } from "@/utils/utils";
+import { getFoodBioactivities } from "@/utils/fetching";
+
+interface Props {
+  commonName: string;
+}
+
+interface Row {
+  id: string;
+  name: string;
+  exhibit_type: "direct" | "inherited";
+  via_chemical_id: string | null;
+  via_chemical_name: string | null;
+  efficacy_pred: number | null;
+  evidence_count: number;
+}
+
+const FoodBioactivitiesSection = async ({ commonName }: Props) => {
+  const payload = await getFoodBioactivities(commonName, 1, "all");
+  const rows: Row[] = payload.data ?? [];
+  const totalRows: number = payload.metadata?.total_rows ?? 0;
+  const direct = rows.filter((r) => r.exhibit_type === "direct").length;
+  const inherited = rows.filter((r) => r.exhibit_type === "inherited").length;
+
+  return (
+    <div className="flex flex-col gap-7">
+      <Heading type="h2" variant="boxed">
+        Bioactivities
+      </Heading>
+      <Card>
+        <p className="mb-4 text-sm text-light-400">
+          {totalRows === 0
+            ? "This food has no recorded bioactivities yet."
+            : `${totalRows} bioactivit${
+                totalRows === 1 ? "y" : "ies"
+              } (${direct} direct, ${inherited} inherited).`}
+        </p>
+        {rows.length > 0 && (
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-light-50/10 text-left font-mono text-xs italic text-light-400">
+                <th className="py-2 pr-4">Bioactivity</th>
+                <th className="py-2 pr-4">Type</th>
+                <th className="py-2 pr-4">Via chemical</th>
+                <th className="py-2">Evidence</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row, idx) => (
+                <tr
+                  key={`${row.id}-${row.exhibit_type}-${idx}`}
+                  className="border-b border-light-50/[0.05] align-top"
+                >
+                  <td className="py-2 pr-4 capitalize break-all">
+                    <Link
+                      href={`/bioactivity/${encodeURIComponent(
+                        encodeSpace(row.name)
+                      )}`}
+                    >
+                      {row.name}
+                    </Link>
+                  </td>
+                  <td className="py-2 pr-4 lowercase">{row.exhibit_type}</td>
+                  <td className="py-2 pr-4 capitalize break-all">
+                    {row.via_chemical_name ?? "—"}
+                  </td>
+                  <td className="py-2">{row.evidence_count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+FoodBioactivitiesSection.displayName = "FoodBioactivitiesSection";
+export default FoodBioactivitiesSection;

--- a/frontend/components/icons/BioactivityIcon.tsx
+++ b/frontend/components/icons/BioactivityIcon.tsx
@@ -1,0 +1,25 @@
+const BioactivityIcon = (props: any) => {
+  const { height = "1em", width = "1em", color = "black", ...rest } = props;
+
+  return (
+    <svg
+      fill="none"
+      stroke={color}
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={3}
+      height={height}
+      width={width}
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 48 48"
+      xmlSpace="preserve"
+      {...rest}
+    >
+      <path d="M4 24h6l4-12 8 24 4-16 4 8h14" />
+    </svg>
+  );
+};
+
+BioactivityIcon.displayName = "BioactivityIcon";
+
+export default BioactivityIcon;

--- a/frontend/components/search/ResultItem.tsx
+++ b/frontend/components/search/ResultItem.tsx
@@ -9,6 +9,7 @@ import Badge from "@/components/basic/Badge";
 import ChemicalIcon from "@/components/icons/ChemicalIcon";
 import DiseaseIcon from "@/components/icons/DiseaseIcon";
 import FoodIcon from "@/components/icons/FoodIcon";
+import BioactivityIcon from "@/components/icons/BioactivityIcon";
 import { SearchContext } from "@/context/searchContext";
 import { Suggestion } from "@/types/Suggestion";
 import { encodeSpace } from "@/utils/utils";
@@ -18,12 +19,15 @@ const colorScheme = {
   chemical: "text-cyan-600 border-cyan-600 bg-cyan-600/10 shadow-cyan-600/50",
   disease:
     "text-purple-500 border-purple-500 bg-purple-500/10 shadow-purple-500/50",
+  bioactivity:
+    "text-emerald-500 border-emerald-500 bg-emerald-500/10 shadow-emerald-500/50",
 };
 
 const icon = {
   food: <FoodIcon color="#d97706" />,
   chemical: <ChemicalIcon color="#0891b2" />,
   disease: <DiseaseIcon color="#a855f7" />,
+  bioactivity: <BioactivityIcon color="#10b981" />,
 };
 
 const highlightMatch = (text: string, searchTerm: string) => {

--- a/frontend/types/Bioactivity.ts
+++ b/frontend/types/Bioactivity.ts
@@ -1,0 +1,55 @@
+export type BioactivityPotency = {
+  value: number | null;
+  unit: string | null;
+};
+
+export type BioactivityHillCurve = {
+  zero_activity: number | null;
+  infinite_activity: number | null;
+  log_ac50: number | null;
+  hill_slope: number | null;
+};
+
+export type BioactivityMeasurement = {
+  attestation_id: string;
+  bioactivity_metadata_id: string;
+  source_assay_id: string | null;
+  target_ids: string[];
+  potency: BioactivityPotency;
+  hill_curve: BioactivityHillCurve;
+  evidence_source: string | null;
+  evidence_type: string | null;
+};
+
+export type BioactivityChemicalRow = {
+  id: string;
+  name: string;
+  measurement_count: number;
+  measurements: BioactivityMeasurement[];
+};
+
+export type BioactivityFoodRow = {
+  id: string;
+  name: string;
+  exhibit_type: "direct" | "inherited";
+  via_chemical_id: string | null;
+  via_chemical_name: string | null;
+  efficacy_pred: number | null;
+  evidence_count: number;
+  evidences: BioactivityMeasurement[];
+};
+
+export type BioactivityDiseaseRow = {
+  id: string;
+  name: string;
+  polarity: string | null;
+  target_ids: string[];
+  evidence_count: number;
+  evidences: Array<{
+    attestation_id: string;
+    bioactivity_metadata_id: string;
+    target_ids: string[];
+    evidence_source: string | null;
+    evidence_type: string | null;
+  }>;
+};

--- a/frontend/types/Metadata.ts
+++ b/frontend/types/Metadata.ts
@@ -7,13 +7,14 @@ export type AmbiguitySibling = {
 
 export type Metadata = {
   id: string;
-  entity_type: "food" | "chemical" | "disease";
+  entity_type: "food" | "chemical" | "disease" | "bioactivity";
   common_name: string;
   scientific_name: string | null;
   synonyms: string[];
   food_classification?: string[];
   chemical_classification?: string[];
   flavor_descriptors?: string[];
+  description?: string;
   external_ids: ExternalIds;
   ambiguity_siblings?: AmbiguitySibling[];
 };

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -14,6 +14,14 @@ import { ChemicalCorrelation } from "@/types/ChemicalCorrelation";
 import { FoodCompositionData } from "@/types/FoodCompositionData";
 import { MacroAndMicroData } from "./MacroAndMicroData";
 import { TaxonomyData, TaxonomyNode, TaxonomyEdge } from "./TaxonomyData";
+import {
+  BioactivityChemicalRow,
+  BioactivityDiseaseRow,
+  BioactivityFoodRow,
+  BioactivityHillCurve,
+  BioactivityMeasurement,
+  BioactivityPotency,
+} from "./Bioactivity";
 
 export type {
   TeamMember,
@@ -34,4 +42,10 @@ export type {
   TaxonomyData,
   TaxonomyNode,
   TaxonomyEdge,
+  BioactivityChemicalRow,
+  BioactivityDiseaseRow,
+  BioactivityFoodRow,
+  BioactivityHillCurve,
+  BioactivityMeasurement,
+  BioactivityPotency,
 };

--- a/frontend/utils/fetching.ts
+++ b/frontend/utils/fetching.ts
@@ -230,6 +230,75 @@ export async function getDownloadEntries() {
   return data;
 }
 
+// fetch chemicals measured against a bioactivity
+export async function getBioactivityChemicals(
+  commonName: string,
+  page: number = 1
+) {
+  const res = await fetch(
+    `${
+      process.env.NEXT_PUBLIC_API_URL
+    }/bioactivity/chemicals?common_name=${encodeURIComponent(commonName)}&page=${page}`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY}`,
+      },
+      next: { revalidate: 86400 },
+    }
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch bioactivity chemicals for ${commonName}`);
+  }
+  return res.json();
+}
+
+// fetch foods exhibiting a bioactivity (direct or inherited)
+export async function getBioactivityFoods(
+  commonName: string,
+  page: number = 1,
+  exhibitType: "all" | "direct" | "inherited" = "all"
+) {
+  const res = await fetch(
+    `${
+      process.env.NEXT_PUBLIC_API_URL
+    }/bioactivity/foods?common_name=${encodeURIComponent(
+      commonName
+    )}&page=${page}&exhibit_type=${exhibitType}`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY}`,
+      },
+      next: { revalidate: 86400 },
+    }
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch bioactivity foods for ${commonName}`);
+  }
+  return res.json();
+}
+
+// fetch diseases associated with a bioactivity
+export async function getBioactivityDiseases(
+  commonName: string,
+  page: number = 1
+) {
+  const res = await fetch(
+    `${
+      process.env.NEXT_PUBLIC_API_URL
+    }/bioactivity/diseases?common_name=${encodeURIComponent(commonName)}&page=${page}`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY}`,
+      },
+      next: { revalidate: 86400 },
+    }
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch bioactivity diseases for ${commonName}`);
+  }
+  return res.json();
+}
+
 // cache & fetching testing function
 export async function getTime() {
   const response = await fetch("https://worldtimeapi.org/api/timezone/Etc/UTC");

--- a/frontend/utils/fetching.ts
+++ b/frontend/utils/fetching.ts
@@ -299,6 +299,75 @@ export async function getBioactivityDiseases(
   return res.json();
 }
 
+// bioactivities measured against a chemical (reverse of getBioactivityChemicals)
+export async function getChemicalBioactivities(
+  commonName: string,
+  page: number = 1
+) {
+  const res = await fetch(
+    `${
+      process.env.NEXT_PUBLIC_API_URL
+    }/chemical/bioactivities?common_name=${encodeURIComponent(commonName)}&page=${page}`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY}`,
+      },
+      next: { revalidate: 86400 },
+    }
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch chemical bioactivities for ${commonName}`);
+  }
+  return res.json();
+}
+
+// bioactivities exhibited by a food
+export async function getFoodBioactivities(
+  commonName: string,
+  page: number = 1,
+  exhibitType: "all" | "direct" | "inherited" = "all"
+) {
+  const res = await fetch(
+    `${
+      process.env.NEXT_PUBLIC_API_URL
+    }/food/bioactivities?common_name=${encodeURIComponent(
+      commonName
+    )}&page=${page}&exhibit_type=${exhibitType}`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY}`,
+      },
+      next: { revalidate: 86400 },
+    }
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch food bioactivities for ${commonName}`);
+  }
+  return res.json();
+}
+
+// bioactivities associated with a disease
+export async function getDiseaseBioactivities(
+  commonName: string,
+  page: number = 1
+) {
+  const res = await fetch(
+    `${
+      process.env.NEXT_PUBLIC_API_URL
+    }/disease/bioactivities?common_name=${encodeURIComponent(commonName)}&page=${page}`,
+    {
+      headers: {
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY}`,
+      },
+      next: { revalidate: 86400 },
+    }
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch disease bioactivities for ${commonName}`);
+  }
+  return res.json();
+}
+
 // cache & fetching testing function
 export async function getTime() {
   const response = await fetch("https://worldtimeapi.org/api/timezone/Etc/UTC");

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -1,1 +1,7 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});


### PR DESCRIPTION
## Summary

Adds the reverse-direction bioactivity views that were deferred from #204. A chemical page now lists the bioactivities measured against it; a food page lists the bioactivities it exhibits (direct + inherited split with via-chemical surfaced); a disease page lists the bioactivities associated with it.

## What landed

**Backend (extends #203)**
- 3 new methods in \`repositories/bioactivity.py\`: \`get_chemical_bioactivities\`, \`get_food_bioactivities\` (with \`exhibit_type\` filter), \`get_disease_bioactivities\`.
- 3 new internal SSR routes wired into the existing routers:
  - \`GET /chemical/bioactivities?common_name=X&page=N\`
  - \`GET /food/bioactivities?common_name=X&page=N&exhibit_type=all|direct|inherited\`
  - \`GET /disease/bioactivities?common_name=X&page=N\`

**Frontend (extends #204)**
- 3 new sections under \`components/entities/bioactivity/\`: \`ChemicalBioactivitiesSection\`, \`FoodBioactivitiesSection\`, \`DiseaseBioactivitiesSection\`. Each row links to \`/bioactivity/[slug]\`.
- 3 new fetching helpers in \`utils/fetching.ts\`.
- Wired into \`chemical/[slug]\`, \`food/[slug]\`, \`disease/[slug]\` pages.
- Added \`@testing-library/react\` \`cleanup()\` to \`vitest.setup.ts\` so renders don't leak between tests.

## Stacking

This branch stacks on top of \`feat/bioactivity-api\` (#203) and was merged with \`feat/bioactivity-frontend\` (#204) so it carries both diffs. After #203 and #204 land in \`dev\`, this PR's diff against \`dev\` collapses to just the cross-entity bits (~636 lines).

Effectively depends on:
- #201 (contract)
- #202 (DB MVs queried by the new endpoints)
- #203 (route patterns + bioactivity repository)
- #204 (BioactivityIcon, types, fetcher patterns)

## Test plan

- [x] 219 backend tests pass (added 4 new repo tests + 3 new route tests)
- [ ] 28 frontend tests pass (added 3 new section tests)
- [ ] \`ruff\` + \`npm run lint\` clean
- [ ] After full stack lands: visit \`/chemical/quercetin\`, \`/food/strawberry\`, \`/disease/asthma\` and confirm bioactivity sections render

🤖 Generated with [Claude Code](https://claude.com/claude-code)