### PR TITLE
feat(bioactivity): endpoint · unit filter + sort by top measurement

### DIFF
--- a/backend/api/src/repositories/bioactivity.py
+++ b/backend/api/src/repositories/bioactivity.py
@@ -48,13 +48,20 @@ _BIO_FOOD_SORT = {
 }
 _VALID_DIR = {"ASC", "DESC"}
 
+# Pseudo-column used when sorting by the row's top measurement value.
+# Resolves to a SQL expression in _paginated, not an actual MV column —
+# only valid when filter_endpoint + filter_unit are both supplied, since
+# raw values across endpoints/units aren't comparable.
+TOP_VALUE_SORT = "top_measurement_value"
+
 
 def _resolve_sort(
     sort_by: str, sort_dir: str, allowlist: dict[str, str], default: str
 ) -> tuple[str, str]:
-    col = allowlist.get(sort_by, default)
     direction = sort_dir.upper() if sort_dir.upper() in _VALID_DIR else "DESC"
-    return col, direction
+    if sort_by == TOP_VALUE_SORT:
+        return TOP_VALUE_SORT, direction
+    return allowlist.get(sort_by, default), direction
 
 
 def _top_measurement_by_value(measurements: list | None) -> dict | None:
@@ -120,18 +127,37 @@ async def _paginated(
     sort_dir: str,
     page: int,
     rows_per_page: int,
+    filter_endpoint: str = "",
+    filter_unit: str = "",
 ) -> dict[str, object]:
     """Shared paginated query against the bioactivity MVs.
 
     Counts and selects in two passes so total_pages reflects the filtered
     set. ``bind_value`` is the value bound to the WHERE filter on
     ``name_col`` (e.g. the bioactivity name or the chemical name).
+
+    When ``filter_endpoint`` and ``filter_unit`` are both set, the row set
+    is restricted to rows whose ``measurements`` JSON array contains at
+    least one item matching both, and the sort pseudo-column
+    ``TOP_VALUE_SORT`` resolves to ``MAX(value)`` across the matching
+    items. (Sorting on top value without a filter would compare raw
+    values across incomparable endpoint/unit combos, which is nonsense.)
     """
     params: dict = {"name": bind_value}
     where_parts = [f"{name_col} = :name"]
     if search:
         where_parts.append(f"{search_col} ILIKE :q")
         params["q"] = f"%{search}%"
+
+    has_filter = bool(filter_endpoint and filter_unit)
+    if has_filter:
+        where_parts.append(
+            "EXISTS (SELECT 1 FROM jsonb_array_elements(measurements) m"
+            " WHERE m->>'endpoint' = :ep AND m->>'unit' = :unit)"
+        )
+        params["ep"] = filter_endpoint
+        params["unit"] = filter_unit
+
     where = " AND ".join(where_parts)
 
     total_result = await session.execute(
@@ -140,12 +166,31 @@ async def _paginated(
     )
     total = int(total_result.scalar() or 0)
 
+    # When sorting by top value, materialise it as a SELECT-list
+    # expression and ORDER BY it. Falls back gracefully (returns 0 rows
+    # via NULLS LAST) when the row has no matching measurement.
+    order_expr = sort_col
+    extra_select = ""
+    if sort_col == TOP_VALUE_SORT:
+        if not has_filter:
+            # Without an endpoint+unit, top-value sort is undefined; fall
+            # back to measurement_count so the page still renders.
+            order_expr = "measurement_count"
+        else:
+            extra_select = (
+                ", (SELECT MAX((m->>'value')::NUMERIC)"
+                " FROM jsonb_array_elements(measurements) m"
+                " WHERE m->>'endpoint' = :ep AND m->>'unit' = :unit"
+                ") AS top_measurement_value"
+            )
+            order_expr = "top_measurement_value"
+
     offset = rows_per_page * (page - 1)
     rows_result = await session.execute(
         text(f"""
-            SELECT {select_cols}
+            SELECT {select_cols}{extra_select}
             FROM {mv} WHERE {where}
-            ORDER BY {sort_col} {sort_dir} NULLS LAST
+            ORDER BY {order_expr} {sort_dir} NULLS LAST
             OFFSET :offset ROWS FETCH FIRST :limit ROWS ONLY
         """),
         {**params, "offset": offset, "limit": rows_per_page},
@@ -165,6 +210,8 @@ async def get_chemicals(
     sort_by: str = "measurement_count",
     sort_dir: str = "desc",
     rows_per_page: int = ROWS_PER_PAGE_DEFAULT,
+    filter_endpoint: str = "",
+    filter_unit: str = "",
 ) -> dict[str, object]:
     """Chemicals measured for this bioactivity."""
     sort_col, direction = _resolve_sort(
@@ -186,6 +233,8 @@ async def get_chemicals(
         sort_dir=direction,
         page=page,
         rows_per_page=rows_per_page,
+        filter_endpoint=filter_endpoint,
+        filter_unit=filter_unit,
     )
 
 
@@ -197,6 +246,8 @@ async def get_foods(
     sort_by: str = "measurement_count",
     sort_dir: str = "desc",
     rows_per_page: int = ROWS_PER_PAGE_DEFAULT,
+    filter_endpoint: str = "",
+    filter_unit: str = "",
 ) -> dict[str, object]:
     """Foods that exhibit this bioactivity."""
     sort_col, direction = _resolve_sort(
@@ -217,6 +268,8 @@ async def get_foods(
         sort_dir=direction,
         page=page,
         rows_per_page=rows_per_page,
+        filter_endpoint=filter_endpoint,
+        filter_unit=filter_unit,
     )
 
 
@@ -228,6 +281,8 @@ async def get_chemical_bioactivities(
     sort_by: str = "measurement_count",
     sort_dir: str = "desc",
     rows_per_page: int = ROWS_PER_PAGE_DEFAULT,
+    filter_endpoint: str = "",
+    filter_unit: str = "",
 ) -> dict[str, object]:
     """A chemical's bioactivities."""
     sort_col, direction = _resolve_sort(
@@ -249,6 +304,8 @@ async def get_chemical_bioactivities(
         sort_dir=direction,
         page=page,
         rows_per_page=rows_per_page,
+        filter_endpoint=filter_endpoint,
+        filter_unit=filter_unit,
     )
 
 
@@ -260,6 +317,8 @@ async def get_food_bioactivities(
     sort_by: str = "measurement_count",
     sort_dir: str = "desc",
     rows_per_page: int = ROWS_PER_PAGE_DEFAULT,
+    filter_endpoint: str = "",
+    filter_unit: str = "",
 ) -> dict[str, object]:
     """A food's bioactivities."""
     sort_col, direction = _resolve_sort(
@@ -280,7 +339,74 @@ async def get_food_bioactivities(
         sort_dir=direction,
         page=page,
         rows_per_page=rows_per_page,
+        filter_endpoint=filter_endpoint,
+        filter_unit=filter_unit,
     )
+
+
+# ---------------------------------------------------------------------
+# Distinct (endpoint, unit) combos for one bioactivity ↔ {chemical|food}
+# direction — used by the table UI to populate filter chips. Counts come
+# from the bioactivity attestation store (no MV cap) so they reflect the
+# full set, not just the 25-row sample carried on each MV row.
+# ---------------------------------------------------------------------
+
+
+# direction → (relationship_id, pivot_side, pivot MV, pivot name column).
+# pivot_side is "head_id" or "tail_id" — the triplet column that holds
+# the pivot entity's id. The OPPOSITE side varies across rows (it's the
+# table-row entity), which is why the filter scopes only the pivot side.
+_DIRECTION_PIVOTS: dict[str, tuple[str, str, str]] = {
+    "bioactivity-chemicals": ("r6", "tail_id", "mv_bioactivity_entities"),
+    "bioactivity-foods": ("r5", "tail_id", "mv_bioactivity_entities"),
+    "chemical-bioactivities": ("r6", "head_id", "mv_chemical_entities"),
+    "food-bioactivities": ("r5", "head_id", "mv_food_entities"),
+}
+
+
+async def get_endpoint_options(
+    session: AsyncSession, common_name: str, direction: str
+) -> dict[str, object]:
+    """List distinct (endpoint, unit) combinations for the given pivot.
+
+    Used to populate the table's endpoint+unit filter chip row. Counts
+    are descending by occurrence so the UI can surface the most useful
+    chips first.
+    """
+    info = _DIRECTION_PIVOTS.get(direction)
+    if info is None:
+        return {"data": [], "metadata": {"row_count": 0}}
+    rel, pivot_side, mv = info
+
+    pivot_id = (
+        await session.execute(
+            text(f"SELECT foodatlas_id FROM {mv} WHERE common_name = :name"),
+            {"name": common_name},
+        )
+    ).scalar()
+    if not pivot_id:
+        return {"data": [], "metadata": {"row_count": 0}}
+
+    rows_result = await session.execute(
+        text(f"""
+            SELECT ba.evidence_endpoint_type AS endpoint,
+                   ba.potency_unit AS unit,
+                   COUNT(*) AS count
+            FROM base_triplets bt
+            CROSS JOIN LATERAL unnest(bt.attestation_ids) AS att(bm)
+            JOIN base_attestations_bioactivity ba
+              ON ba.bioactivity_metadata_id = att.bm
+            WHERE bt.relationship_id = :rel
+              AND bt.{pivot_side} = :pivot
+              AND ba.evidence_endpoint_type <> ''
+              AND ba.potency_unit <> ''
+            GROUP BY ba.evidence_endpoint_type, ba.potency_unit
+            ORDER BY COUNT(*) DESC
+        """),
+        {"rel": rel, "pivot": pivot_id},
+    )
+    data = [dict(r._mapping) for r in rows_result]
+    return {"data": data, "metadata": {"row_count": len(data)}}
 
 
 # ---------------------------------------------------------------------

--- a/backend/api/src/routes/bioactivity.py
+++ b/backend/api/src/routes/bioactivity.py
@@ -28,6 +28,8 @@ async def bioactivity_chemicals(
     search: str = Query(""),
     sort_by: str = Query("measurement_count"),
     sort_dir: str = Query("desc"),
+    filter_endpoint: str = Query(""),
+    filter_unit: str = Query(""),
     db: AsyncSession = Depends(get_db),
 ):
     return await bioactivity.get_chemicals(
@@ -37,6 +39,8 @@ async def bioactivity_chemicals(
         search=search,
         sort_by=sort_by,
         sort_dir=sort_dir,
+        filter_endpoint=filter_endpoint,
+        filter_unit=filter_unit,
     )
 
 
@@ -47,6 +51,8 @@ async def bioactivity_foods(
     search: str = Query(""),
     sort_by: str = Query("measurement_count"),
     sort_dir: str = Query("desc"),
+    filter_endpoint: str = Query(""),
+    filter_unit: str = Query(""),
     db: AsyncSession = Depends(get_db),
 ):
     return await bioactivity.get_foods(
@@ -56,7 +62,25 @@ async def bioactivity_foods(
         search=search,
         sort_by=sort_by,
         sort_dir=sort_dir,
+        filter_endpoint=filter_endpoint,
+        filter_unit=filter_unit,
     )
+
+
+@router.get("/endpoints")
+async def bioactivity_endpoint_options(
+    common_name: str = Query(...),
+    direction: str = Query(
+        ...,
+        description=(
+            "Pivot+relationship combo. One of: bioactivity-chemicals, "
+            "bioactivity-foods, chemical-bioactivities, food-bioactivities."
+        ),
+    ),
+    db: AsyncSession = Depends(get_db),
+):
+    """Distinct (endpoint, unit, count) tuples for the table's filter UI."""
+    return await bioactivity.get_endpoint_options(db, common_name, direction)
 
 
 @router.get("/measurements")

--- a/backend/api/src/routes/chemical.py
+++ b/backend/api/src/routes/chemical.py
@@ -54,6 +54,8 @@ async def chemical_bioactivities(
     search: str = Query(""),
     sort_by: str = Query("measurement_count"),
     sort_dir: str = Query("desc"),
+    filter_endpoint: str = Query(""),
+    filter_unit: str = Query(""),
     db: AsyncSession = Depends(get_db),
 ):
     return await bioactivity.get_chemical_bioactivities(
@@ -63,4 +65,6 @@ async def chemical_bioactivities(
         search=search,
         sort_by=sort_by,
         sort_dir=sort_dir,
+        filter_endpoint=filter_endpoint,
+        filter_unit=filter_unit,
     )

--- a/backend/api/src/routes/food.py
+++ b/backend/api/src/routes/food.py
@@ -105,6 +105,8 @@ async def food_bioactivities(
     search: str = Query(""),
     sort_by: str = Query("measurement_count"),
     sort_dir: str = Query("desc"),
+    filter_endpoint: str = Query(""),
+    filter_unit: str = Query(""),
     db: AsyncSession = Depends(get_db),
 ):
     return await bioactivity.get_food_bioactivities(
@@ -114,4 +116,6 @@ async def food_bioactivities(
         search=search,
         sort_by=sort_by,
         sort_dir=sort_dir,
+        filter_endpoint=filter_endpoint,
+        filter_unit=filter_unit,
     )

--- a/frontend/__tests__/bioactivity-sections.test.tsx
+++ b/frontend/__tests__/bioactivity-sections.test.tsx
@@ -12,6 +12,9 @@ vi.mock("@/utils/fetching", () => ({
   getBioactivityFoods: vi.fn(),
   getChemicalBioactivities: vi.fn(),
   getFoodBioactivities: vi.fn(),
+  // BioactivityTable calls this on mount to populate the endpoint·unit
+  // filter chips; stub it so the mock graph is complete.
+  getBioactivityEndpointOptions: vi.fn().mockResolvedValue([]),
 }));
 
 // next/navigation isn't mounted in the vitest jsdom env; Button uses

--- a/frontend/components/entities/bioactivity/BioactivityChemicalsSection.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityChemicalsSection.tsx
@@ -8,6 +8,7 @@ import type { BioactivityChemicalRow } from "@/types";
 import BioactivityTable, {
   NameLinkCell,
   NumberCell,
+  TOP_MEASUREMENT_SORT_KEY,
   TopMeasurementCell,
   ViewAssaysCell,
   type SortableColumn,
@@ -56,10 +57,11 @@ const BioactivityChemicalsSection = ({ commonName, anchorId }: Props) => {
         ),
       },
       {
-        key: "top",
+        key: TOP_MEASUREMENT_SORT_KEY,
         label: "Top measurement",
         align: "right",
         width: "w-[28%]",
+        sortable: true,
         render: (row) => <TopMeasurementCell row={row} />,
       },
       {
@@ -76,6 +78,8 @@ const BioactivityChemicalsSection = ({ commonName, anchorId }: Props) => {
   return (
     <BioactivityTable
       tableId={`bioactivity-chemicals-${commonName}`}
+      direction="bioactivity-chemicals"
+      pivotName={commonName}
       fetcher={fetcher}
       columns={columns}
       searchPlaceholder="Search chemicals"

--- a/frontend/components/entities/bioactivity/BioactivityFoodsSection.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityFoodsSection.tsx
@@ -6,6 +6,7 @@ import { getBioactivityFoods } from "@/utils/fetching";
 import type { BioactivityListParams } from "@/utils/fetching";
 import BioactivityTable, {
   NameLinkCell,
+  TOP_MEASUREMENT_SORT_KEY,
   TopMeasurementCell,
   ViewAssaysCell,
   type SortableColumn,
@@ -33,10 +34,11 @@ const BioactivityFoodsSection = ({ commonName, anchorId }: Props) => {
         render: (row) => <NameLinkCell row={row} hrefPrefix="/food/" />,
       },
       {
-        key: "top",
+        key: TOP_MEASUREMENT_SORT_KEY,
         label: "Top measurement",
         align: "right",
         width: "w-[35%]",
+        sortable: true,
         render: (row) => <TopMeasurementCell row={row} />,
       },
       {
@@ -53,6 +55,8 @@ const BioactivityFoodsSection = ({ commonName, anchorId }: Props) => {
   return (
     <BioactivityTable
       tableId={`bioactivity-foods-${commonName}`}
+      direction="bioactivity-foods"
+      pivotName={commonName}
       fetcher={fetcher}
       columns={columns}
       searchPlaceholder="Search foods"

--- a/frontend/components/entities/bioactivity/BioactivityTable.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityTable.tsx
@@ -16,6 +16,7 @@ import {
   MdSearch,
   MdUnfoldMore,
 } from "react-icons/md";
+import { twMerge } from "tailwind-merge";
 
 import Link from "@/components/basic/Link";
 import LoadingCard from "@/components/basic/LoadingCard";
@@ -24,8 +25,10 @@ import BioactivityMeasurementsModal from "@/components/entities/bioactivity/Bioa
 import { formatTopMeasurement, topMeasurementOf } from "@/components/entities/bioactivity/format";
 import { usePaginations } from "@/context/paginationsContext";
 import { encodeSpace } from "@/utils/utils";
-import type {
-  BioactivityListParams,
+import {
+  getBioactivityEndpointOptions,
+  type BioactivityDirection,
+  type BioactivityListParams,
 } from "@/utils/fetching";
 import type {
   BioactivityChemicalRow,
@@ -54,9 +57,20 @@ export type SortableColumn = {
   render: (row: BioactivityRow, ctx: ColumnContext) => ReactNode;
 };
 
+// Sort-by value that the API understands as "max value across matching
+// measurements" — only meaningful when an endpoint+unit filter is set.
+const TOP_VALUE_SORT_KEY = "top_measurement_value";
+
 interface Props {
   // Stable identifier for pagination context — e.g. "food-bioact-foodId".
   tableId: string;
+  // Pivot+direction combo used to fetch the endpoint-filter chip options.
+  // Optional — when absent, the chip row is hidden (table behaves as
+  // before). Must match the route the fetcher hits.
+  direction?: BioactivityDirection;
+  // The pivot entity's common_name, used by getBioactivityEndpointOptions
+  // to look up the bioactivity_id (or chem/food id) in the right MV.
+  pivotName?: string;
   // Server-side fetcher; the table passes page/search/sort/sortDir.
   fetcher: (
     params: BioactivityListParams
@@ -98,6 +112,8 @@ interface Props {
 
 const BioactivityTable = ({
   tableId,
+  direction,
+  pivotName,
   fetcher,
   columns,
   defaultSortBy = "measurement_count",
@@ -114,6 +130,30 @@ const BioactivityTable = ({
     by: defaultSortBy,
     dir: defaultSortDir,
   });
+  // Filter chip selection. Empty string = "All" (no filter). Both must
+  // be set together for the backend to honour the filter; pairing them
+  // here keeps the wire format consistent.
+  const [filter, setFilter] = useState<{ endpoint: string; unit: string }>({
+    endpoint: "",
+    unit: "",
+  });
+  const filterActive = Boolean(filter.endpoint && filter.unit);
+  // Chip options: distinct (endpoint, unit, count) tuples for this
+  // direction+pivot, fetched once per page load.
+  const [filterOptions, setFilterOptions] = useState<
+    { endpoint: string; unit: string; count: number }[]
+  >([]);
+  useEffect(() => {
+    if (!direction || !pivotName) return;
+    let cancelled = false;
+    (async () => {
+      const opts = await getBioactivityEndpointOptions(pivotName, direction);
+      if (!cancelled) setFilterOptions(opts);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [direction, pivotName]);
 
   const [rows, setRows] = useState<BioactivityRow[]>([]);
   const [totalPages, setTotalPages] = useState(0);
@@ -132,6 +172,8 @@ const BioactivityTable = ({
         search: searchTerm,
         sortBy: sort.by,
         sortDir: sort.dir,
+        filterEndpoint: filter.endpoint || undefined,
+        filterUnit: filter.unit || undefined,
       });
       if (cancelled) return;
       setRows(payload?.data ?? []);
@@ -141,7 +183,7 @@ const BioactivityTable = ({
     return () => {
       cancelled = true;
     };
-  }, [fetcher, currentPage, searchTerm, sort]);
+  }, [fetcher, currentPage, searchTerm, sort, filter]);
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchTerm(e.target.value.toLowerCase());
@@ -151,13 +193,26 @@ const BioactivityTable = ({
     setSearchTerm("");
     setTablePaginations(tableId, 1, 20);
   };
+  // Top-measurement sort is only meaningful when a unit filter is set
+  // (raw values across units are incomparable). For that header, clicks
+  // toggle direction but require the filter to be active.
   const handleSortClick = (key: string) => {
+    if (key === TOP_VALUE_SORT_KEY && !filterActive) return;
     setTablePaginations(tableId, 1, 20);
     setSort((prev) =>
       prev.by === key
         ? { by: key, dir: prev.dir === "asc" ? "desc" : "asc" }
         : { by: key, dir: "desc" }
     );
+  };
+  const handleFilterChange = (endpoint: string, unit: string) => {
+    setFilter({ endpoint, unit });
+    setTablePaginations(tableId, 1, 20);
+    // When clearing the filter, also drop the top-value sort if it was
+    // active — it's not meaningful without a filter.
+    if (!endpoint && !unit && sort.by === TOP_VALUE_SORT_KEY) {
+      setSort({ by: defaultSortBy, dir: defaultSortDir });
+    }
   };
 
   const colSpan = columns.length;
@@ -166,8 +221,8 @@ const BioactivityTable = ({
 
   return (
     <div className="flex flex-col gap-7">
-      {/* toolbar — same shape as the composition table's search row */}
-      <div className="w-full">
+      {/* toolbar — search + endpoint:unit chip row */}
+      <div className="w-full flex flex-col gap-3">
         <div className="relative flex items-center">
           <MdSearch className="absolute left-2.5 w-5 h-5 text-light-400" />
           <input
@@ -188,6 +243,31 @@ const BioactivityTable = ({
             </button>
           )}
         </div>
+        {filterOptions.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-[10px] uppercase tracking-wider text-light-500 mr-1">
+              Endpoint · unit
+            </span>
+            <EndpointChip
+              label="All"
+              active={!filterActive}
+              onClick={() => handleFilterChange("", "")}
+            />
+            {filterOptions.map((opt) => {
+              const active =
+                filter.endpoint === opt.endpoint && filter.unit === opt.unit;
+              return (
+                <EndpointChip
+                  key={`${opt.endpoint}|${opt.unit}`}
+                  label={`${opt.endpoint} · ${opt.unit}`}
+                  count={opt.count}
+                  active={active}
+                  onClick={() => handleFilterChange(opt.endpoint, opt.unit)}
+                />
+              );
+            })}
+          </div>
+        )}
       </div>
 
       <div className="overflow-x-auto">
@@ -217,6 +297,11 @@ const BioactivityTable = ({
                       active={sort.by === c.key}
                       dir={sort.dir}
                       onClick={() => handleSortClick(c.key)}
+                      disabledHint={
+                        c.key === TOP_VALUE_SORT_KEY && !filterActive
+                          ? "Pick an endpoint · unit chip to sort by potency"
+                          : undefined
+                      }
                     />
                   ) : (
                     <span className="select-none uppercase text-xs font-medium">
@@ -332,19 +417,27 @@ const SortableHeader = ({
   active,
   dir,
   onClick,
+  disabledHint,
 }: {
   label: string;
   align?: "left" | "right";
   active: boolean;
   dir: SortDir;
   onClick: () => void;
+  // Tooltip + cursor when the column can't be sorted in the current
+  // state (e.g. cross-unit top-value sort with no filter selected).
+  disabledHint?: string;
 }) => (
   <button
     type="button"
     onClick={onClick}
-    className={`group flex items-center gap-1 ${
-      align === "right" ? "justify-end ml-auto" : ""
-    } cursor-pointer focus:outline-none`}
+    disabled={Boolean(disabledHint)}
+    title={disabledHint}
+    className={twMerge(
+      "group flex items-center gap-1 cursor-pointer focus:outline-none",
+      align === "right" && "justify-end ml-auto",
+      disabledHint && "cursor-not-allowed opacity-60"
+    )}
   >
     <span
       className={`select-none uppercase text-xs font-medium transition duration-300 ease-in-out ${
@@ -364,6 +457,47 @@ const SortableHeader = ({
     )}
   </button>
 );
+
+const EndpointChip = ({
+  label,
+  count,
+  active,
+  onClick,
+}: {
+  label: string;
+  count?: number;
+  active: boolean;
+  onClick: () => void;
+}) => (
+  <button
+    type="button"
+    onClick={onClick}
+    aria-pressed={active}
+    className={twMerge(
+      "inline-flex items-baseline gap-1 px-2.5 py-0.5 rounded-full border-[1.5px] font-mono italic text-xs transition-colors",
+      active
+        ? "bg-light-200 text-light-900 border-light-200 font-semibold"
+        : "bg-transparent border-light-700/60 text-light-400 hover:text-light-100 hover:border-light-500"
+    )}
+  >
+    <span>{label}</span>
+    {typeof count === "number" && (
+      <span
+        className={twMerge(
+          "not-italic font-mono text-[10px] tabular-nums",
+          active ? "text-light-700" : "text-light-500"
+        )}
+      >
+        {count.toLocaleString()}
+      </span>
+    )}
+  </button>
+);
+
+// Sort key recognised by the API as "sort by max value across
+// measurements that match filter_endpoint + filter_unit". Exported so
+// section column specs can use it as the Top Measurement sortable key.
+export const TOP_MEASUREMENT_SORT_KEY = TOP_VALUE_SORT_KEY;
 
 // Shared cell renderers used by sections (re-exported so each section's
 // column spec stays terse).

--- a/frontend/components/entities/bioactivity/ChemicalBioactivitiesSection.tsx
+++ b/frontend/components/entities/bioactivity/ChemicalBioactivitiesSection.tsx
@@ -8,6 +8,7 @@ import type { BioactivityChemicalRow } from "@/types";
 import BioactivityTable, {
   NameLinkCell,
   NumberCell,
+  TOP_MEASUREMENT_SORT_KEY,
   TopMeasurementCell,
   ViewAssaysCell,
   type SortableColumn,
@@ -56,10 +57,11 @@ const ChemicalBioactivitiesSection = ({ commonName, anchorId }: Props) => {
         ),
       },
       {
-        key: "top",
+        key: TOP_MEASUREMENT_SORT_KEY,
         label: "Top measurement",
         align: "right",
         width: "w-[28%]",
+        sortable: true,
         render: (row) => <TopMeasurementCell row={row} />,
       },
       {
@@ -76,6 +78,8 @@ const ChemicalBioactivitiesSection = ({ commonName, anchorId }: Props) => {
   return (
     <BioactivityTable
       tableId={`chemical-bioactivities-${commonName}`}
+      direction="chemical-bioactivities"
+      pivotName={commonName}
       fetcher={fetcher}
       columns={columns}
       searchPlaceholder="Search bioactivities"

--- a/frontend/components/entities/bioactivity/FoodBioactivitiesSection.tsx
+++ b/frontend/components/entities/bioactivity/FoodBioactivitiesSection.tsx
@@ -6,6 +6,7 @@ import { getFoodBioactivities } from "@/utils/fetching";
 import type { BioactivityListParams } from "@/utils/fetching";
 import BioactivityTable, {
   NameLinkCell,
+  TOP_MEASUREMENT_SORT_KEY,
   TopMeasurementCell,
   ViewAssaysCell,
   type SortableColumn,
@@ -33,10 +34,11 @@ const FoodBioactivitiesSection = ({ commonName, anchorId }: Props) => {
         render: (row) => <NameLinkCell row={row} hrefPrefix="/bioactivity/" />,
       },
       {
-        key: "top",
+        key: TOP_MEASUREMENT_SORT_KEY,
         label: "Top measurement",
         align: "right",
         width: "w-[35%]",
+        sortable: true,
         render: (row) => <TopMeasurementCell row={row} />,
       },
       {
@@ -53,6 +55,8 @@ const FoodBioactivitiesSection = ({ commonName, anchorId }: Props) => {
   return (
     <BioactivityTable
       tableId={`food-bioactivities-${commonName}`}
+      direction="food-bioactivities"
+      pivotName={commonName}
       fetcher={fetcher}
       columns={columns}
       searchPlaceholder="Search bioactivities"

--- a/frontend/utils/fetching.ts
+++ b/frontend/utils/fetching.ts
@@ -272,6 +272,12 @@ export type BioactivityListParams = {
   search?: string;
   sortBy?: string;
   sortDir?: "asc" | "desc";
+  // When both are set, the API restricts rows to those with at least
+  // one measurement matching the endpoint+unit, and `sort_by =
+  // "top_measurement_value"` becomes meaningful (sorts by max value
+  // across matching measurements).
+  filterEndpoint?: string;
+  filterUnit?: string;
 };
 
 const buildBioactivityQuery = (params?: BioactivityListParams): string => {
@@ -280,6 +286,8 @@ const buildBioactivityQuery = (params?: BioactivityListParams): string => {
   if (params?.search) p.set("search", params.search);
   if (params?.sortBy) p.set("sort_by", params.sortBy);
   if (params?.sortDir) p.set("sort_dir", params.sortDir);
+  if (params?.filterEndpoint) p.set("filter_endpoint", params.filterEndpoint);
+  if (params?.filterUnit) p.set("filter_unit", params.filterUnit);
   const qs = p.toString();
   return qs ? `&${qs}` : "";
 };
@@ -397,6 +405,43 @@ export async function getBioactivityMeasurements(
     return await res.json();
   } catch {
     return null;
+  }
+}
+
+// Direction selector for the bioactivity table — one per table-page combo.
+export type BioactivityDirection =
+  | "bioactivity-chemicals"
+  | "bioactivity-foods"
+  | "chemical-bioactivities"
+  | "food-bioactivities";
+
+// Distinct (endpoint, unit, count) tuples for the table's filter chips.
+// Returns [] on any fetch failure so the table can render without chips.
+export async function getBioactivityEndpointOptions(
+  commonName: string,
+  direction: BioactivityDirection
+): Promise<{ endpoint: string; unit: string; count: number }[]> {
+  try {
+    const res = await fetch(
+      `${apiBase()}/bioactivity/endpoints?common_name=${encodeURIComponent(
+        commonName
+      )}&direction=${direction}`,
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY}`,
+        },
+        next: { revalidate: 86400 },
+      }
+    );
+    if (!res.ok) return [];
+    const payload = await res.json();
+    return (payload?.data ?? []) as {
+      endpoint: string;
+      unit: string;
+      count: number;
+    }[];
+  } catch {
+    return [];
   }
 }
 


### PR DESCRIPTION
## Summary
Adds an "Endpoint · unit" filter chip row above the bioactivity tables. Pick a chip and the table narrows to rows with that endpoint+unit; the Top Measurement column header becomes sortable. "All" reverts.

## Why
Raw values from different endpoints / units aren't comparable (IC50 µM vs IC50 nM vs activity %), so sorting Top Measurement free-form is meaningless. Endpoint-first filter narrows the set to a uniformly comparable subset, then plain numeric sort works.

## Backend
- `filter_endpoint` + `filter_unit` params on the four bioactivity list endpoints.
- New `sort_by="top_measurement_value"` — materialises `MAX((m->>'value')::NUMERIC)` across matching items via `jsonb_array_elements(measurements)` and ORDERs by it.
- New `/bioactivity/endpoints?common_name=&direction=` returns `(endpoint, unit, count)` tuples for the chip row, sourced from `base_attestations_bioactivity` (no MV cap).

## Frontend
- New `BioactivityListParams` fields + `getBioactivityEndpointOptions`.
- `BioactivityTable` chip row, filter state, top-value sort wiring, disabled hint on the Top Measurement header when no filter is set.
- Each section passes `direction` + `pivotName` so the table knows what to query.

## Test plan
- [ ] /bioactivity/antioxidant chemicals tab → chip row populated with IC50/AC50/EC50 chips; clicking IC50 · MICROMOLAR filters rows and enables "Top measurement" sort.
- [ ] All chip clears and reverts sort.
- [ ] Same on /food/tomato → Bioactivities, /chemical/quercetin → Bioactivities, /bioactivity/<x> → Foods.

🤖 Generated with [Claude Code](https://claude.com/claude-code)