### PR TITLE
infra(api): enable ECS exec on ApiService for ad-hoc DB ops

### DIFF
--- a/infra/aws/scripts/exec-api-shell.sh
+++ b/infra/aws/scripts/exec-api-shell.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Open a shell inside a running API container via ECS exec (SSM Session
+# Manager under the hood) — no SSH bastion, no RDS port-forward setup.
+# The container already has DB credentials in env (DB_HOST/DB_USER/
+# DB_PASSWORD/DB_NAME) and VPC reach to the RDS, so once you're in:
+#
+#   $ python -c 'from sqlalchemy import create_engine, text; from src.config import Settings; s=Settings(); e=create_engine(s.db_url); c=e.connect(); c.execute(text("SELECT 1")); c.commit()'
+#
+# …becomes the canonical way to run ad-hoc SQL against the live RDS.
+#
+# Usage:
+#   ./exec-api-shell.sh                       # staging by default
+#   ./exec-api-shell.sh prod                  # explicit prod target
+#   STACK=FoodAtlasApiStack ./exec-api-shell.sh
+#
+# Prereqs: aws sso login --profile <profile>; AWS Session Manager
+# plugin installed locally (https://docs.aws.amazon.com/systems-manager/
+# latest/userguide/session-manager-working-with-install-plugin.html).
+
+set -euo pipefail
+
+ENV_ARG="${1:-staging}"
+case "$ENV_ARG" in
+    staging) STACK="${STACK:-FoodAtlasApiStack-Staging}";;
+    prod | production) STACK="${STACK:-FoodAtlasApiStack}";;
+    *)
+        echo "Usage: $0 [staging|prod]" >&2
+        exit 1
+        ;;
+esac
+
+REGION="${AWS_REGION:-us-west-1}"
+
+# Resolve cluster + service from the stack's ApiService construct.
+CLUSTER=$(aws cloudformation describe-stack-resources \
+    --stack-name "$STACK" \
+    --region "$REGION" \
+    --query "StackResources[?LogicalResourceId=='ApiCluster'].PhysicalResourceId" \
+    --output text)
+SERVICE=$(aws cloudformation describe-stack-resources \
+    --stack-name "$STACK" \
+    --region "$REGION" \
+    --query "StackResources[?starts_with(LogicalResourceId, 'ApiService') && ResourceType=='AWS::ECS::Service'].PhysicalResourceId" \
+    --output text)
+
+if [[ -z "$CLUSTER" || -z "$SERVICE" ]]; then
+    echo "Couldn't resolve cluster/service from $STACK. Is the stack deployed?" >&2
+    exit 1
+fi
+
+# Pick the first running task — for ad-hoc ops it doesn't matter which.
+TASK_ARN=$(aws ecs list-tasks \
+    --cluster "$CLUSTER" \
+    --service-name "$SERVICE" \
+    --desired-status RUNNING \
+    --region "$REGION" \
+    --query "taskArns[0]" \
+    --output text)
+
+if [[ -z "$TASK_ARN" || "$TASK_ARN" == "None" ]]; then
+    echo "No running tasks in $SERVICE." >&2
+    exit 1
+fi
+
+# Container name in the ApplicationLoadBalancedFargateService pattern
+# is "web" by default. Override via CONTAINER env if your task is different.
+CONTAINER_NAME="${CONTAINER:-web}"
+
+echo "stack:     $STACK"
+echo "cluster:   $CLUSTER"
+echo "service:   $SERVICE"
+echo "task:      $TASK_ARN"
+echo "container: $CONTAINER_NAME"
+echo
+
+exec aws ecs execute-command \
+    --cluster "$CLUSTER" \
+    --task "$TASK_ARN" \
+    --container "$CONTAINER_NAME" \
+    --command "/bin/bash" \
+    --interactive \
+    --region "$REGION"

--- a/infra/aws/stacks/api_stack.py
+++ b/infra/aws/stacks/api_stack.py
@@ -38,6 +38,7 @@ from aws_cdk import aws_ecr as ecr
 from aws_cdk import aws_ecs as ecs
 from aws_cdk import aws_ecs_patterns as ecs_patterns
 from aws_cdk import aws_elasticloadbalancingv2 as elbv2
+from aws_cdk import aws_iam as iam
 from aws_cdk import aws_logs as logs
 from aws_cdk import aws_rds as rds
 from aws_cdk import aws_s3 as s3
@@ -178,6 +179,21 @@ class ApiStack(cdk.Stack):
         # via boto3 so we cannot inject the value once at task start.
         public_keys_secret.grant_read(task_definition.task_role)
 
+        # Permissions required for ECS exec (see ApiService construction
+        # below for the EnableExecuteCommand override). Without these,
+        # `aws ecs execute-command` returns "TargetNotConnected".
+        task_definition.task_role.add_to_principal_policy(
+            iam.PolicyStatement(
+                actions=[
+                    "ssmmessages:CreateControlChannel",
+                    "ssmmessages:CreateDataChannel",
+                    "ssmmessages:OpenControlChannel",
+                    "ssmmessages:OpenDataChannel",
+                ],
+                resources=["*"],
+            )
+        )
+
         cert_arn = self.node.try_get_context("api_cert_arn")
         service_kwargs: dict[str, Any] = {
             "cluster": self.cluster,
@@ -212,6 +228,17 @@ class ApiStack(cdk.Stack):
             self,
             "ApiService",
             **service_kwargs,
+        )
+
+        # ECS exec on the underlying FargateService so ops can
+        # `aws ecs execute-command` into a running task — no SSH bastion,
+        # no RDS port-forward setup. The API container already has DB
+        # creds + VPC reach, so ad-hoc SQL becomes a `python -c` away.
+        # Session traffic is IAM-gated and SSM-logged. CDK auto-wires
+        # the ssmmessages:* perms onto the task role when this is on.
+        # Set via L1 escape hatch because the pattern doesn't expose it.
+        self.service.service.node.default_child.add_property_override(  # type: ignore[union-attr]
+            "EnableExecuteCommand", True
         )
 
         self.service.target_group.configure_health_check(


### PR DESCRIPTION
## Summary
Foundation for ad-hoc DB ops against the staging (or prod) RDS without an SSH bastion or SSM port-forward setup.

### Changes
- **`infra/aws/stacks/api_stack.py`**: L1 `EnableExecuteCommand` override on the underlying `FargateService` (the `ApplicationLoadBalancedFargateService` pattern doesn't expose the property directly). Grants the task role the four `ssmmessages:*` permissions needed by SSM under the hood.
- **`infra/aws/scripts/exec-api-shell.sh`**: helper that finds a running task in the staging (or prod) ApiService and opens an interactive bash via `aws ecs execute-command`. Defaults to staging.

### Why
The API container already has DB credentials (`DB_HOST`/`DB_USER`/`DB_PASSWORD`/`DB_NAME`) and VPC reach to the private RDS. With ECS exec on, a shell session can apply a SQL migration via `python -c` (sqlalchemy is already a dep). No EC2 to manage, no port-forward to set up, IAM-gated, Session-Manager-logged.

### Immediate use case
Apply the n_foods column + indexes from PR #217 to staging without waiting for a full ETL run. The full one-liner is in the commit body.

### Prereqs for ops
- AWS SSO logged in (`foodatlas-prod-admin` profile for staging too).
- SSM Session Manager plugin installed locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)