### PR TITLE
fix(frontend): proxy search autocomplete to dodge mixed-content

### DIFF
--- a/frontend/hooks/useSearchAutocompleteOptions.tsx
+++ b/frontend/hooks/useSearchAutocompleteOptions.tsx
@@ -3,6 +3,7 @@ import useSWR from "swr";
 
 import { AutocompleteContext } from "@/context/autocompleteContext";
 import { usePaginations } from "@/context/paginationsContext";
+import { apiBase } from "@/utils/fetching";
 
 const fetcher = async (url: string) => {
   const response = await fetch(url, {
@@ -20,7 +21,7 @@ const useSearchAutocompleteOptions = () => {
   const { currentPage } = getTablePaginations("results-page");
 
   // base url
-  const baseUrl = `${process.env.NEXT_PUBLIC_API_URL}/metadata/search?`;
+  const baseUrl = `${apiBase()}/metadata/search?`;
 
   // full url
   const url =


### PR DESCRIPTION
Missed this hook in #208. `/metadata/search` is called via SWR from the browser on the `/results` page (bypasses `fetching.ts`), so it was still hitting the HTTP ALB directly and getting blocked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)