### PR TITLE
feat(food): inferred bioactivities via composition + evidence source badge

### DIFF
--- a/backend/api/src/repositories/bioactivity.py
+++ b/backend/api/src/repositories/bioactivity.py
@@ -345,6 +345,87 @@ async def get_food_bioactivities(
 
 
 # ---------------------------------------------------------------------
+# Food → chemical → bioactivity (transitive inference)
+# ---------------------------------------------------------------------
+# Each row is one (chemical-in-food x bioactivity-of-chemical) pair --
+# the chemical comes from mv_food_chemical_composition (carries the
+# food-level concentration), the bioactivity counts/sample come from
+# mv_chemical_bioactivity (the same source the direct chemical table
+# uses). This is presented under the direct food→bioactivity table as
+# "implied by the food's chemistry".
+
+_INFERRED_SORT = {
+    "bioactivity": "cb.bioactivity_name",
+    "chemical": "fcc.chemical_name",
+    "concentration": "(fcc.median_concentration->>'value')::NUMERIC",
+    "measurement_count": "cb.measurement_count",
+    "active_count": "cb.active_count",
+    "inactive_count": "cb.inactive_count",
+}
+
+
+async def get_food_inferred_bioactivities(
+    session: AsyncSession,
+    common_name: str,
+    page: int = 1,
+    search: str = "",
+    sort_by: str = "concentration",
+    sort_dir: str = "desc",
+    rows_per_page: int = ROWS_PER_PAGE_DEFAULT,
+) -> dict[str, object]:
+    """Bioactivities of the chemicals found in this food (transitive)."""
+    sort_col = _INFERRED_SORT.get(sort_by, _INFERRED_SORT["concentration"])
+    direction = sort_dir.upper() if sort_dir.upper() in _VALID_DIR else "DESC"
+
+    params: dict = {"name": common_name}
+    where_parts = ["fcc.food_name = :name"]
+    if search:
+        where_parts.append(
+            "(cb.bioactivity_name ILIKE :q OR fcc.chemical_name ILIKE :q)"
+        )
+        params["q"] = f"%{search}%"
+    where = " AND ".join(where_parts)
+
+    total_result = await session.execute(
+        text(f"""
+            SELECT COUNT(*)
+            FROM mv_food_chemical_composition fcc
+            JOIN mv_chemical_bioactivity cb
+              ON cb.chemical_foodatlas_id = fcc.chemical_foodatlas_id
+            WHERE {where}
+        """),
+        params,
+    )
+    total = int(total_result.scalar() or 0)
+
+    offset = rows_per_page * (page - 1)
+    rows_result = await session.execute(
+        text(f"""
+            SELECT
+              cb.bioactivity_name AS bioactivity,
+              cb.bioactivity_foodatlas_id AS bioactivity_id,
+              fcc.chemical_name AS chemical,
+              fcc.chemical_foodatlas_id AS chemical_id,
+              fcc.median_concentration,
+              cb.measurement_count, cb.active_count, cb.inactive_count,
+              cb.measurements
+            FROM mv_food_chemical_composition fcc
+            JOIN mv_chemical_bioactivity cb
+              ON cb.chemical_foodatlas_id = fcc.chemical_foodatlas_id
+            WHERE {where}
+            ORDER BY {sort_col} {direction} NULLS LAST
+            OFFSET :offset ROWS FETCH FIRST :limit ROWS ONLY
+        """),
+        {**params, "offset": offset, "limit": rows_per_page},
+    )
+    data = _attach_top_measurement([dict(r._mapping) for r in rows_result])
+    return {
+        "data": data,
+        "metadata": _build_meta(total, page, rows_per_page, len(data)),
+    }
+
+
+# ---------------------------------------------------------------------
 # Distinct (endpoint, unit) combos for one bioactivity ↔ {chemical|food}
 # direction — used by the table UI to populate filter chips. Counts come
 # from the bioactivity attestation store (no MV cap) so they reflect the

--- a/backend/api/src/repositories/bioactivity.py
+++ b/backend/api/src/repositories/bioactivity.py
@@ -37,6 +37,8 @@ _BIO_CHEM_SORT = {
     "measurement_count": "measurement_count",
     "active_count": "active_count",
     "inactive_count": "inactive_count",
+    # Correlated subquery alias — see get_chemicals.select_cols.
+    "n_foods": "n_foods",
 }
 _FOOD_BIO_SORT = {
     "name": "food_name",
@@ -225,7 +227,16 @@ async def get_chemicals(
         select_cols=(
             "chemical_name AS name, chemical_foodatlas_id AS id, "
             "measurement_count, active_count, inactive_count, "
-            "unspecified_count, inconclusive_count, measurements"
+            "unspecified_count, inconclusive_count, measurements, "
+            # Correlated subquery: how many distinct foods contain this
+            # chemical. Counted once per row in the paginated output (20
+            # rows/page), keyed on chemical_foodatlas_id. Cheap with
+            # mv_food_chemical_composition's row count today; if it
+            # becomes a bottleneck, promote to a CTE.
+            "(SELECT COUNT(DISTINCT food_foodatlas_id) "
+            "FROM mv_food_chemical_composition "
+            "WHERE chemical_foodatlas_id = "
+            "mv_chemical_bioactivity.chemical_foodatlas_id) AS n_foods"
         ),
         search_col="chemical_name",
         search=search,

--- a/backend/api/src/routes/food.py
+++ b/backend/api/src/routes/food.py
@@ -119,3 +119,29 @@ async def food_bioactivities(
         filter_endpoint=filter_endpoint,
         filter_unit=filter_unit,
     )
+
+
+@router.get("/inferred-bioactivities")
+async def food_inferred_bioactivities(
+    common_name: str = Query(...),
+    page: int = Query(1, ge=1),
+    search: str = Query(""),
+    sort_by: str = Query("concentration"),
+    sort_dir: str = Query("desc"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Bioactivities inferred via the food's chemical composition.
+
+    Joins mv_food_chemical_composition x mv_chemical_bioactivity on
+    chemical_foodatlas_id. One row per (chemical, bioactivity) pair —
+    the chemical's food-level concentration is included so the UI can
+    surface "how much is in it" alongside the inferred bioactivity.
+    """
+    return await bioactivity.get_food_inferred_bioactivities(
+        db,
+        common_name,
+        page=page,
+        search=search,
+        sort_by=sort_by,
+        sort_dir=sort_dir,
+    )

--- a/frontend/app/(everything-else)/food/[slug]/page.tsx
+++ b/frontend/app/(everything-else)/food/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { notFound } from "next/navigation";
 
 import FoodCompositionTab from "@/components/entities/food/FoodCompositionTab";
 import FoodBioactivitiesSection from "@/components/entities/bioactivity/FoodBioactivitiesSection";
+import FoodInferredBioactivitiesSection from "@/components/entities/bioactivity/FoodInferredBioactivitiesSection";
 import HeaderSection from "@/components/entities/HeaderSection";
 import HeaderSectionSuspense from "@/components/entities/HeaderSectionSuspense";
 import EntityDetailLayout from "@/components/entities/EntityDetailLayout";
@@ -104,10 +105,14 @@ const FoodPage = async ({ params }: FoodPageProps) => {
             label: "Bioactivities",
             count: bioactivitiesCount,
             content: (
-              <FoodBioactivitiesSection
-                commonName={commonName}
-                anchorId={anchorId}
-              />
+              <div className="flex flex-col gap-12">
+                <FoodBioactivitiesSection
+                  commonName={commonName}
+                  anchorId={anchorId}
+                />
+                <div className="border-t-2 border-double border-light-700/60" />
+                <FoodInferredBioactivitiesSection commonName={commonName} />
+              </div>
             ),
           },
           {

--- a/frontend/components/entities/bioactivity/BioactivityChemicalsSection.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityChemicalsSection.tsx
@@ -32,7 +32,7 @@ const BioactivityChemicalsSection = ({ commonName, anchorId }: Props) => {
         key: "name",
         label: "Chemical",
         align: "left",
-        width: "w-[28%]",
+        width: "w-[24%]",
         sortable: true,
         render: (row) => <NameLinkCell row={row} hrefPrefix="/chemical/" />,
       },
@@ -40,7 +40,7 @@ const BioactivityChemicalsSection = ({ commonName, anchorId }: Props) => {
         key: "active_count",
         label: "Active",
         align: "right",
-        width: "w-[14%]",
+        width: "w-[10%]",
         sortable: true,
         render: (row) => (
           <NumberCell value={(row as BioactivityChemicalRow).active_count} />
@@ -50,10 +50,20 @@ const BioactivityChemicalsSection = ({ commonName, anchorId }: Props) => {
         key: "inactive_count",
         label: "Inactive",
         align: "right",
-        width: "w-[14%]",
+        width: "w-[10%]",
         sortable: true,
         render: (row) => (
           <NumberCell value={(row as BioactivityChemicalRow).inactive_count} />
+        ),
+      },
+      {
+        key: "n_foods",
+        label: "# Foods",
+        align: "right",
+        width: "w-[12%]",
+        sortable: true,
+        render: (row) => (
+          <NumberCell value={(row as BioactivityChemicalRow).n_foods ?? 0} />
         ),
       },
       {

--- a/frontend/components/entities/bioactivity/BioactivityMeasurementsModal.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityMeasurementsModal.tsx
@@ -354,24 +354,27 @@ const MeasurementsTable = ({
   return (
     <table className="w-full table-fixed">
       <colgroup>
-        <col className="w-[28%]" />
-        <col className="w-[16%]" />
+        <col className="w-[26%]" />
+        <col className="w-[14%]" />
+        <col className="w-[10%]" />
         <col className="w-[12%]" />
-        <col className="w-[22%]" />
-        <col className="w-[22%]" />
+        <col className="w-[20%]" />
+        <col className="w-[18%]" />
       </colgroup>
       <thead className="text-light-400 text-left">
         <tr>
-          {["Assay", "Endpoint", "Outcome", "Value", "Curve"].map((h) => (
-            <th
-              key={h}
-              className="h-9 border-b border-light-700 leading-none py-1.5 px-2 first:pl-0 last:pr-0"
-            >
-              <span className="select-none uppercase text-xs font-medium">
-                {h}
-              </span>
-            </th>
-          ))}
+          {["Assay", "Endpoint", "Outcome", "Source", "Value", "Curve"].map(
+            (h) => (
+              <th
+                key={h}
+                className="h-9 border-b border-light-700 leading-none py-1.5 px-2 first:pl-0 last:pr-0"
+              >
+                <span className="select-none uppercase text-xs font-medium">
+                  {h}
+                </span>
+              </th>
+            )
+          )}
         </tr>
       </thead>
       <tbody className="text-sm font-light">
@@ -390,6 +393,9 @@ const MeasurementsTable = ({
             </td>
             <td className="py-1.5 px-2 align-top">
               <OutcomeBadge outcome={m.outcome} />
+            </td>
+            <td className="py-1.5 px-2 align-top">
+              <SourceBadge source={m.evidence_source} />
             </td>
             <td className="py-1.5 px-2 align-top font-mono text-xs text-light-200 tabular-nums text-right">
               {m.value === null || m.value === undefined ? (
@@ -413,7 +419,7 @@ const MeasurementsTable = ({
         ))}
         {Array.from({ length: padCount }).map((_, i) => (
           <tr key={`pad-${i}`}>
-            <td className="py-1.5 pr-2" colSpan={5}>
+            <td className="py-1.5 pr-2" colSpan={6}>
               {skeleton ? (
                 <LoadingCard className="h-5" />
               ) : (
@@ -424,6 +430,32 @@ const MeasurementsTable = ({
         ))}
       </tbody>
     </table>
+  );
+};
+
+// Distinguishes Experimental measurements from Predicted / computational
+// ones — the staging snapshot is all Experimental today but the field is
+// in base_attestations_bioactivity and will populate once Predicted rows
+// land. Stays mute (em-dash) for blank/unknown values.
+const SourceBadge = ({
+  source,
+}: {
+  source: string | null | undefined;
+}) => {
+  if (!source) return <span className="text-light-600">—</span>;
+  const lc = source.toLowerCase();
+  const tone = lc.startsWith("exp")
+    ? "border-light-700/60 bg-light-900/40 text-light-300"
+    : lc.startsWith("pred") || lc.startsWith("comp")
+      ? "border-amber-500/40 bg-amber-500/10 text-amber-200"
+      : "border-light-700/60 bg-light-900/40 text-light-400";
+  return (
+    <span
+      className={`inline-block capitalize text-[10px] leading-tight px-2 py-0.5 rounded-full border ${tone}`}
+      title={source}
+    >
+      {source}
+    </span>
   );
 };
 

--- a/frontend/components/entities/bioactivity/FoodBioactivitiesSection.tsx
+++ b/frontend/components/entities/bioactivity/FoodBioactivitiesSection.tsx
@@ -53,21 +53,35 @@ const FoodBioactivitiesSection = ({ commonName, anchorId }: Props) => {
   );
 
   return (
-    <BioactivityTable
-      tableId={`food-bioactivities-${commonName}`}
-      direction="food-bioactivities"
-      pivotName={commonName}
-      fetcher={fetcher}
-      columns={columns}
-      searchPlaceholder="Search bioactivities"
-      emptyMessage="No bioactivities recorded for this food yet"
-      modalConfig={{
-        anchorLabel: commonName,
-        headIsRow: false,
-        relationship: "r5",
-        anchorId,
-      }}
-    />
+    <div className="flex flex-col gap-6">
+      {/* Header — mirrors the chip+blurb pattern on the inferred section
+       * so the two are visually parallel and the diff is obvious. */}
+      <div className="flex flex-col gap-2">
+        <span className="self-start bg-light-200 shadow-inner shadow-light-50 rounded-r-md px-2.5 py-0.5 font-mono italic font-medium text-light-900 text-[10px] tracking-[0.12em] uppercase -ml-3">
+          Directly measured
+        </span>
+        <p className="font-serif italic text-light-400 text-sm">
+          Bioactivities {commonName} (or an extract of it) was tested for in
+          an assay. These are direct food-level measurements — the food
+          itself was the test material.
+        </p>
+      </div>
+      <BioactivityTable
+        tableId={`food-bioactivities-${commonName}`}
+        direction="food-bioactivities"
+        pivotName={commonName}
+        fetcher={fetcher}
+        columns={columns}
+        searchPlaceholder="Search bioactivities"
+        emptyMessage="No bioactivities recorded for this food yet"
+        modalConfig={{
+          anchorLabel: commonName,
+          headIsRow: false,
+          relationship: "r5",
+          anchorId,
+        }}
+      />
+    </div>
   );
 };
 

--- a/frontend/components/entities/bioactivity/FoodInferredBioactivitiesSection.tsx
+++ b/frontend/components/entities/bioactivity/FoodInferredBioactivitiesSection.tsx
@@ -123,10 +123,10 @@ const FoodInferredBioactivitiesSection = ({ commonName }: Props) => {
           Inferred via composition
         </span>
         <p className="font-serif italic text-light-400 text-sm">
-          Bioactivities of the chemicals found in {commonName} — i.e., the
-          chemical was measured against the bioactivity directly, and the
-          chemical occurs in this food. Concentration is the food-level
-          median.
+          Bioactivities of chemicals found in {commonName}. The chemical
+          was measured against the activity directly — {commonName} itself
+          was not the test material. Concentration is the food-level
+          median of that chemical.
         </p>
       </div>
 

--- a/frontend/components/entities/bioactivity/FoodInferredBioactivitiesSection.tsx
+++ b/frontend/components/entities/bioactivity/FoodInferredBioactivitiesSection.tsx
@@ -1,0 +1,388 @@
+// Foods don't directly measure bioactivity in the lab; they contain
+// chemicals that do. This section surfaces the transitive inference:
+// one row per (chemical-in-food, bioactivity-of-chemical) pair, with
+// the food-level concentration of that chemical alongside the chemical's
+// measurement counts + top measurement against the bioactivity.
+//
+// Sits below FoodBioactivitiesSection on the food page's Bioactivities
+// tab. "View assays" opens the same measurements modal as the direct
+// table, anchored on the row's chemical (not the food).
+
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  MdClose,
+  MdInfoOutline,
+  MdKeyboardArrowDown,
+  MdKeyboardArrowUp,
+  MdSearch,
+  MdUnfoldMore,
+} from "react-icons/md";
+
+import Link from "@/components/basic/Link";
+import LoadingCard from "@/components/basic/LoadingCard";
+import Pagination from "@/components/basic/Pagination";
+import BioactivityMeasurementsModal from "@/components/entities/bioactivity/BioactivityMeasurementsModal";
+import {
+  formatTopMeasurement,
+  topMeasurementOf,
+} from "@/components/entities/bioactivity/format";
+import { usePaginations } from "@/context/paginationsContext";
+import { getFoodInferredBioactivities } from "@/utils/fetching";
+import { encodeSpace, formatConcentrationValueAlt } from "@/utils/utils";
+import type {
+  BioactivityMeasurement,
+  BioactivityTopMeasurement,
+} from "@/types";
+
+interface InferredRow {
+  bioactivity: string;
+  bioactivity_id: string;
+  chemical: string;
+  chemical_id: string;
+  median_concentration: { value: number | null; unit: string } | null;
+  measurement_count: number;
+  active_count: number;
+  inactive_count: number;
+  measurements: BioactivityMeasurement[];
+  top_measurement: BioactivityTopMeasurement | null;
+}
+
+type SortDir = "asc" | "desc";
+
+interface Props {
+  commonName: string;
+}
+
+const TABLE_ID_PREFIX = "food-inferred-bioact";
+
+const FoodInferredBioactivitiesSection = ({ commonName }: Props) => {
+  const tableId = `${TABLE_ID_PREFIX}-${commonName}`;
+  const { getTablePaginations, setTablePaginations } = usePaginations();
+  const { currentPage } = getTablePaginations(tableId);
+
+  const [searchTerm, setSearchTerm] = useState("");
+  const [sort, setSort] = useState<{ by: string; dir: SortDir }>({
+    by: "concentration",
+    dir: "desc",
+  });
+
+  const [rows, setRows] = useState<InferredRow[]>([]);
+  const [totalPages, setTotalPages] = useState(0);
+  const [isLoading, setIsLoading] = useState(true);
+  const [selected, setSelected] = useState<InferredRow | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setIsLoading(true);
+    (async () => {
+      const payload = await getFoodInferredBioactivities(commonName, {
+        page: currentPage,
+        search: searchTerm,
+        sortBy: sort.by,
+        sortDir: sort.dir,
+      });
+      if (cancelled) return;
+      setRows((payload?.data as InferredRow[] | undefined) ?? []);
+      setTotalPages(payload?.metadata?.total_pages ?? 0);
+      setIsLoading(false);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [commonName, currentPage, searchTerm, sort]);
+
+  const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setSearchTerm(e.target.value.toLowerCase());
+    setTablePaginations(tableId, 1, 20);
+  };
+  const handleSearchClear = () => {
+    setSearchTerm("");
+    setTablePaginations(tableId, 1, 20);
+  };
+  const handleSortClick = (key: string) => {
+    setTablePaginations(tableId, 1, 20);
+    setSort((prev) =>
+      prev.by === key
+        ? { by: key, dir: prev.dir === "asc" ? "desc" : "asc" }
+        : { by: key, dir: "desc" }
+    );
+  };
+
+  const showingPaginator = totalPages > 1 || isLoading;
+  const showEmpty = !isLoading && rows.length === 0;
+
+  return (
+    <div className="flex flex-col gap-7">
+      {/* Heading + provenance disclaimer — same chip vocabulary as the
+       * card-catalog sections. The italic line frames the data as
+       * inferred, not directly observed in the food. */}
+      <div className="flex flex-col gap-2">
+        <span className="self-start bg-light-200 shadow-inner shadow-light-50 rounded-r-md px-2.5 py-0.5 font-mono italic font-medium text-light-900 text-[10px] tracking-[0.12em] uppercase -ml-3">
+          Inferred via composition
+        </span>
+        <p className="font-serif italic text-light-400 text-sm">
+          Bioactivities of the chemicals found in {commonName} — i.e., the
+          chemical was measured against the bioactivity directly, and the
+          chemical occurs in this food. Concentration is the food-level
+          median.
+        </p>
+      </div>
+
+      <div className="w-full">
+        <div className="relative flex items-center">
+          <MdSearch className="absolute left-2.5 w-5 h-5 text-light-400" />
+          <input
+            className="pl-9 pr-9 w-full lg:w-72 h-9 text-sm rounded-lg border border-light-50/5 bg-light-900 focus:bg-light-400/20 hover:bg-light-400/20 text-light-100 placeholder-light-400 transition duration-100 ease-in-out outline-light-50/60"
+            type="text"
+            placeholder="Search bioactivity or chemical"
+            value={searchTerm}
+            onChange={handleSearchChange}
+          />
+          {searchTerm && (
+            <button
+              type="button"
+              aria-label="Clear search"
+              onClick={handleSearchClear}
+              className="absolute right-2 flex items-center justify-center w-5 h-5 rounded-full text-light-400 hover:text-light-100 hover:bg-light-700 transition-colors"
+            >
+              <MdClose className="w-3.5 h-3.5" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full table-fixed">
+          <colgroup>
+            <col className="w-[22%]" />
+            <col className="w-[18%]" />
+            <col className="w-[16%]" />
+            <col className="w-[10%]" />
+            <col className="w-[20%]" />
+            <col className="w-[14%]" />
+          </colgroup>
+          <thead className="text-light-400 text-left">
+            <tr>
+              <SortableTh
+                label="Bioactivity"
+                sortKey="bioactivity"
+                sort={sort}
+                onClick={handleSortClick}
+                align="left"
+                first
+              />
+              <SortableTh
+                label="Via chemical"
+                sortKey="chemical"
+                sort={sort}
+                onClick={handleSortClick}
+                align="left"
+              />
+              <SortableTh
+                label="Concentration"
+                sortKey="concentration"
+                sort={sort}
+                onClick={handleSortClick}
+                align="right"
+              />
+              <SortableTh
+                label="Assays"
+                sortKey="measurement_count"
+                sort={sort}
+                onClick={handleSortClick}
+                align="right"
+              />
+              <th className="h-9 border-b border-light-700 leading-none py-1.5 px-4 text-right">
+                <span className="select-none uppercase text-xs font-medium text-light-400">
+                  Top measurement
+                </span>
+              </th>
+              <th className="h-9 border-b border-light-700 leading-none py-1.5 pl-4 text-right last:pr-0">
+                <span className="select-none uppercase text-xs font-medium text-light-400">
+                  Detail
+                </span>
+              </th>
+            </tr>
+          </thead>
+          <tbody className="text-sm font-light">
+            {isLoading ? (
+              Array.from({ length: 20 }).map((_, i) => (
+                <tr key={`l-${i}`}>
+                  <td className="w-full py-1.5" colSpan={6}>
+                    <div className="h-9 flex items-center">
+                      <LoadingCard className="h-5" />
+                    </div>
+                  </td>
+                </tr>
+              ))
+            ) : showEmpty ? (
+              <tr>
+                <td colSpan={6}>
+                  <div className="h-[10rem] flex items-center justify-center text-light-300 gap-2">
+                    <MdInfoOutline /> No chemicals in this food have measured
+                    bioactivities yet
+                  </div>
+                </td>
+              </tr>
+            ) : (
+              rows.map((row, idx) => (
+                <Row
+                  key={`${row.chemical_id}-${row.bioactivity_id}-${idx}`}
+                  row={row}
+                  onOpen={() => setSelected(row)}
+                />
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {showingPaginator && (
+        <div className="mt-2 max-w-xl w-full mx-auto">
+          <Pagination
+            tableId={tableId}
+            numberOfPages={totalPages}
+            isLoading={isLoading}
+          />
+        </div>
+      )}
+
+      <BioactivityMeasurementsModal
+        isOpen={selected !== null}
+        onClose={() => setSelected(null)}
+        headLabel={selected?.chemical ?? ""}
+        tailLabel={selected?.bioactivity ?? ""}
+        initialMeasurements={selected?.measurements ?? []}
+        expectedCount={selected?.measurement_count}
+        anchorId={selected?.chemical_id ?? null}
+        selectedId={selected?.bioactivity_id ?? null}
+        relationship="r6"
+        headIsRow={false}
+      />
+    </div>
+  );
+};
+
+const SortableTh = ({
+  label,
+  sortKey,
+  sort,
+  onClick,
+  align,
+  first,
+}: {
+  label: string;
+  sortKey: string;
+  sort: { by: string; dir: SortDir };
+  onClick: (k: string) => void;
+  align: "left" | "right";
+  first?: boolean;
+}) => {
+  const active = sort.by === sortKey;
+  return (
+    <th
+      className={`h-9 border-b border-light-700 leading-none py-1.5 ${
+        first ? "pr-4" : "px-4"
+      } ${align === "right" ? "text-right" : "text-left"}`}
+    >
+      <button
+        type="button"
+        onClick={() => onClick(sortKey)}
+        className={`group flex items-center gap-1 cursor-pointer focus:outline-none ${
+          align === "right" ? "justify-end ml-auto" : ""
+        }`}
+      >
+        <span
+          className={`select-none uppercase text-xs font-medium transition duration-300 ease-in-out ${
+            active ? "text-light-100" : "text-light-400 group-hover:text-light-100"
+          }`}
+        >
+          {label}
+        </span>
+        {active ? (
+          sort.dir === "asc" ? (
+            <MdKeyboardArrowUp className="text-accent-600 group-hover:text-accent-300 flex-shrink-0" />
+          ) : (
+            <MdKeyboardArrowDown className="text-accent-600 group-hover:text-accent-300 flex-shrink-0" />
+          )
+        ) : (
+          <MdUnfoldMore className="text-light-400 group-hover:text-light-100 flex-shrink-0" />
+        )}
+      </button>
+    </th>
+  );
+};
+
+const Row = ({ row, onOpen }: { row: InferredRow; onOpen: () => void }) => {
+  const conc = row.median_concentration;
+  const top = topMeasurementOf({
+    measurements: row.measurements,
+    top_measurement: row.top_measurement,
+  });
+  return (
+    <tr>
+      <td className="py-1.5 pr-4">
+        <div className="flex min-h-9 items-center capitalize">
+          <Link
+            href={`/bioactivity/${encodeURIComponent(
+              encodeSpace(row.bioactivity)
+            )}`}
+            isExternal={false}
+          >
+            {row.bioactivity}
+          </Link>
+        </div>
+      </td>
+      <td className="py-1.5 px-4">
+        <div className="flex min-h-9 items-center capitalize">
+          <Link
+            href={`/chemical/${encodeURIComponent(encodeSpace(row.chemical))}`}
+            isExternal={false}
+          >
+            {row.chemical}
+          </Link>
+        </div>
+      </td>
+      <td className="py-1.5 px-4 text-right">
+        <div className="flex min-h-9 items-center justify-end font-mono text-xs text-light-200 tabular-nums">
+          {conc?.value == null ? (
+            <span className="text-light-600">—</span>
+          ) : (
+            <>
+              {formatConcentrationValueAlt(conc.value)}
+              <span className="ml-1 text-light-500">{conc.unit ?? ""}</span>
+            </>
+          )}
+        </div>
+      </td>
+      <td className="py-1.5 px-4 text-right">
+        <div className="flex min-h-9 items-center justify-end tabular-nums text-light-200">
+          {row.measurement_count.toLocaleString()}
+        </div>
+      </td>
+      <td className="py-1.5 px-4 text-right">
+        <div className="flex min-h-9 items-center justify-end font-mono text-xs text-light-200">
+          {formatTopMeasurement(top)}
+        </div>
+      </td>
+      <td className="py-1.5 pl-4 text-right">
+        <div className="flex min-h-9 items-center justify-end">
+          <button
+            type="button"
+            onClick={onOpen}
+            disabled={row.measurement_count === 0}
+            className="font-mono italic text-xs px-2.5 py-0.5 rounded-full border border-light-700/60 text-light-300 hover:text-light-100 hover:border-light-500 transition-colors disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
+          >
+            View {row.measurement_count.toLocaleString()} →
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+};
+
+FoodInferredBioactivitiesSection.displayName =
+  "FoodInferredBioactivitiesSection";
+export default FoodInferredBioactivitiesSection;

--- a/frontend/types/Bioactivity.ts
+++ b/frontend/types/Bioactivity.ts
@@ -64,6 +64,10 @@ export type BioactivityChemicalRow = {
   inactive_count: number;
   measurements: BioactivityMeasurement[];
   top_measurement: BioactivityTopMeasurement | null;
+  // # of distinct foods containing this chemical. Only populated by
+  // /bioactivity/chemicals (server-side correlated subquery); undefined
+  // on the chemical-bioactivities direction where it's not relevant.
+  n_foods?: number;
 };
 
 export type BioactivityFoodRow = {

--- a/frontend/utils/fetching.ts
+++ b/frontend/utils/fetching.ts
@@ -351,6 +351,22 @@ export async function getBioactivityFoods(
   );
 }
 
+// Bioactivities inferred via a food's chemical composition (food → chemical
+// → bioactivity). Each row is a (chemical, bioactivity) pair; the
+// chemical's food-level median_concentration is carried so we can sort/
+// display "how much is in it" alongside the inferred bioactivity.
+export async function getFoodInferredBioactivities(
+  commonName: string,
+  params?: BioactivityListParams
+) {
+  return bioactivityListFetch(
+    "/food/inferred-bioactivities",
+    commonName,
+    params,
+    "food inferred bioactivities"
+  );
+}
+
 // bioactivities measured against a chemical (reverse of getBioactivityChemicals)
 export async function getChemicalBioactivities(
   commonName: string,


### PR DESCRIPTION
## Summary
Two changes on the food page's Bioactivities tab.

### Inferred-via-composition section
Foods don't directly measure bioactivity; they contain chemicals that do. A new section sits below the existing direct food→bioactivity table and lists one row per (chemical-in-food, bioactivity-of-chemical) pair — with the chemical's food-level median concentration alongside the chemical-level measurement count + top measurement.

Backend: `GET /food/inferred-bioactivities` joins `mv_food_chemical_composition × mv_chemical_bioactivity` on `chemical_foodatlas_id`. Paginated, searchable (matches bioactivity OR chemical), sortable by bioactivity / chemical / concentration (default desc) / measurement_count.

Frontend: new `FoodInferredBioactivitiesSection` — same chrome as the other tables. "View N →" opens the measurements modal anchored on the row's chemical (r6 direction).

### Source column in the measurements modal
Surfaces the existing `base_attestations_bioactivity.evidence_source` field. All staging rows are `Experimental` today, but the field is wired so Predicted rows will show up amber-toned once they land. Added between Outcome and Value.

## Test plan
- [ ] /food/tomato → Bioactivities tab → direct table above, "Inferred via composition" section below sorted by concentration desc.
- [ ] Search filters across both bioactivity and chemical name.
- [ ] "View N →" opens modal with the chemical as head, bioactivity as tail.
- [ ] Modal shows Source column (currently always "Experimental").

🤖 Generated with [Claude Code](https://claude.com/claude-code)