### PR TITLE
feat(bioactivity): Hill dose-response curve sparkline in measurements modal

### DIFF
--- a/frontend/app/(everything-else)/bioactivity/[slug]/page.tsx
+++ b/frontend/app/(everything-else)/bioactivity/[slug]/page.tsx
@@ -48,9 +48,9 @@ const BioactivityPage = async ({ params }: BioactivityPageProps) => {
     getMetaData(commonName, entityType).catch(() => null),
   ]);
   const chemicalsCount =
-    (chemPayload?.metadata?.row_count as number | undefined) ?? null;
+    (chemPayload?.metadata?.total_rows as number | undefined) ?? null;
   const foodsCount =
-    (foodPayload?.metadata?.row_count as number | undefined) ?? null;
+    (foodPayload?.metadata?.total_rows as number | undefined) ?? null;
   const anchorId = metaPayload?.id ?? null;
 
   return (

--- a/frontend/app/(everything-else)/bioactivity/[slug]/page.tsx
+++ b/frontend/app/(everything-else)/bioactivity/[slug]/page.tsx
@@ -42,14 +42,16 @@ const BioactivityPage = async ({ params }: BioactivityPageProps) => {
   const commonName = decodeSpace(decodeURIComponent(slug));
   const entityType = "bioactivity" as const;
 
-  const [chemPayload, foodPayload] = await Promise.all([
+  const [chemPayload, foodPayload, metaPayload] = await Promise.all([
     getBioactivityChemicals(commonName).catch(() => null),
     getBioactivityFoods(commonName).catch(() => null),
+    getMetaData(commonName, entityType).catch(() => null),
   ]);
   const chemicalsCount =
     (chemPayload?.metadata?.row_count as number | undefined) ?? null;
   const foodsCount =
     (foodPayload?.metadata?.row_count as number | undefined) ?? null;
+  const anchorId = metaPayload?.id ?? null;
 
   return (
     <div>
@@ -64,13 +66,23 @@ const BioactivityPage = async ({ params }: BioactivityPageProps) => {
             id: "chemicals",
             label: "Chemicals Measured",
             count: chemicalsCount,
-            content: <BioactivityChemicalsSection commonName={commonName} />,
+            content: (
+              <BioactivityChemicalsSection
+                commonName={commonName}
+                anchorId={anchorId}
+              />
+            ),
           },
           {
             id: "foods",
             label: "Foods Exhibiting",
             count: foodsCount,
-            content: <BioactivityFoodsSection commonName={commonName} />,
+            content: (
+              <BioactivityFoodsSection
+                commonName={commonName}
+                anchorId={anchorId}
+              />
+            ),
           },
           {
             id: "overview",

--- a/frontend/app/(everything-else)/chemical/[slug]/page.tsx
+++ b/frontend/app/(everything-else)/chemical/[slug]/page.tsx
@@ -53,7 +53,7 @@ const ChemicalPage = async ({ params }: ChemicalPageProps) => {
       (composition.without_concentrations?.length ?? 0)
     : null;
   const bioactivitiesCount =
-    (bioPayload?.metadata?.row_count as number | undefined) ?? null;
+    (bioPayload?.metadata?.total_rows as number | undefined) ?? null;
   const anchorId = metaPayload?.id ?? null;
 
   return (

--- a/frontend/app/(everything-else)/chemical/[slug]/page.tsx
+++ b/frontend/app/(everything-else)/chemical/[slug]/page.tsx
@@ -13,6 +13,7 @@ import ChemicalCompositionSectionSuspense from "@/components/entities/chemical/C
 import {
   getChemicalBioactivities,
   getChemicalCompositionData,
+  getMetaData,
 } from "@/utils/fetching";
 import { decodeSpace, toTitleCase } from "@/utils/utils";
 
@@ -42,9 +43,10 @@ const ChemicalPage = async ({ params }: ChemicalPageProps) => {
   // Parallel best-effort count fetches for the tab badges. Health Impacts
   // count would require two paginated requests (positive + negative); we
   // omit it for now (tab renders without a badge).
-  const [composition, bioPayload] = await Promise.all([
+  const [composition, bioPayload, metaPayload] = await Promise.all([
     getChemicalCompositionData(commonName).catch(() => null),
     getChemicalBioactivities(commonName).catch(() => null),
+    getMetaData(commonName, entityType).catch(() => null),
   ]);
   const compositionCount = composition
     ? (composition.with_concentrations?.length ?? 0) +
@@ -52,6 +54,7 @@ const ChemicalPage = async ({ params }: ChemicalPageProps) => {
     : null;
   const bioactivitiesCount =
     (bioPayload?.metadata?.row_count as number | undefined) ?? null;
+  const anchorId = metaPayload?.id ?? null;
 
   return (
     <div>
@@ -81,7 +84,12 @@ const ChemicalPage = async ({ params }: ChemicalPageProps) => {
             id: "bioactivities",
             label: "Bioactivities",
             count: bioactivitiesCount,
-            content: <ChemicalBioactivitiesSection commonName={commonName} />,
+            content: (
+              <ChemicalBioactivitiesSection
+                commonName={commonName}
+                anchorId={anchorId}
+              />
+            ),
           },
           {
             id: "overview",

--- a/frontend/app/(everything-else)/food/[slug]/page.tsx
+++ b/frontend/app/(everything-else)/food/[slug]/page.tsx
@@ -48,7 +48,7 @@ const FoodPage = async ({ params }: FoodPageProps) => {
   // Composition uses the same call as the table (default filters: all sources,
   // include unmeasured, no search) so the badge matches "Found N chemicals".
   // Counts from /food/composition/counts double-count multi-class chemicals.
-  const [compPayload, nutritionData, bioPayload] = await Promise.all([
+  const [compPayload, nutritionData, bioPayload, metaPayload] = await Promise.all([
     getFoodCompositionData(
       commonName,
       1,
@@ -61,7 +61,9 @@ const FoodPage = async ({ params }: FoodPageProps) => {
     ).catch(() => null),
     getFoodMacroAndMicroData(commonName).catch(() => null),
     getFoodBioactivities(commonName).catch(() => null),
+    getMetaData(commonName, entityType).catch(() => null),
   ]);
+  const anchorId = metaPayload?.id ?? null;
   const compositionCount =
     (compPayload?.metadata?.total_rows as number | undefined) ?? null;
   const nutritionCount = nutritionData
@@ -101,7 +103,12 @@ const FoodPage = async ({ params }: FoodPageProps) => {
             id: "bioactivities",
             label: "Bioactivities",
             count: bioactivitiesCount,
-            content: <FoodBioactivitiesSection commonName={commonName} />,
+            content: (
+              <FoodBioactivitiesSection
+                commonName={commonName}
+                anchorId={anchorId}
+              />
+            ),
           },
           {
             id: "overview",

--- a/frontend/app/(everything-else)/food/[slug]/page.tsx
+++ b/frontend/app/(everything-else)/food/[slug]/page.tsx
@@ -75,7 +75,7 @@ const FoodPage = async ({ params }: FoodPageProps) => {
         .map(([key, items]) => ({ key, count: items.length }))
     : [];
   const bioactivitiesCount =
-    (bioPayload?.metadata?.row_count as number | undefined) ?? null;
+    (bioPayload?.metadata?.total_rows as number | undefined) ?? null;
 
   return (
     <div>

--- a/frontend/components/basic/Modal.tsx
+++ b/frontend/components/basic/Modal.tsx
@@ -2,6 +2,7 @@
 
 import { Dialog, DialogPanel } from "@headlessui/react";
 import { MdClose } from "react-icons/md";
+import { twMerge } from "tailwind-merge";
 
 import Heading from "@/components/basic/Heading";
 import Button from "@/components/basic/Button";
@@ -12,6 +13,13 @@ interface ModalProps {
   description?: React.ReactNode;
   isOpen: boolean;
   onClose: () => void;
+  // When true, the dialog panel takes a fixed viewport-bounded height and
+  // its children stack as a flex column. The `children` area scrolls
+  // internally (flex-1 overflow-y-auto); the optional `footer` pins to
+  // the bottom. Use this when content height varies with pagination/state
+  // and you don't want the dialog re-centering on every page change.
+  fullHeight?: boolean;
+  footer?: React.ReactNode;
 }
 
 const Modal = ({
@@ -20,6 +28,8 @@ const Modal = ({
   children,
   title,
   description,
+  fullHeight,
+  footer,
 }: ModalProps) => {
   // Headless UI Dialog handles scroll locking internally.
   // scrollbar-gutter: stable on <html> (globals.css) reserves scrollbar
@@ -38,9 +48,14 @@ const Modal = ({
       <div className="fixed inset-0 overflow-y-auto md:p-12">
         {/* center content */}
         <div className="flex min-h-full items-center justify-center">
-          <DialogPanel className="w-full max-w-5xl md:rounded-xl border border-light-50/5 bg-light-950 backdrop-blur-2xl shadow-inner shadow-light-700/20 p-5 md:p-7">
+          <DialogPanel
+            className={twMerge(
+              "w-full max-w-5xl md:rounded-xl border border-light-50/5 bg-light-950 backdrop-blur-2xl shadow-inner shadow-light-700/20 p-5 md:p-7",
+              fullHeight && "flex flex-col h-[min(85vh,800px)]"
+            )}
+          >
             {/* modal header */}
-            <div className="flex justify-between items-center">
+            <div className="flex justify-between items-center shrink-0">
               <Heading className="capitalize" type="h3" variant="boxed">
                 {title}
               </Heading>
@@ -55,10 +70,17 @@ const Modal = ({
             </div>
             {/* (optional) modal description */}
             {description && (
-              <div className="my-3 text-light-400">{description}</div>
+              <div className="my-3 text-light-400 shrink-0">{description}</div>
             )}
             {/* modal content */}
-            <div className="mt-5">{children}</div>
+            <div
+              className={twMerge(
+                fullHeight ? "mt-5 flex-1 min-h-0 flex flex-col" : "mt-5"
+              )}
+            >
+              {children}
+            </div>
+            {footer && <div className="mt-4 shrink-0">{footer}</div>}
           </DialogPanel>
         </div>
       </div>

--- a/frontend/components/entities/bioactivity/BioactivityChemicalsSection.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityChemicalsSection.tsx
@@ -15,9 +15,10 @@ import BioactivityTable, {
 
 interface Props {
   commonName: string;
+  anchorId?: string | null;
 }
 
-const BioactivityChemicalsSection = ({ commonName }: Props) => {
+const BioactivityChemicalsSection = ({ commonName, anchorId }: Props) => {
   const fetcher = useCallback(
     (params: BioactivityListParams) =>
       getBioactivityChemicals(commonName, params),
@@ -83,6 +84,7 @@ const BioactivityChemicalsSection = ({ commonName }: Props) => {
         anchorLabel: commonName,
         headIsRow: true,
         relationship: "r6",
+        anchorId,
       }}
     />
   );

--- a/frontend/components/entities/bioactivity/BioactivityFoodsSection.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityFoodsSection.tsx
@@ -13,9 +13,10 @@ import BioactivityTable, {
 
 interface Props {
   commonName: string;
+  anchorId?: string | null;
 }
 
-const BioactivityFoodsSection = ({ commonName }: Props) => {
+const BioactivityFoodsSection = ({ commonName, anchorId }: Props) => {
   const fetcher = useCallback(
     (params: BioactivityListParams) => getBioactivityFoods(commonName, params),
     [commonName]
@@ -60,6 +61,7 @@ const BioactivityFoodsSection = ({ commonName }: Props) => {
         anchorLabel: commonName,
         headIsRow: true,
         relationship: "r5",
+        anchorId,
       }}
     />
   );

--- a/frontend/components/entities/bioactivity/BioactivityMeasurementsModal.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityMeasurementsModal.tsx
@@ -7,8 +7,13 @@
 // Falls back to `initialMeasurements` (the row's MV-capped sample) when
 // the fetch fails or anchor/row ids aren't both provided.
 //
-// Includes client-side search (assay + endpoint), outcome filter, and
-// 20-row pagination so a pair with hundreds of assays is browsable.
+// Layout is fixed-height (Modal fullHeight) with three stable zones:
+// header (title + toolbar), scrollable rows area, pinned footer
+// (pagination). Toolbar / pagination / row slots are ALWAYS rendered —
+// when loading, the same shell holds skeleton rows; when on the last
+// page or after filtering, placeholder rows pad up to PAGE_SIZE so the
+// table doesn't shrink. Net result: the modal opens at its final size
+// and stays there — buttons don't migrate, dialog doesn't recenter.
 
 "use client";
 
@@ -113,8 +118,8 @@ const BioactivityMeasurementsModal = ({
     setCurrentPage(1);
   }, [isOpen, selectedId]);
 
-  // Only show the outcome chip for outcomes that actually occur in this
-  // pair's rows — most pairs only have one or two distinct outcomes.
+  // Outcomes computed from the FULL row set (not filtered) so the chip
+  // row doesn't reflow when filters apply.
   const availableOutcomes = useMemo<OutcomeFilter[]>(() => {
     const present = new Set<string>();
     rows.forEach((r) => {
@@ -150,7 +155,8 @@ const BioactivityMeasurementsModal = ({
     return filtered.slice(start, start + PAGE_SIZE);
   }, [filtered, currentPage]);
 
-  // Defer rendering the table by one paint so the modal opens snappily.
+  // Defer the table commit by one paint so the modal animation opens
+  // snappily even when the row count is large.
   const [isContentReady, setIsContentReady] = useState(false);
   useEffect(() => {
     if (!isOpen) {
@@ -170,11 +176,15 @@ const BioactivityMeasurementsModal = ({
   const showingFewerThanTotal =
     fullRows == null && expectedCount != null && rows.length < expectedCount;
 
+  const placeholderCount = Math.max(0, PAGE_SIZE - visible.length);
+  const showEmptyState = !showSkeleton && filtered.length === 0;
+
   return (
     <Modal
       title={`Assay measurements · ${headLabel} × ${tailLabel}`}
       isOpen={isOpen}
       onClose={onClose}
+      fullHeight
       description={
         <span className="font-mono italic text-xs text-light-400 capitalize">
           {totalKnown.toLocaleString()} measurement
@@ -191,16 +201,68 @@ const BioactivityMeasurementsModal = ({
           )}
         </span>
       }
+      footer={
+        <div
+          className={twMerge(
+            "max-w-xl w-full mx-auto flex items-center justify-between transition-opacity",
+            totalPages > 1 ? "opacity-100" : "opacity-0 pointer-events-none"
+          )}
+          aria-hidden={totalPages <= 1}
+        >
+          <Button
+            isIconOnly
+            isSquared
+            isDisabled={showSkeleton || currentPage === 1}
+            onClick={() => setCurrentPage(1)}
+            aria-label="First page"
+          >
+            <MdKeyboardDoubleArrowLeft />
+          </Button>
+          <Button
+            isIconOnly
+            isSquared
+            isDisabled={showSkeleton || currentPage === 1}
+            onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+            aria-label="Previous page"
+          >
+            <MdKeyboardArrowLeft />
+          </Button>
+          <span className="w-40 text-center text-sm text-light-300">
+            Page {currentPage} of {totalPages}
+          </span>
+          <Button
+            isIconOnly
+            isSquared
+            isDisabled={showSkeleton || currentPage === totalPages}
+            onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+            aria-label="Next page"
+          >
+            <MdKeyboardArrowRight />
+          </Button>
+          <Button
+            isIconOnly
+            isSquared
+            isDisabled={showSkeleton || currentPage === totalPages}
+            onClick={() => setCurrentPage(totalPages)}
+            aria-label="Last page"
+          >
+            <MdKeyboardDoubleArrowRight />
+          </Button>
+        </div>
+      }
     >
-      {/* toolbar */}
-      <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+      {/* Toolbar — ALWAYS rendered (even on skeleton) so its presence
+       * isn't a layout-shift trigger. Outcome chips render based on the
+       * full row set so they don't pop in/out as filters change. */}
+      <div className="mb-4 shrink-0 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <div className="relative flex items-center">
           <MdSearch className="absolute left-2.5 w-5 h-5 text-light-400" />
           <input
-            className="pl-9 pr-9 w-full lg:w-72 h-9 text-sm rounded-lg border border-light-50/5 bg-light-900 focus:bg-light-400/20 hover:bg-light-400/20 text-light-100 placeholder-light-400 transition duration-100 ease-in-out outline-light-50/60"
+            className="pl-9 pr-9 w-full lg:w-72 h-9 text-sm rounded-lg border border-light-50/5 bg-light-900 focus:bg-light-400/20 hover:bg-light-400/20 text-light-100 placeholder-light-400 transition duration-100 ease-in-out outline-light-50/60 disabled:opacity-60"
             type="text"
             placeholder="Search assay or endpoint"
             value={searchTerm}
+            disabled={showSkeleton}
             onChange={(e) => {
               setSearchTerm(e.target.value);
               setCurrentPage(1);
@@ -220,21 +282,25 @@ const BioactivityMeasurementsModal = ({
             </button>
           )}
         </div>
-        {availableOutcomes.length > 1 && (
-          <div className="flex flex-wrap gap-1.5">
-            {availableOutcomes.map((opt) => {
+        {/* Outcome filter row — reserved with a min-height so the row
+         * doesn't appear/disappear based on whether multiple outcomes
+         * are present. */}
+        <div className="min-h-[2rem] flex flex-wrap items-center gap-1.5">
+          {availableOutcomes.length > 1 &&
+            availableOutcomes.map((opt) => {
               const active = outcomeFilter === opt;
               return (
                 <button
                   key={opt}
                   type="button"
+                  disabled={showSkeleton}
                   onClick={() => {
                     setOutcomeFilter(opt);
                     setCurrentPage(1);
                   }}
                   aria-pressed={active}
                   className={twMerge(
-                    "px-3 py-1 rounded-full border-[1.5px] font-mono italic text-xs capitalize transition-colors",
+                    "px-3 py-1 rounded-full border-[1.5px] font-mono italic text-xs capitalize transition-colors disabled:opacity-60",
                     active
                       ? "bg-light-200 text-light-900 border-light-200 font-semibold"
                       : "bg-transparent border-light-700/60 text-light-400 hover:text-light-100 hover:border-light-500"
@@ -244,166 +310,122 @@ const BioactivityMeasurementsModal = ({
                 </button>
               );
             })}
-          </div>
-        )}
+        </div>
       </div>
 
-      <div className="max-h-[70vh] overflow-y-auto">
-        {showSkeleton ? (
-          <MeasurementsSkeleton rowCount={Math.min(rows.length || 6, 8)} />
-        ) : visible.length === 0 ? (
-          <div className="h-32 flex items-center justify-center text-light-300 gap-2 text-sm">
-            <MdInfoOutline />{" "}
+      {/* Scroll area — flex-1 so it absorbs the dialog's free space.
+       * Inside: the table always renders PAGE_SIZE row slots (data +
+       * empty padders), and an empty-state OVERLAY appears on top when
+       * the filtered set is empty, so the row scaffolding doesn't
+       * collapse. */}
+      <div className="flex-1 min-h-0 overflow-y-auto relative">
+        <MeasurementsTable
+          rows={visible}
+          placeholderCount={placeholderCount}
+          skeleton={showSkeleton}
+        />
+        {showEmptyState && (
+          <div className="absolute inset-0 flex items-center justify-center bg-light-950/80 text-light-300 gap-2 text-sm pointer-events-none">
+            <MdInfoOutline />
             {rows.length === 0
               ? "No measurements recorded for this pair"
               : "No measurements match the current filters"}
           </div>
-        ) : (
-          <MeasurementsTable rows={visible} />
         )}
       </div>
-
-      {totalPages > 1 && (
-        <div className="mt-6 max-w-xl w-full mx-auto flex items-center justify-between">
-          <Button
-            isIconOnly
-            isSquared
-            isDisabled={currentPage === 1}
-            onClick={() => setCurrentPage(1)}
-            aria-label="First page"
-          >
-            <MdKeyboardDoubleArrowLeft />
-          </Button>
-          <Button
-            isIconOnly
-            isSquared
-            isDisabled={currentPage === 1}
-            onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
-            aria-label="Previous page"
-          >
-            <MdKeyboardArrowLeft />
-          </Button>
-          <span className="w-40 text-center text-sm text-light-300">
-            Page {currentPage} of {totalPages}
-          </span>
-          <Button
-            isIconOnly
-            isSquared
-            isDisabled={currentPage === totalPages}
-            onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
-            aria-label="Next page"
-          >
-            <MdKeyboardArrowRight />
-          </Button>
-          <Button
-            isIconOnly
-            isSquared
-            isDisabled={currentPage === totalPages}
-            onClick={() => setCurrentPage(totalPages)}
-            aria-label="Last page"
-          >
-            <MdKeyboardDoubleArrowRight />
-          </Button>
-        </div>
-      )}
     </Modal>
   );
 };
 
-const MeasurementsSkeleton = ({ rowCount }: { rowCount: number }) => (
-  <table className="w-full table-fixed">
-    <colgroup>
-      <col className="w-[28%]" />
-      <col className="w-[16%]" />
-      <col className="w-[12%]" />
-      <col className="w-[22%]" />
-      <col className="w-[22%]" />
-    </colgroup>
-    <thead className="text-light-400 text-left">
-      <tr>
-        {["Assay", "Endpoint", "Outcome", "Value", "Curve"].map((h) => (
-          <th
-            key={h}
-            className="h-9 border-b border-light-700 leading-none py-1.5 px-2 first:pl-0 last:pr-0"
-          >
-            <span className="select-none uppercase text-xs font-medium">{h}</span>
-          </th>
-        ))}
-      </tr>
-    </thead>
-    <tbody>
-      {Array.from({ length: rowCount }).map((_, i) => (
-        <tr key={i}>
-          <td className="py-1.5 pr-2" colSpan={5}>
-            <LoadingCard className="h-5" />
-          </td>
-        </tr>
-      ))}
-    </tbody>
-  </table>
-);
-
-const MeasurementsTable = ({ rows }: { rows: ModalRow[] }) => (
-  <table className="w-full table-fixed">
-    <colgroup>
-      <col className="w-[28%]" />
-      <col className="w-[16%]" />
-      <col className="w-[12%]" />
-      <col className="w-[22%]" />
-      <col className="w-[22%]" />
-    </colgroup>
-    <thead className="text-light-400 text-left">
-      <tr>
-        {["Assay", "Endpoint", "Outcome", "Value", "Curve"].map((h) => (
-          <th
-            key={h}
-            className="h-9 border-b border-light-700 leading-none py-1.5 px-2 first:pl-0 last:pr-0"
-          >
-            <span className="select-none uppercase text-xs font-medium">{h}</span>
-          </th>
-        ))}
-      </tr>
-    </thead>
-    <tbody className="text-sm font-light">
-      {rows.map((m, i) => (
-        <tr key={`${m.assay ?? "row"}-${i}`}>
-          <td className="py-1.5 pr-2 align-top">
-            <div
-              className="font-mono text-xs text-light-200 truncate"
-              title={m.assay ?? undefined}
+const MeasurementsTable = ({
+  rows,
+  placeholderCount,
+  skeleton,
+}: {
+  rows: ModalRow[];
+  placeholderCount: number;
+  skeleton: boolean;
+}) => {
+  // When in skeleton mode we draw PAGE_SIZE shimmer rows; otherwise we
+  // draw the real rows and pad up to PAGE_SIZE with empty <tr>s so the
+  // last-page case doesn't shrink the table height.
+  const dataRows = skeleton ? [] : rows;
+  const padCount = skeleton ? PAGE_SIZE : placeholderCount;
+  return (
+    <table className="w-full table-fixed">
+      <colgroup>
+        <col className="w-[28%]" />
+        <col className="w-[16%]" />
+        <col className="w-[12%]" />
+        <col className="w-[22%]" />
+        <col className="w-[22%]" />
+      </colgroup>
+      <thead className="text-light-400 text-left">
+        <tr>
+          {["Assay", "Endpoint", "Outcome", "Value", "Curve"].map((h) => (
+            <th
+              key={h}
+              className="h-9 border-b border-light-700 leading-none py-1.5 px-2 first:pl-0 last:pr-0"
             >
-              {m.assay ?? "—"}
-            </div>
-          </td>
-          <td className="py-1.5 px-2 align-top text-light-200">
-            {m.endpoint || "—"}
-          </td>
-          <td className="py-1.5 px-2 align-top">
-            <OutcomeBadge outcome={m.outcome} />
-          </td>
-          <td className="py-1.5 px-2 align-top font-mono text-xs text-light-200 tabular-nums text-right">
-            {m.value === null || m.value === undefined ? (
-              <span className="text-light-600">—</span>
-            ) : (
-              <>
-                {formatNumberShort(m.value)}{" "}
-                <span className="text-light-500">{m.unit || ""}</span>
-              </>
-            )}
-          </td>
-          <td className="py-1.5 pl-2 align-top text-light-300">
-            <HillCurveSparkline
-              zero={m.efficacy_zeroactivity}
-              infinite={m.efficacy_infiniteactivity}
-              logAC50={m.efficacy_logac50_value}
-              slope={m.efficacy_hillslope}
-            />
-          </td>
+              <span className="select-none uppercase text-xs font-medium">
+                {h}
+              </span>
+            </th>
+          ))}
         </tr>
-      ))}
-    </tbody>
-  </table>
-);
+      </thead>
+      <tbody className="text-sm font-light">
+        {dataRows.map((m, i) => (
+          <tr key={`${m.assay ?? "row"}-${i}`}>
+            <td className="py-1.5 pr-2 align-top">
+              <div
+                className="font-mono text-xs text-light-200 truncate"
+                title={m.assay ?? undefined}
+              >
+                {m.assay ?? "—"}
+              </div>
+            </td>
+            <td className="py-1.5 px-2 align-top text-light-200">
+              {m.endpoint || "—"}
+            </td>
+            <td className="py-1.5 px-2 align-top">
+              <OutcomeBadge outcome={m.outcome} />
+            </td>
+            <td className="py-1.5 px-2 align-top font-mono text-xs text-light-200 tabular-nums text-right">
+              {m.value === null || m.value === undefined ? (
+                <span className="text-light-600">—</span>
+              ) : (
+                <>
+                  {formatNumberShort(m.value)}{" "}
+                  <span className="text-light-500">{m.unit || ""}</span>
+                </>
+              )}
+            </td>
+            <td className="py-1.5 pl-2 align-top text-light-300">
+              <HillCurveSparkline
+                zero={m.efficacy_zeroactivity}
+                infinite={m.efficacy_infiniteactivity}
+                logAC50={m.efficacy_logac50_value}
+                slope={m.efficacy_hillslope}
+              />
+            </td>
+          </tr>
+        ))}
+        {Array.from({ length: padCount }).map((_, i) => (
+          <tr key={`pad-${i}`}>
+            <td className="py-1.5 pr-2" colSpan={5}>
+              {skeleton ? (
+                <LoadingCard className="h-5" />
+              ) : (
+                <div className="h-5" />
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};
 
 const OutcomeBadge = ({ outcome }: { outcome: string | null | undefined }) => {
   if (!outcome) return <span className="text-light-600">—</span>;

--- a/frontend/components/entities/bioactivity/BioactivityMeasurementsModal.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityMeasurementsModal.tsx
@@ -6,12 +6,25 @@
 // the MV-nested sample doesn't carry, so we can render a curve sparkline.
 // Falls back to `initialMeasurements` (the row's MV-capped sample) when
 // the fetch fails or anchor/row ids aren't both provided.
+//
+// Includes client-side search (assay + endpoint), outcome filter, and
+// 20-row pagination so a pair with hundreds of assays is browsable.
 
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { MdInfoOutline } from "react-icons/md";
+import {
+  MdClose,
+  MdInfoOutline,
+  MdKeyboardArrowLeft,
+  MdKeyboardArrowRight,
+  MdKeyboardDoubleArrowLeft,
+  MdKeyboardDoubleArrowRight,
+  MdSearch,
+} from "react-icons/md";
+import { twMerge } from "tailwind-merge";
 
+import Button from "@/components/basic/Button";
 import LoadingCard from "@/components/basic/LoadingCard";
 import Modal from "@/components/basic/Modal";
 import HillCurveSparkline from "@/components/entities/bioactivity/HillCurveSparkline";
@@ -21,9 +34,11 @@ import type {
   BioactivityMeasurementFull,
 } from "@/types";
 
-// Union row used by the modal — we render whichever subset of fields the
-// row actually carries. Full rows pick up the Hill-curve sparkline.
 type ModalRow = Partial<BioactivityMeasurementFull> & BioactivityMeasurement;
+
+const PAGE_SIZE = 20;
+const OUTCOME_OPTIONS = ["all", "active", "inactive", "unspecified", "inconclusive"] as const;
+type OutcomeFilter = (typeof OUTCOME_OPTIONS)[number];
 
 interface Props {
   isOpen: boolean;
@@ -32,12 +47,9 @@ interface Props {
   tailLabel: string;
   initialMeasurements?: BioactivityMeasurement[] | null;
   expectedCount?: number;
-  // When both are provided we lazy-fetch the full measurement set on open.
   anchorId?: string | null;
   selectedId?: string | null;
   relationship?: "r5" | "r6";
-  // For r5/r6 the head depends on direction; the section tells us which
-  // side the table-row corresponds to (anchor vs row).
   headIsRow?: boolean;
 }
 
@@ -59,8 +71,8 @@ const BioactivityMeasurementsModal = ({
   const [fullRows, setFullRows] = useState<ModalRow[] | null>(null);
   const [isFetching, setIsFetching] = useState(false);
 
-  // Lazy-fetch full measurements when opened. Resets on close so a
-  // subsequent open re-fetches if the selection changed.
+  // Lazy-fetch full measurements on open. Resets on close so a subsequent
+  // open re-fetches if the selection changed.
   useEffect(() => {
     if (!isOpen) {
       setFullRows(null);
@@ -73,11 +85,7 @@ const BioactivityMeasurementsModal = ({
     const headId = headIsRow ? selectedId : anchorId;
     const tailId = headIsRow ? anchorId : selectedId;
     (async () => {
-      const payload = await getBioactivityMeasurements(
-        headId,
-        tailId,
-        relationship
-      );
+      const payload = await getBioactivityMeasurements(headId, tailId, relationship);
       if (cancelled) return;
       const data = (payload?.data as BioactivityMeasurementFull[] | undefined) ?? null;
       setFullRows(data && data.length ? data : null);
@@ -92,14 +100,57 @@ const BioactivityMeasurementsModal = ({
     () => fullRows ?? initialMeasurements ?? [],
     [fullRows, initialMeasurements]
   );
-  const totalKnown = fullRows?.length ?? expectedCount ?? rows.length;
-  const showingFewerThanTotal =
-    fullRows == null && expectedCount != null && rows.length < expectedCount;
 
-  // Defer rendering the (potentially long) measurements table by one paint
-  // so the modal animation opens snappily and the user sees a skeleton in
-  // place of a frozen UI while React commits the rows. Resets when closed
-  // so the next open also gets the spinner.
+  const [searchTerm, setSearchTerm] = useState("");
+  const [outcomeFilter, setOutcomeFilter] = useState<OutcomeFilter>("all");
+  const [currentPage, setCurrentPage] = useState(1);
+
+  // Reset filters/page when the modal closes or the underlying selection
+  // changes (different chemical/food clicked).
+  useEffect(() => {
+    setSearchTerm("");
+    setOutcomeFilter("all");
+    setCurrentPage(1);
+  }, [isOpen, selectedId]);
+
+  // Only show the outcome chip for outcomes that actually occur in this
+  // pair's rows — most pairs only have one or two distinct outcomes.
+  const availableOutcomes = useMemo<OutcomeFilter[]>(() => {
+    const present = new Set<string>();
+    rows.forEach((r) => {
+      const o = r.outcome?.toLowerCase().trim();
+      if (o) present.add(o);
+    });
+    return OUTCOME_OPTIONS.filter((o) => o === "all" || present.has(o));
+  }, [rows]);
+
+  const filtered = useMemo(() => {
+    const term = searchTerm.trim().toLowerCase();
+    return rows.filter((r) => {
+      if (outcomeFilter !== "all") {
+        const o = r.outcome?.toLowerCase().trim() ?? "";
+        if (o !== outcomeFilter) return false;
+      }
+      if (term) {
+        const haystack = `${r.assay ?? ""} ${r.endpoint ?? ""}`.toLowerCase();
+        if (!haystack.includes(term)) return false;
+      }
+      return true;
+    });
+  }, [rows, searchTerm, outcomeFilter]);
+
+  const totalPages = Math.max(1, Math.ceil(filtered.length / PAGE_SIZE));
+  // Snap to page 1 when filters shrink the result set below the current page.
+  useEffect(() => {
+    if (currentPage > totalPages) setCurrentPage(1);
+  }, [currentPage, totalPages]);
+
+  const visible = useMemo(() => {
+    const start = (currentPage - 1) * PAGE_SIZE;
+    return filtered.slice(start, start + PAGE_SIZE);
+  }, [filtered, currentPage]);
+
+  // Defer rendering the table by one paint so the modal opens snappily.
   const [isContentReady, setIsContentReady] = useState(false);
   useEffect(() => {
     if (!isOpen) {
@@ -112,15 +163,27 @@ const BioactivityMeasurementsModal = ({
 
   const showSkeleton = !isContentReady || (isFetching && rows.length === 0);
 
+  // Total uses the full row count if available, falls back to the
+  // upstream-supplied expectedCount (which itself is the per-pair
+  // measurement_count from the list endpoint).
+  const totalKnown = fullRows?.length ?? expectedCount ?? rows.length;
+  const showingFewerThanTotal =
+    fullRows == null && expectedCount != null && rows.length < expectedCount;
+
   return (
     <Modal
-      title={`${headLabel} × ${tailLabel}`}
+      title={`Assay measurements · ${headLabel} × ${tailLabel}`}
       isOpen={isOpen}
       onClose={onClose}
       description={
         <span className="font-mono italic text-xs text-light-400 capitalize">
           {totalKnown.toLocaleString()} measurement
           {totalKnown === 1 ? "" : "s"}
+          {filtered.length !== rows.length && (
+            <span className="ml-2 not-italic normal-case text-light-600">
+              · {filtered.length.toLocaleString()} after filters
+            </span>
+          )}
           {showingFewerThanTotal && (
             <span className="ml-2 not-italic normal-case text-light-600">
               (showing first {rows.length})
@@ -129,17 +192,120 @@ const BioactivityMeasurementsModal = ({
         </span>
       }
     >
-      <div className="mt-4 max-h-[70vh] overflow-y-auto">
-        {showSkeleton ? (
-          <MeasurementsSkeleton rowCount={Math.min(rows.length || 6, 8)} />
-        ) : rows.length === 0 ? (
-          <div className="h-32 flex items-center justify-center text-light-300 gap-2 text-sm">
-            <MdInfoOutline /> No measurements recorded for this pair
+      {/* toolbar */}
+      <div className="mb-4 flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+        <div className="relative flex items-center">
+          <MdSearch className="absolute left-2.5 w-5 h-5 text-light-400" />
+          <input
+            className="pl-9 pr-9 w-full lg:w-72 h-9 text-sm rounded-lg border border-light-50/5 bg-light-900 focus:bg-light-400/20 hover:bg-light-400/20 text-light-100 placeholder-light-400 transition duration-100 ease-in-out outline-light-50/60"
+            type="text"
+            placeholder="Search assay or endpoint"
+            value={searchTerm}
+            onChange={(e) => {
+              setSearchTerm(e.target.value);
+              setCurrentPage(1);
+            }}
+          />
+          {searchTerm && (
+            <button
+              type="button"
+              aria-label="Clear search"
+              onClick={() => {
+                setSearchTerm("");
+                setCurrentPage(1);
+              }}
+              className="absolute right-2 flex items-center justify-center w-5 h-5 rounded-full text-light-400 hover:text-light-100 hover:bg-light-700 transition-colors"
+            >
+              <MdClose className="w-3.5 h-3.5" />
+            </button>
+          )}
+        </div>
+        {availableOutcomes.length > 1 && (
+          <div className="flex flex-wrap gap-1.5">
+            {availableOutcomes.map((opt) => {
+              const active = outcomeFilter === opt;
+              return (
+                <button
+                  key={opt}
+                  type="button"
+                  onClick={() => {
+                    setOutcomeFilter(opt);
+                    setCurrentPage(1);
+                  }}
+                  aria-pressed={active}
+                  className={twMerge(
+                    "px-3 py-1 rounded-full border-[1.5px] font-mono italic text-xs capitalize transition-colors",
+                    active
+                      ? "bg-light-200 text-light-900 border-light-200 font-semibold"
+                      : "bg-transparent border-light-700/60 text-light-400 hover:text-light-100 hover:border-light-500"
+                  )}
+                >
+                  {opt}
+                </button>
+              );
+            })}
           </div>
-        ) : (
-          <MeasurementsTable rows={rows} />
         )}
       </div>
+
+      <div className="max-h-[70vh] overflow-y-auto">
+        {showSkeleton ? (
+          <MeasurementsSkeleton rowCount={Math.min(rows.length || 6, 8)} />
+        ) : visible.length === 0 ? (
+          <div className="h-32 flex items-center justify-center text-light-300 gap-2 text-sm">
+            <MdInfoOutline />{" "}
+            {rows.length === 0
+              ? "No measurements recorded for this pair"
+              : "No measurements match the current filters"}
+          </div>
+        ) : (
+          <MeasurementsTable rows={visible} />
+        )}
+      </div>
+
+      {totalPages > 1 && (
+        <div className="mt-6 max-w-xl w-full mx-auto flex items-center justify-between">
+          <Button
+            isIconOnly
+            isSquared
+            isDisabled={currentPage === 1}
+            onClick={() => setCurrentPage(1)}
+            aria-label="First page"
+          >
+            <MdKeyboardDoubleArrowLeft />
+          </Button>
+          <Button
+            isIconOnly
+            isSquared
+            isDisabled={currentPage === 1}
+            onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+            aria-label="Previous page"
+          >
+            <MdKeyboardArrowLeft />
+          </Button>
+          <span className="w-40 text-center text-sm text-light-300">
+            Page {currentPage} of {totalPages}
+          </span>
+          <Button
+            isIconOnly
+            isSquared
+            isDisabled={currentPage === totalPages}
+            onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+            aria-label="Next page"
+          >
+            <MdKeyboardArrowRight />
+          </Button>
+          <Button
+            isIconOnly
+            isSquared
+            isDisabled={currentPage === totalPages}
+            onClick={() => setCurrentPage(totalPages)}
+            aria-label="Last page"
+          >
+            <MdKeyboardDoubleArrowRight />
+          </Button>
+        </div>
+      )}
     </Modal>
   );
 };
@@ -202,7 +368,10 @@ const MeasurementsTable = ({ rows }: { rows: ModalRow[] }) => (
       {rows.map((m, i) => (
         <tr key={`${m.assay ?? "row"}-${i}`}>
           <td className="py-1.5 pr-2 align-top">
-            <div className="font-mono text-xs text-light-200 truncate" title={m.assay ?? undefined}>
+            <div
+              className="font-mono text-xs text-light-200 truncate"
+              title={m.assay ?? undefined}
+            >
               {m.assay ?? "—"}
             </div>
           </td>

--- a/frontend/components/entities/bioactivity/BioactivityMeasurementsModal.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityMeasurementsModal.tsx
@@ -1,10 +1,11 @@
 // Modal that shows the per-(head, bioactivity) measurement list.
 //
-// Today the modal reads from `initialMeasurements` — the row's nested
-// measurements array as returned by the list endpoints (currently capped
-// at 25 by the materialized view). When /bioactivity/measurements is
-// deployed, we can switch to lazy-fetching the full unbounded set via
-// getBioactivityMeasurements.
+// Lazy-fetches the FULL measurement set from /bioactivity/measurements
+// when both the anchor entity id and the selected row id are known —
+// that endpoint returns Hill-fit fields (zero/infinite/logAC50/slope)
+// the MV-nested sample doesn't carry, so we can render a curve sparkline.
+// Falls back to `initialMeasurements` (the row's MV-capped sample) when
+// the fetch fails or anchor/row ids aren't both provided.
 
 "use client";
 
@@ -13,7 +14,16 @@ import { MdInfoOutline } from "react-icons/md";
 
 import LoadingCard from "@/components/basic/LoadingCard";
 import Modal from "@/components/basic/Modal";
-import type { BioactivityMeasurement } from "@/types";
+import HillCurveSparkline from "@/components/entities/bioactivity/HillCurveSparkline";
+import { getBioactivityMeasurements } from "@/utils/fetching";
+import type {
+  BioactivityMeasurement,
+  BioactivityMeasurementFull,
+} from "@/types";
+
+// Union row used by the modal — we render whichever subset of fields the
+// row actually carries. Full rows pick up the Hill-curve sparkline.
+type ModalRow = Partial<BioactivityMeasurementFull> & BioactivityMeasurement;
 
 interface Props {
   isOpen: boolean;
@@ -22,6 +32,13 @@ interface Props {
   tailLabel: string;
   initialMeasurements?: BioactivityMeasurement[] | null;
   expectedCount?: number;
+  // When both are provided we lazy-fetch the full measurement set on open.
+  anchorId?: string | null;
+  selectedId?: string | null;
+  relationship?: "r5" | "r6";
+  // For r5/r6 the head depends on direction; the section tells us which
+  // side the table-row corresponds to (anchor vs row).
+  headIsRow?: boolean;
 }
 
 const formatNumberShort = (n: number): string =>
@@ -34,13 +51,50 @@ const BioactivityMeasurementsModal = ({
   tailLabel,
   initialMeasurements,
   expectedCount,
+  anchorId,
+  selectedId,
+  relationship,
+  headIsRow,
 }: Props) => {
-  const rows = useMemo<BioactivityMeasurement[]>(
-    () => initialMeasurements ?? [],
-    [initialMeasurements]
+  const [fullRows, setFullRows] = useState<ModalRow[] | null>(null);
+  const [isFetching, setIsFetching] = useState(false);
+
+  // Lazy-fetch full measurements when opened. Resets on close so a
+  // subsequent open re-fetches if the selection changed.
+  useEffect(() => {
+    if (!isOpen) {
+      setFullRows(null);
+      setIsFetching(false);
+      return;
+    }
+    if (!anchorId || !selectedId || !relationship) return;
+    let cancelled = false;
+    setIsFetching(true);
+    const headId = headIsRow ? selectedId : anchorId;
+    const tailId = headIsRow ? anchorId : selectedId;
+    (async () => {
+      const payload = await getBioactivityMeasurements(
+        headId,
+        tailId,
+        relationship
+      );
+      if (cancelled) return;
+      const data = (payload?.data as BioactivityMeasurementFull[] | undefined) ?? null;
+      setFullRows(data && data.length ? data : null);
+      setIsFetching(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, anchorId, selectedId, relationship, headIsRow]);
+
+  const rows = useMemo<ModalRow[]>(
+    () => fullRows ?? initialMeasurements ?? [],
+    [fullRows, initialMeasurements]
   );
-  const totalKnown = expectedCount ?? rows.length;
-  const showingFewerThanTotal = expectedCount != null && rows.length < expectedCount;
+  const totalKnown = fullRows?.length ?? expectedCount ?? rows.length;
+  const showingFewerThanTotal =
+    fullRows == null && expectedCount != null && rows.length < expectedCount;
 
   // Defer rendering the (potentially long) measurements table by one paint
   // so the modal animation opens snappily and the user sees a skeleton in
@@ -55,6 +109,8 @@ const BioactivityMeasurementsModal = ({
     const raf = requestAnimationFrame(() => setIsContentReady(true));
     return () => cancelAnimationFrame(raf);
   }, [isOpen]);
+
+  const showSkeleton = !isContentReady || (isFetching && rows.length === 0);
 
   return (
     <Modal
@@ -74,7 +130,7 @@ const BioactivityMeasurementsModal = ({
       }
     >
       <div className="mt-4 max-h-[70vh] overflow-y-auto">
-        {!isContentReady ? (
+        {showSkeleton ? (
           <MeasurementsSkeleton rowCount={Math.min(rows.length || 6, 8)} />
         ) : rows.length === 0 ? (
           <div className="h-32 flex items-center justify-center text-light-300 gap-2 text-sm">
@@ -91,14 +147,15 @@ const BioactivityMeasurementsModal = ({
 const MeasurementsSkeleton = ({ rowCount }: { rowCount: number }) => (
   <table className="w-full table-fixed">
     <colgroup>
-      <col className="w-[34%]" />
-      <col className="w-[20%]" />
-      <col className="w-[14%]" />
-      <col className="w-[32%]" />
+      <col className="w-[28%]" />
+      <col className="w-[16%]" />
+      <col className="w-[12%]" />
+      <col className="w-[22%]" />
+      <col className="w-[22%]" />
     </colgroup>
     <thead className="text-light-400 text-left">
       <tr>
-        {["Assay", "Endpoint", "Outcome", "Value"].map((h) => (
+        {["Assay", "Endpoint", "Outcome", "Value", "Curve"].map((h) => (
           <th
             key={h}
             className="h-9 border-b border-light-700 leading-none py-1.5 px-2 first:pl-0 last:pr-0"
@@ -111,7 +168,7 @@ const MeasurementsSkeleton = ({ rowCount }: { rowCount: number }) => (
     <tbody>
       {Array.from({ length: rowCount }).map((_, i) => (
         <tr key={i}>
-          <td className="py-1.5 pr-2" colSpan={4}>
+          <td className="py-1.5 pr-2" colSpan={5}>
             <LoadingCard className="h-5" />
           </td>
         </tr>
@@ -120,17 +177,18 @@ const MeasurementsSkeleton = ({ rowCount }: { rowCount: number }) => (
   </table>
 );
 
-const MeasurementsTable = ({ rows }: { rows: BioactivityMeasurement[] }) => (
+const MeasurementsTable = ({ rows }: { rows: ModalRow[] }) => (
   <table className="w-full table-fixed">
     <colgroup>
-      <col className="w-[34%]" />
-      <col className="w-[20%]" />
-      <col className="w-[14%]" />
-      <col className="w-[32%]" />
+      <col className="w-[28%]" />
+      <col className="w-[16%]" />
+      <col className="w-[12%]" />
+      <col className="w-[22%]" />
+      <col className="w-[22%]" />
     </colgroup>
     <thead className="text-light-400 text-left">
       <tr>
-        {["Assay", "Endpoint", "Outcome", "Value"].map((h) => (
+        {["Assay", "Endpoint", "Outcome", "Value", "Curve"].map((h) => (
           <th
             key={h}
             className="h-9 border-b border-light-700 leading-none py-1.5 px-2 first:pl-0 last:pr-0"
@@ -154,8 +212,8 @@ const MeasurementsTable = ({ rows }: { rows: BioactivityMeasurement[] }) => (
           <td className="py-1.5 px-2 align-top">
             <OutcomeBadge outcome={m.outcome} />
           </td>
-          <td className="py-1.5 pl-2 align-top font-mono text-xs text-light-200 tabular-nums text-right">
-            {m.value === null ? (
+          <td className="py-1.5 px-2 align-top font-mono text-xs text-light-200 tabular-nums text-right">
+            {m.value === null || m.value === undefined ? (
               <span className="text-light-600">—</span>
             ) : (
               <>
@@ -164,13 +222,21 @@ const MeasurementsTable = ({ rows }: { rows: BioactivityMeasurement[] }) => (
               </>
             )}
           </td>
+          <td className="py-1.5 pl-2 align-top text-light-300">
+            <HillCurveSparkline
+              zero={m.efficacy_zeroactivity}
+              infinite={m.efficacy_infiniteactivity}
+              logAC50={m.efficacy_logac50_value}
+              slope={m.efficacy_hillslope}
+            />
+          </td>
         </tr>
       ))}
     </tbody>
   </table>
 );
 
-const OutcomeBadge = ({ outcome }: { outcome: string | null }) => {
+const OutcomeBadge = ({ outcome }: { outcome: string | null | undefined }) => {
   if (!outcome) return <span className="text-light-600">—</span>;
   const lc = outcome.toLowerCase();
   const tone =

--- a/frontend/components/entities/bioactivity/BioactivityTable.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityTable.tsx
@@ -87,6 +87,12 @@ interface Props {
     anchorLabel: string;
     headIsRow: boolean;
     relationship: "r5" | "r6";
+    // Anchor entity's foodatlas_id, when known. Combined with the
+    // selected row's id, the modal lazy-fetches the full measurement set
+    // from /bioactivity/measurements (which carries Hill-fit fields for
+    // the dose-response sparkline). When absent, modal falls back to the
+    // row's MV-nested sample only.
+    anchorId?: string | null;
   };
 }
 
@@ -275,6 +281,10 @@ const BioactivityTable = ({
         }
         initialMeasurements={selected?.measurements ?? []}
         expectedCount={selected?.measurement_count}
+        anchorId={modalConfig.anchorId}
+        selectedId={selected?.id}
+        relationship={modalConfig.relationship}
+        headIsRow={modalConfig.headIsRow}
       />
     </div>
   );

--- a/frontend/components/entities/bioactivity/ChemicalBioactivitiesSection.tsx
+++ b/frontend/components/entities/bioactivity/ChemicalBioactivitiesSection.tsx
@@ -15,9 +15,10 @@ import BioactivityTable, {
 
 interface Props {
   commonName: string;
+  anchorId?: string | null;
 }
 
-const ChemicalBioactivitiesSection = ({ commonName }: Props) => {
+const ChemicalBioactivitiesSection = ({ commonName, anchorId }: Props) => {
   const fetcher = useCallback(
     (params: BioactivityListParams) =>
       getChemicalBioactivities(commonName, params),
@@ -83,6 +84,7 @@ const ChemicalBioactivitiesSection = ({ commonName }: Props) => {
         anchorLabel: commonName,
         headIsRow: false,
         relationship: "r6",
+        anchorId,
       }}
     />
   );

--- a/frontend/components/entities/bioactivity/FoodBioactivitiesSection.tsx
+++ b/frontend/components/entities/bioactivity/FoodBioactivitiesSection.tsx
@@ -13,9 +13,10 @@ import BioactivityTable, {
 
 interface Props {
   commonName: string;
+  anchorId?: string | null;
 }
 
-const FoodBioactivitiesSection = ({ commonName }: Props) => {
+const FoodBioactivitiesSection = ({ commonName, anchorId }: Props) => {
   const fetcher = useCallback(
     (params: BioactivityListParams) => getFoodBioactivities(commonName, params),
     [commonName]
@@ -60,6 +61,7 @@ const FoodBioactivitiesSection = ({ commonName }: Props) => {
         anchorLabel: commonName,
         headIsRow: false,
         relationship: "r5",
+        anchorId,
       }}
     />
   );

--- a/frontend/components/entities/bioactivity/HillCurveSparkline.tsx
+++ b/frontend/components/entities/bioactivity/HillCurveSparkline.tsx
@@ -1,0 +1,123 @@
+// 4-parameter Hill / log-logistic dose-response curve, drawn as a tiny
+// SVG sparkline. Renders only when ALL four params are present; the
+// component returns null otherwise (most ChEMBL/PubChem rows only carry
+// a logAC50 + raw value, no full fit — only ToxCast-style measurements
+// have zero/infinite/slope too).
+//
+// Hill equation (concentration-form):
+//   y(x) = bottom + (top − bottom) / (1 + 10^((logAC50 − log10(x)) * slope))
+
+interface Props {
+  zero: number | null | undefined;
+  infinite: number | null | undefined;
+  logAC50: number | null | undefined;
+  slope: number | null | undefined;
+  width?: number;
+  height?: number;
+}
+
+const SAMPLES = 80;
+// Sweep 3 decades on each side of AC50 — captures the plateau-rise-plateau
+// shape for any sane slope (-3..+3 dose-effect range covers > 99% of fits).
+const DECADES = 3;
+
+const HillCurveSparkline = ({
+  zero,
+  infinite,
+  logAC50,
+  slope,
+  width = 120,
+  height = 40,
+}: Props) => {
+  if (
+    zero == null ||
+    infinite == null ||
+    logAC50 == null ||
+    slope == null ||
+    !Number.isFinite(zero) ||
+    !Number.isFinite(infinite) ||
+    !Number.isFinite(logAC50) ||
+    !Number.isFinite(slope) ||
+    slope === 0 ||
+    zero === infinite
+  ) {
+    return null;
+  }
+
+  const logXMin = logAC50 - DECADES;
+  const logXMax = logAC50 + DECADES;
+  const yMin = Math.min(zero, infinite);
+  const yMax = Math.max(zero, infinite);
+  const yRange = yMax - yMin;
+
+  const points: string[] = [];
+  for (let i = 0; i < SAMPLES; i++) {
+    const t = i / (SAMPLES - 1);
+    const logX = logXMin + t * (logXMax - logXMin);
+    const y = zero + (infinite - zero) / (1 + 10 ** ((logAC50 - logX) * slope));
+    const px = t * width;
+    const py = height - ((y - yMin) / yRange) * height;
+    points.push(`${px.toFixed(1)},${py.toFixed(1)}`);
+  }
+
+  // AC50 marker — vertical line + dot at the midpoint.
+  const midX = ((logAC50 - logXMin) / (logXMax - logXMin)) * width;
+  const midY = height / 2;
+
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      role="img"
+      aria-label={`Hill curve fit, AC50 at 10^${logAC50.toFixed(2)}, slope ${slope.toFixed(2)}`}
+      className="block"
+    >
+      {/* baseline + asymptote ticks */}
+      <line
+        x1="0"
+        x2={width}
+        y1={height - 0.5}
+        y2={height - 0.5}
+        stroke="currentColor"
+        strokeOpacity="0.15"
+        strokeWidth="1"
+      />
+      <line
+        x1="0"
+        x2={width}
+        y1="0.5"
+        y2="0.5"
+        stroke="currentColor"
+        strokeOpacity="0.15"
+        strokeWidth="1"
+      />
+      {/* AC50 marker line */}
+      <line
+        x1={midX}
+        x2={midX}
+        y1="0"
+        y2={height}
+        stroke="currentColor"
+        strokeOpacity="0.2"
+        strokeWidth="1"
+        strokeDasharray="2 2"
+      />
+      {/* curve */}
+      <polyline
+        points={points.join(" ")}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      {/* AC50 dot */}
+      <circle cx={midX} cy={midY} r="2" fill="currentColor" />
+    </svg>
+  );
+};
+
+HillCurveSparkline.displayName = "HillCurveSparkline";
+
+export default HillCurveSparkline;


### PR DESCRIPTION
## Summary
- New `HillCurveSparkline` SVG component that draws the 4-param Hill fit (`zero`, `infinite`, `logAC50`, `slope`) as a tiny sparkline; renders only when all four are present.
- `BioactivityMeasurementsModal` now lazy-fetches the full measurement set from `/bioactivity/measurements` on open (the MV-nested sample doesn't carry efficacy fields). Falls back to the MV sample if the fetch fails or required ids aren't known.
- Threaded `anchorId` (the page's entity `foodatlas_id`) from each entity page → section → `modalConfig` so the modal has both head and tail for the measurements query.

## Test plan
- [ ] Open a bioactivity (e.g. /bioactivity/androgen-receptor-antagonist) → click "View N assays" on any chemical → ToxCast rows show a curve in the Curve column; ChEMBL rows show an empty cell.
- [ ] Rows without full fit don't crash, just show an empty Curve cell.
- [ ] Modal still works when anchor id can't be resolved (fallback to MV-nested sample, no curve).

🤖 Generated with [Claude Code](https://claude.com/claude-code)