### PR TITLE
feat(newsletter): apothecary design language for email + landing preview

### DIFF
--- a/backend/kgc/data/newsletter.html
+++ b/backend/kgc/data/newsletter.html
@@ -3,67 +3,83 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>FoodAtlas Weekly Digest</title>
+  <meta name="color-scheme" content="dark only">
+  <meta name="supported-color-schemes" content="dark only">
+  <title>FoodAtlas Weekly Bulletin</title>
   <style>
-    body { margin:0; padding:0; background:#eef0ea; -webkit-text-size-adjust:100%; }
+    body { margin:0; padding:0; background:#0D0C0C; -webkit-text-size-adjust:100%; color:#efe6de; }
     table { border-collapse:collapse; }
     a { text-decoration:none; }
+    /* gmail dark-mode safety: force our colors regardless */
+    [data-ogsc] body, [data-ogsc] body * { background-color:inherit !important; color:inherit !important; }
   </style>
 </head>
-<body style="margin:0; padding:0; background:#eef0ea;">
-  <div style="display:none; max-height:0; overflow:hidden; font-size:1px; line-height:1px; color:#eef0ea; opacity:0;">
-    {{ new_papers|commafy }} new papers added {{ new_associations|commafy }} associations this week.
+<body style="margin:0; padding:0; background:#0D0C0C; color:#efe6de;">
+  <div style="display:none; max-height:0; overflow:hidden; font-size:1px; line-height:1px; color:#0D0C0C; opacity:0;">
+    {{ new_papers|commafy }} new papers · {{ new_associations|commafy }} new associations this week.
   </div>
-  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#eef0ea;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background:#0D0C0C;">
     <tr>
       <td align="center" style="padding:28px 12px;">
-        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="width:600px; background:#ffffff; border:1px solid #e2e7df; border-radius:10px;">
+        <table role="presentation" width="600" cellpadding="0" cellspacing="0" style="width:600px; background:#151414; border:1px solid #21201f; border-radius:12px;">
           <tr>
-            <td style="padding:38px 40px 40px 40px;">
+            <td style="padding:38px 36px 40px 36px;">
 
               <!-- MASTHEAD -->
               <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
                 <tr>
-                  <td align="left" style="font-family:Georgia,serif; font-size:20px; font-weight:700; color:#11241a; letter-spacing:-0.2px;">
-                    <span style="color:#1f6f4f;">Food</span>Atlas
+                  <td align="left" style="font-family:Georgia,'Times New Roman',serif; font-size:22px; font-weight:700; color:#efe6de; letter-spacing:-0.2px;">
+                    FoodAtlas
                   </td>
-                  <td align="right" style="font-family:Arial,sans-serif; font-size:11px; font-weight:700; letter-spacing:1.8px; color:#9aa69c; text-transform:uppercase;">
-                    Weekly&nbsp;Digest
+                  <td align="right" style="font-family:'Courier New',Courier,monospace; font-style:italic; font-size:10px; letter-spacing:0.22em; color:#837e7a; text-transform:uppercase;">
+                    Weekly&nbsp;Bulletin
                   </td>
                 </tr>
               </table>
-              <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
-                <tr><td style="border-top:1px solid #e7ebe4; height:26px; line-height:26px; font-size:0;">&nbsp;</td></tr>
+
+              <!-- top double rule -->
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:18px;">
+                <tr><td style="border-top:2px double #383634; height:24px; line-height:24px; font-size:0;">&nbsp;</td></tr>
               </table>
 
-              <!-- HEADLINE -->
-              <div style="font-family:Arial,sans-serif; font-size:11px; font-weight:700; letter-spacing:1.8px; color:#1f6f4f; text-transform:uppercase;">
-                Weekly Digest &nbsp;&middot;&nbsp; {{ date }}
-              </div>
-              <h1 style="margin:12px 0 0 0; font-family:Georgia,serif; font-size:27px; line-height:1.22; font-weight:700; color:#11241a;">
+              <!-- LEDE -->
+              <!-- apothecary chip label -->
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin-bottom:14px;">
+                <tr>
+                  <td style="background:#efe6de; padding:3px 10px; border-radius:4px; font-family:'Courier New',Courier,monospace; font-style:italic; font-weight:600; font-size:10px; letter-spacing:0.12em; color:#1a1918; text-transform:uppercase;">
+                    No. {{ date }}
+                  </td>
+                </tr>
+              </table>
+              <h1 style="margin:0; font-family:Georgia,'Times New Roman',serif; font-size:28px; line-height:1.22; font-weight:400; color:#efe6de;">
                 {{ new_associations|commafy }} new associations entered the atlas this week
               </h1>
-              <p style="margin:14px 0 0 0; font-family:Arial,sans-serif; font-size:14.5px; line-height:1.62; color:#4a554c;">
-                This week's literature run processed <strong style="color:#11241a;">{{ new_papers|commafy }}</strong> new papers and
-                added <strong style="color:#11241a;">{{ new_associations|commafy }}</strong> associations &mdash; including
-                <strong style="color:#11241a;">{{ new_food_chemical|commafy }}</strong> new food&ndash;chemical links across
+              <p style="margin:16px 0 0 0; font-family:Georgia,'Times New Roman',serif; font-size:15px; line-height:1.62; color:#b2aca5;">
+                The literature run processed
+                <strong style="color:#efe6de; font-weight:600;">{{ new_papers|commafy }}</strong> new papers and
+                added <strong style="color:#efe6de; font-weight:600;">{{ new_associations|commafy }}</strong> associations &mdash; including
+                <strong style="color:#efe6de; font-weight:600;">{{ new_food_chemical|commafy }}</strong> new food&ndash;chemical links across
                 {{ foods_touched|commafy }} foods and {{ chemicals_touched|commafy }} chemicals.
               </p>
 
               <!-- AT A GLANCE -->
               <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
-                <tr><td style="height:34px; line-height:34px; font-size:0;">&nbsp;</td></tr>
+                <tr><td style="height:36px; line-height:36px; font-size:0;">&nbsp;</td></tr>
               </table>
-              <div style="font-family:Arial,sans-serif; font-size:11px; font-weight:700; letter-spacing:1.5px; color:#8a958c; text-transform:uppercase;">
-                The atlas at a glance &nbsp;&middot;&nbsp; {{ date }}
-              </div>
-              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:14px; border-top:1px solid #e7ebe4; border-bottom:1px solid #e7ebe4;">
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin-bottom:14px;">
+                <tr>
+                  <td style="background:#efe6de; padding:3px 10px; border-radius:4px; font-family:'Courier New',Courier,monospace; font-style:italic; font-weight:600; font-size:10px; letter-spacing:0.12em; color:#1a1918; text-transform:uppercase;">
+                    At a glance
+                  </td>
+                </tr>
+              </table>
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="border-top:2px double #383634; border-bottom:2px double #383634;">
                 <tr>
                   {% for m in atlas %}
                   <td align="center" style="padding:18px 4px;">
-                    <div style="font-family:Georgia,serif; font-size:21px; font-weight:700; color:#11241a; line-height:1;">{{ m.value|commafy }}</div>
-                    <div style="font-family:Arial,sans-serif; font-size:10.5px; color:#8a958c; padding-top:7px; text-transform:uppercase; letter-spacing:0.5px;">{{ m.label }}</div>
-                    <div style="font-family:Arial,sans-serif; font-size:11px; font-weight:700; color:#1f6f4f; padding-top:5px;">{{ m.delta|signed }}</div>
+                    <div style="font-family:Georgia,'Times New Roman',serif; font-size:22px; font-weight:400; color:#efe6de; line-height:1;">{{ m.value|commafy }}</div>
+                    <div style="font-family:'Courier New',Courier,monospace; font-style:italic; font-size:10px; color:#837e7a; padding-top:7px; text-transform:uppercase; letter-spacing:0.12em;">{{ m.label }}</div>
+                    <div style="font-family:'Courier New',Courier,monospace; font-style:italic; font-size:11px; font-weight:600; color:#F4511E; padding-top:5px;">{{ m.delta|signed }}</div>
                   </td>
                   {% endfor %}
                 </tr>
@@ -73,19 +89,25 @@
               <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
                 <tr><td style="height:36px; line-height:36px; font-size:0;">&nbsp;</td></tr>
               </table>
-              <h2 style="margin:0; font-family:Georgia,serif; font-size:18px; font-weight:700; color:#11241a;">Foods with the most new discoveries</h2>
-              <p style="margin:5px 0 0 0; font-family:Arial,sans-serif; font-size:13px; color:#8a958c;">Ranked by number of distinct new compounds added this week.</p>
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin-bottom:8px;">
+                <tr>
+                  <td style="background:#efe6de; padding:3px 10px; border-radius:4px; font-family:'Courier New',Courier,monospace; font-style:italic; font-weight:600; font-size:10px; letter-spacing:0.12em; color:#1a1918; text-transform:uppercase;">
+                    Foods with most new discoveries
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0 0 4px 0; font-family:Georgia,'Times New Roman',serif; font-style:italic; font-size:13px; color:#837e7a;">Ranked by number of distinct new compounds added this week.</p>
 
               <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:6px;">
                 {% for h in highlights %}
                 <tr>
-                  <td valign="top" style="padding:16px 0;{% if not loop.last %} border-bottom:1px solid #edf0ea;{% endif %}">
-                    <div style="font-family:Georgia,serif; font-size:16px; font-weight:700;">
-                      <a href="{{ h.url }}" style="color:#11241a;">{{ h.name }}&nbsp;<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#1f6f4f" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg></a>
+                  <td valign="top" style="padding:14px 0;{% if not loop.last %} border-bottom:1px solid #21201f;{% endif %}">
+                    <div style="font-family:Georgia,'Times New Roman',serif; font-size:16px; font-weight:600;">
+                      <a href="{{ h.url }}" style="color:#efe6de;">{{ h.name }} <span style="color:#F4511E; font-family:'Courier New',Courier,monospace; font-style:italic; font-size:13px;">&rarr;</span></a>
                     </div>
-                    <div style="margin-top:7px; font-family:Arial,sans-serif; font-size:13px; line-height:1.5; color:#6a766c;">{{ h.chemicals|join("  ·  ") }}</div>
+                    <div style="margin-top:6px; font-family:'Courier New',Courier,monospace; font-style:italic; font-size:12px; line-height:1.5; color:#b2aca5;">{{ h.chemicals|join("  ·  ") }}</div>
                   </td>
-                  <td valign="top" align="right" width="78" style="padding:16px 0;{% if not loop.last %} border-bottom:1px solid #edf0ea;{% endif %} font-family:Arial,sans-serif; font-size:12px; font-weight:700; color:#1f6f4f; white-space:nowrap;">{{ h.count }} new</td>
+                  <td valign="top" align="right" width="78" style="padding:14px 0;{% if not loop.last %} border-bottom:1px solid #21201f;{% endif %} font-family:'Courier New',Courier,monospace; font-style:italic; font-size:12px; font-weight:600; color:#F4511E; white-space:nowrap;">{{ h.count }} new</td>
                 </tr>
                 {% endfor %}
               </table>
@@ -94,23 +116,29 @@
               <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
                 <tr><td style="height:36px; line-height:36px; font-size:0;">&nbsp;</td></tr>
               </table>
-              <h2 style="margin:0; font-family:Georgia,serif; font-size:18px; font-weight:700; color:#11241a;">New in the literature</h2>
-              <p style="margin:5px 0 0 0; font-family:Arial,sans-serif; font-size:13px; color:#8a958c;">Papers that contributed the most new food&ndash;chemical associations this week.</p>
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin-bottom:8px;">
+                <tr>
+                  <td style="background:#efe6de; padding:3px 10px; border-radius:4px; font-family:'Courier New',Courier,monospace; font-style:italic; font-weight:600; font-size:10px; letter-spacing:0.12em; color:#1a1918; text-transform:uppercase;">
+                    New in the literature
+                  </td>
+                </tr>
+              </table>
+              <p style="margin:0; font-family:Georgia,'Times New Roman',serif; font-style:italic; font-size:13px; color:#837e7a;">Papers that contributed the most new food&ndash;chemical associations this week.</p>
 
               {% for p in papers %}
-              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:12px; border-collapse:separate; border-spacing:0;">
+              <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:14px; border-collapse:separate; border-spacing:0;">
                 <tr>
-                  <td style="background:#f6faf4; border:1px solid #e4ebe0; border-radius:12px; padding:18px 20px;">
-                    <a href="{{ p.url }}" style="font-family:Georgia,serif; font-size:15.5px; line-height:1.34; font-weight:700; color:#11241a;">{{ p.title }}</a>
+                  <td style="background:#1a1918; border:1px solid #21201f; border-radius:10px; padding:18px 20px;">
+                    <a href="{{ p.url }}" style="font-family:Georgia,'Times New Roman',serif; font-size:15.5px; line-height:1.35; font-weight:600; color:#efe6de;">{{ p.title }}</a>
                     <table role="presentation" cellpadding="0" cellspacing="0" style="margin-top:12px;">
                       <tr><td>
-                        {% for chip in p.associations %}<span style="display:inline-block; font-family:Arial,sans-serif; font-size:12px; color:#1f6f4f; background:#eef6f1; border:1px solid #d4e7dc; border-radius:6px; padding:5px 9px; margin:0 6px 6px 0; line-height:1.3;">{{ chip }}</span>{% endfor %}
+                        {% for chip in p.associations %}<span style="display:inline-block; font-family:'Courier New',Courier,monospace; font-style:italic; font-size:11px; color:#1a1918; background:#efe6de; border-radius:999px; padding:3px 9px; margin:0 6px 6px 0; line-height:1.4;">{{ chip }}</span>{% endfor %}
                       </td></tr>
                     </table>
-                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:6px; border-top:1px solid #e4ebe0;">
+                    <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:8px; border-top:1px solid #21201f;">
                       <tr>
-                        <td style="padding-top:10px; font-family:Arial,sans-serif; font-size:12px; font-weight:700; color:#11241a;">{{ p.count|commafy }} new association{{ 's' if p.count != 1 else '' }}</td>
-                        <td align="right" style="padding-top:10px;"><a href="{{ p.url }}" style="font-family:Arial,sans-serif; font-size:12px; font-weight:700; color:#1f6f4f;">Source &rarr;</a></td>
+                        <td style="padding-top:10px; font-family:'Courier New',Courier,monospace; font-style:italic; font-size:11px; font-weight:600; color:#b2aca5;">{{ p.count|commafy }} new association{{ 's' if p.count != 1 else '' }}</td>
+                        <td align="right" style="padding-top:10px;"><a href="{{ p.url }}" style="font-family:'Courier New',Courier,monospace; font-style:italic; font-size:11px; font-weight:600; color:#F4511E;">Source &rarr;</a></td>
                       </tr>
                     </table>
                   </td>
@@ -122,16 +150,22 @@
               <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
                 <tr><td style="height:34px; line-height:34px; font-size:0;">&nbsp;</td></tr>
               </table>
-              <h2 style="margin:0; font-family:Georgia,serif; font-size:18px; font-weight:700; color:#11241a;">The atlas so far</h2>
+              <table role="presentation" cellpadding="0" cellspacing="0" style="margin-bottom:8px;">
+                <tr>
+                  <td style="background:#efe6de; padding:3px 10px; border-radius:4px; font-family:'Courier New',Courier,monospace; font-style:italic; font-weight:600; font-size:10px; letter-spacing:0.12em; color:#1a1918; text-transform:uppercase;">
+                    The atlas so far
+                  </td>
+                </tr>
+              </table>
 
-              <p style="margin:16px 0 0 0; font-family:Arial,sans-serif; font-size:12px; font-weight:700; letter-spacing:0.4px; color:#8a958c; text-transform:uppercase;">Most-characterized foods</p>
+              <p style="margin:14px 0 0 0; font-family:'Courier New',Courier,monospace; font-style:italic; font-size:11px; font-weight:600; letter-spacing:0.12em; color:#837e7a; text-transform:uppercase;">Most-characterized foods</p>
               <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="margin-top:2px;">
                 {% for r in most_characterized %}
                 <tr>
-                  <td style="padding:11px 0;{% if not loop.last %} border-bottom:1px solid #edf0ea;{% endif %} font-family:Georgia,serif; font-size:15px; font-weight:700;">
-                    <a href="{{ r.url }}" style="color:#11241a;">{{ r.name }}&nbsp;<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="#1f6f4f" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" style="vertical-align:middle;" aria-hidden="true"><path d="M10 13a5 5 0 0 0 7.54.54l3-3a5 5 0 0 0-7.07-7.07l-1.72 1.71"/><path d="M14 11a5 5 0 0 0-7.54-.54l-3 3a5 5 0 0 0 7.07 7.07l1.71-1.71"/></svg></a>
+                  <td style="padding:11px 0;{% if not loop.last %} border-bottom:1px solid #21201f;{% endif %} font-family:Georgia,'Times New Roman',serif; font-size:15px; font-weight:600;">
+                    <a href="{{ r.url }}" style="color:#efe6de;">{{ r.name }} <span style="color:#F4511E; font-family:'Courier New',Courier,monospace; font-style:italic; font-size:12px;">&rarr;</span></a>
                   </td>
-                  <td align="right" style="padding:11px 0;{% if not loop.last %} border-bottom:1px solid #edf0ea;{% endif %} font-family:Arial,sans-serif; font-size:13px; color:#6a766c; white-space:nowrap;">{{ r.value|commafy }} chemicals</td>
+                  <td align="right" style="padding:11px 0;{% if not loop.last %} border-bottom:1px solid #21201f;{% endif %} font-family:'Courier New',Courier,monospace; font-style:italic; font-size:12px; color:#b2aca5; white-space:nowrap;">{{ r.value|commafy }} chemicals</td>
                 </tr>
                 {% endfor %}
               </table>
@@ -142,7 +176,7 @@
               </table>
               <table role="presentation" width="100%" cellpadding="0" cellspacing="0"><tr>
                 <td align="center">
-                  <a href="https://foodatlas.ai" style="display:inline-block; background:#1f6f4f; font-family:Arial,sans-serif; font-size:13.5px; font-weight:700; color:#ffffff; padding:13px 28px; border-radius:8px;">Explore the atlas &rarr;</a>
+                  <a href="https://foodatlas.ai" style="display:inline-block; background:#efe6de; font-family:'Courier New',Courier,monospace; font-style:italic; font-weight:700; font-size:13px; color:#1a1918; padding:12px 28px; border-radius:8px; letter-spacing:0.04em;">Explore the atlas &rarr;</a>
                 </td>
               </tr></table>
 
@@ -151,16 +185,16 @@
                 <tr><td style="height:34px; line-height:34px; font-size:0;">&nbsp;</td></tr>
               </table>
               <table role="presentation" width="100%" cellpadding="0" cellspacing="0">
-                <tr><td style="border-top:1px solid #e7ebe4; padding-top:20px;">
-                  <p style="margin:0; font-family:Arial,sans-serif; font-size:11.5px; line-height:1.6; color:#9aa69c;">
+                <tr><td style="border-top:2px double #383634; padding-top:20px;">
+                  <p style="margin:0; font-family:Georgia,'Times New Roman',serif; font-style:italic; font-size:12px; line-height:1.6; color:#837e7a;">
                     Built by PIPA and the AI Institute for Next Generation Food Systems. This digest is generated
                     automatically from the weekly literature run. Highlight chemicals are curated by an LLM;
                     associations are literature claims, not verified facts.
                   </p>
-                  <p style="margin:9px 0 0 0; font-family:Arial,sans-serif; font-size:11.5px; color:#9aa69c;">
-                    <a href="https://foodatlas.ai" style="color:#1f6f4f; font-weight:700;">foodatlas.ai</a>
+                  <p style="margin:10px 0 0 0; font-family:'Courier New',Courier,monospace; font-style:italic; font-size:11px; color:#837e7a;">
+                    <a href="https://foodatlas.ai" style="color:#F4511E; font-weight:700;">foodatlas.ai</a>
                     &nbsp;&middot;&nbsp;
-                    <a href="https://foodatlas.ai/preferences" style="color:#9aa69c;">manage preferences</a>
+                    <a href="https://foodatlas.ai/preferences" style="color:#837e7a;">manage preferences</a>
                   </p>
                 </td></tr>
               </table>

--- a/frontend/components/landing/NewsletterSection.tsx
+++ b/frontend/components/landing/NewsletterSection.tsx
@@ -29,77 +29,83 @@ const NewsletterSection = () => {
           {/* top double rule — letterpress slip framing */}
           <div className="border-t-2 border-double border-light-700/60" />
 
-          <div className="grid grid-cols-1 md:grid-cols-[1fr_auto] gap-10 md:gap-16 items-end py-10 md:py-14">
-            {/* masthead */}
-            <div className="flex flex-col gap-3">
-              <span className="font-mono italic uppercase text-light-500 text-[11px] tracking-[0.22em]">
-                Weekly Dispatch · No charge
-              </span>
-              <h2 className="font-serif text-3xl md:text-5xl text-light-100 leading-tight">
-                The Weekly Bulletin
-              </h2>
-              <p className="font-serif italic text-light-400 text-base md:text-lg max-w-md">
-                Dispatches from the FoodAtlas knowledge graph — new entities,
-                fresh evidence, and the occasional methodology note, every
-                Sunday.
-              </p>
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-10 lg:gap-16 items-center py-10 md:py-14">
+            {/* LEFT: pitch + subscribe slip */}
+            <div className="flex flex-col gap-6 order-2 lg:order-1">
+              <div className="flex flex-col gap-3">
+                <span className="font-mono italic uppercase text-light-500 text-[11px] tracking-[0.22em]">
+                  Weekly Dispatch · No charge
+                </span>
+                <h2 className="font-serif text-3xl md:text-5xl text-light-100 leading-tight">
+                  The Weekly Bulletin
+                </h2>
+                <p className="font-serif italic text-light-400 text-base md:text-lg max-w-md">
+                  Dispatches from the FoodAtlas knowledge graph — new
+                  entities, fresh evidence, and the occasional methodology
+                  note, every Sunday.
+                </p>
+              </div>
+
+              <form
+                onSubmit={onSubmit}
+                className="w-full max-w-[26rem] flex flex-col gap-3"
+                aria-label="Newsletter subscription"
+              >
+                {status === "success" ? (
+                  <div className="flex flex-col gap-1.5 border-y-2 border-double border-light-500/60 py-4 px-1">
+                    <span className="font-mono italic text-[10px] uppercase tracking-[0.22em] text-accent-500">
+                      Subscribed
+                    </span>
+                    <p className="font-serif italic text-light-100 text-lg">
+                      You&apos;re on the list. The next dispatch is on its way.
+                    </p>
+                  </div>
+                ) : (
+                  <>
+                    {/* the input sits ON the rule, like a fillable form slip */}
+                    <div className="relative flex items-end gap-3 border-b-2 border-double border-light-500/70 pb-2">
+                      <label
+                        htmlFor="newsletter-email"
+                        className="font-mono italic text-[10px] uppercase tracking-[0.22em] text-light-500 pb-0.5"
+                      >
+                        Email
+                      </label>
+                      <input
+                        id="newsletter-email"
+                        type="email"
+                        required
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="reader@example.org"
+                        autoComplete="email"
+                        className="flex-1 min-w-0 bg-transparent outline-none text-light-100 placeholder:text-light-600 font-serif text-base pb-0.5"
+                      />
+                      <button
+                        type="submit"
+                        disabled={status === "submitting"}
+                        className="self-end -mb-[1.5px] px-3.5 py-1 rounded-t-md bg-light-200 text-light-900 text-xs font-mono italic font-semibold border-[1.5px] border-light-200 shadow-[inset_0_1px_2px_rgba(255,249,242,0.6)] hover:bg-light-100 transition-colors disabled:opacity-50"
+                      >
+                        {status === "submitting" ? "Sending…" : "Subscribe →"}
+                      </button>
+                    </div>
+                    {status === "error" ? (
+                      <p className="font-mono italic text-[11px] uppercase tracking-[0.2em] text-red-400">
+                        Something went wrong. Please try again.
+                      </p>
+                    ) : (
+                      <p className="font-mono italic text-[10px] uppercase tracking-[0.2em] text-light-600">
+                        Weekly · Free · Opt out anytime
+                      </p>
+                    )}
+                  </>
+                )}
+              </form>
             </div>
 
-            {/* subscription slip */}
-            <form
-              onSubmit={onSubmit}
-              className="w-full md:w-[26rem] flex flex-col gap-3"
-              aria-label="Newsletter subscription"
-            >
-              {status === "success" ? (
-                <div className="flex flex-col gap-1.5 border-y-2 border-double border-light-500/60 py-4 px-1">
-                  <span className="font-mono italic text-[10px] uppercase tracking-[0.22em] text-accent-500">
-                    Subscribed
-                  </span>
-                  <p className="font-serif italic text-light-100 text-lg">
-                    You&apos;re on the list. The next dispatch is on its way.
-                  </p>
-                </div>
-              ) : (
-                <>
-                  {/* the input sits ON the rule, like a fillable form slip */}
-                  <div className="relative flex items-end gap-3 border-b-2 border-double border-light-500/70 pb-2">
-                    <label
-                      htmlFor="newsletter-email"
-                      className="font-mono italic text-[10px] uppercase tracking-[0.22em] text-light-500 pb-0.5"
-                    >
-                      Email
-                    </label>
-                    <input
-                      id="newsletter-email"
-                      type="email"
-                      required
-                      value={email}
-                      onChange={(e) => setEmail(e.target.value)}
-                      placeholder="reader@example.org"
-                      autoComplete="email"
-                      className="flex-1 min-w-0 bg-transparent outline-none text-light-100 placeholder:text-light-600 font-serif text-base pb-0.5"
-                    />
-                    <button
-                      type="submit"
-                      disabled={status === "submitting"}
-                      className="self-end -mb-[1.5px] px-3.5 py-1 rounded-t-md bg-light-200 text-light-900 text-xs font-mono italic font-semibold border-[1.5px] border-light-200 shadow-[inset_0_1px_2px_rgba(255,249,242,0.6)] hover:bg-light-100 transition-colors disabled:opacity-50"
-                    >
-                      {status === "submitting" ? "Sending…" : "Subscribe →"}
-                    </button>
-                  </div>
-                  {status === "error" ? (
-                    <p className="font-mono italic text-[11px] uppercase tracking-[0.2em] text-red-400">
-                      Something went wrong. Please try again.
-                    </p>
-                  ) : (
-                    <p className="font-mono italic text-[10px] uppercase tracking-[0.2em] text-light-600">
-                      Weekly · Free · Opt out anytime
-                    </p>
-                  )}
-                </>
-              )}
-            </form>
+            {/* RIGHT: preview of the weekly bulletin as a tilted paper */}
+            <div className="order-1 lg:order-2 relative">
+              <BulletinPreview />
+            </div>
           </div>
 
           {/* bottom double rule */}
@@ -109,6 +115,126 @@ const NewsletterSection = () => {
     </section>
   );
 };
+
+// Static visual of the bulletin — top portion only, fades at the bottom
+// to suggest more below. Tilted a hair so it reads as a printed page
+// propped against the section. Chrome mirrors newsletter.html exactly
+// (cream chip section labels, double-rule dividers, serif headline,
+// mono-italic captions, accent-orange deltas) so subscribers' first
+// email matches what they were sold here.
+const PREVIEW_STATS: { value: string; label: string; delta: string }[] = [
+  { value: "1,284", label: "associations", delta: "+312" },
+  { value: "147", label: "papers", delta: "+24" },
+  { value: "58", label: "foods", delta: "+9" },
+];
+const PREVIEW_HIGHLIGHTS: { name: string; chemicals: string; count: string }[] =
+  [
+    {
+      name: "Black tea",
+      chemicals: "theaflavin · gallic acid · L-theanine",
+      count: "21",
+    },
+    {
+      name: "Walnut",
+      chemicals: "juglone · ellagic acid · α-linolenic acid",
+      count: "17",
+    },
+    {
+      name: "Saffron",
+      chemicals: "crocin · safranal · picrocrocin",
+      count: "14",
+    },
+  ];
+
+const BulletinPreview = () => (
+  <div
+    className="relative mx-auto w-full max-w-[26rem] lg:max-w-md rotate-[-1.6deg] hover:rotate-0 transition-transform duration-500 ease-out"
+    aria-hidden
+  >
+    {/* paper shadow */}
+    <div
+      className="absolute inset-0 translate-y-3 translate-x-1 rounded-xl bg-black/40 blur-2xl"
+      aria-hidden
+    />
+    <div className="relative rounded-xl border border-light-50/[0.08] bg-light-950 shadow-[inset_0_5px_8px_rgba(255,249,242,0.02)] overflow-hidden">
+      <div className="p-6 pb-0 flex flex-col gap-4">
+        {/* masthead */}
+        <div className="flex items-baseline justify-between">
+          <span className="font-serif text-light-100 text-lg font-semibold">
+            FoodAtlas
+          </span>
+          <span className="font-mono italic text-[9px] uppercase tracking-[0.22em] text-light-500">
+            Weekly&nbsp;Bulletin
+          </span>
+        </div>
+        <div className="border-t-2 border-double border-light-700/60" />
+
+        {/* chip + headline */}
+        <span className="self-start bg-light-200 shadow-inner shadow-light-50 rounded px-2 py-[2px] font-mono italic font-semibold text-[9px] tracking-[0.12em] uppercase text-light-900">
+          No. Sun · Jun 30
+        </span>
+        <h3 className="font-serif text-light-100 text-xl leading-tight">
+          1,284 new associations entered the atlas this week
+        </h3>
+
+        {/* stats tile row */}
+        <span className="self-start bg-light-200 shadow-inner shadow-light-50 rounded px-2 py-[2px] font-mono italic font-semibold text-[9px] tracking-[0.12em] uppercase text-light-900 mt-1">
+          At a glance
+        </span>
+        <div className="grid grid-cols-3 border-t-2 border-b-2 border-double border-light-700/60 py-3">
+          {PREVIEW_STATS.map((s) => (
+            <div key={s.label} className="text-center">
+              <div className="font-serif text-light-100 text-xl leading-none">
+                {s.value}
+              </div>
+              <div className="mt-1 font-mono italic text-[9px] uppercase tracking-[0.12em] text-light-500">
+                {s.label}
+              </div>
+              <div className="mt-1 font-mono italic text-[10px] font-semibold text-accent-600">
+                {s.delta}
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* highlights chip + list */}
+        <span className="self-start bg-light-200 shadow-inner shadow-light-50 rounded px-2 py-[2px] font-mono italic font-semibold text-[9px] tracking-[0.12em] uppercase text-light-900 mt-1">
+          Foods with most new discoveries
+        </span>
+        <div className="flex flex-col">
+          {PREVIEW_HIGHLIGHTS.map((h, idx) => (
+            <div
+              key={h.name}
+              className={`flex items-start justify-between gap-4 py-2.5 ${
+                idx > 0 ? "border-t border-light-800" : ""
+              }`}
+            >
+              <div className="min-w-0">
+                <div className="font-serif text-light-100 text-sm">
+                  {h.name}{" "}
+                  <span className="text-accent-600 font-mono italic">→</span>
+                </div>
+                <div className="mt-1 font-mono italic text-[10px] text-light-400 truncate">
+                  {h.chemicals}
+                </div>
+              </div>
+              <div className="font-mono italic text-[10px] font-semibold text-accent-600 whitespace-nowrap pt-0.5">
+                {h.count} new
+              </div>
+            </div>
+          ))}
+        </div>
+        {/* bottom spacer — paper continues below the fade */}
+        <div className="h-10" />
+      </div>
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-light-950 to-transparent" />
+    </div>
+    {/* small paper meta caption */}
+    <div className="mt-4 text-center font-mono italic text-[10px] uppercase tracking-[0.22em] text-light-600">
+      A peek at last Sunday&apos;s bulletin
+    </div>
+  </div>
+);
 
 NewsletterSection.displayName = "NewsletterSection";
 


### PR DESCRIPTION
## Summary
Two coordinated changes that make the weekly newsletter and the landing CTA visually consistent with the rest of the site.

### `backend/kgc/data/newsletter.html`
Rebuilt in the site's apothecary dark theme:
- Dark page bg (`#0D0C0C`) + slightly-lighter card (`#151414`).
- Cream apothecary chip section labels ("AT A GLANCE", "FOODS WITH MOST NEW DISCOVERIES", …) on double-rule dividers.
- Serif Georgia headlines, mono-italic Courier captions.
- Accent-orange (`#F4511E`) for deltas, link arrows, paper-card CTAs.
- Cream pill association chips inside paper cards.
- Cream primary CTA ("Explore the atlas →").
- `color-scheme` meta + Gmail dark-mode override classes so clients don't auto-invert.

### `NewsletterSection.tsx`
Layout: 1-col → 2-col on `lg+`. Right column gains a new `<BulletinPreview>` — a lightly-tilted "paper" rendering of the bulletin's top fold (masthead, chip + serif headline, three stat tiles with +deltas, three-row highlights list), with a gradient fade at the bottom that suggests the page continues. Subtle hover de-tilts.

Mobile collapses to one column, preview above the form.

🤖 Generated with [Claude Code](https://claude.com/claude-code)