### PR TITLE
infra(db): migrate-bioact-perf subcommand + Fargate runner script

### DIFF
--- a/backend/db/main.py
+++ b/backend/db/main.py
@@ -5,6 +5,7 @@ import tempfile
 from pathlib import Path
 
 import click
+from sqlalchemy import text
 from src.config import DBSettings
 from src.engine import create_sync_engine
 from src.etl.loader import load_kg, load_trust_only, refresh_materialized_views
@@ -82,6 +83,88 @@ def refresh() -> None:
     engine = create_sync_engine(settings)
     with engine.connect() as conn:
         refresh_materialized_views(conn)
+    click.echo("Done.")
+
+
+# Ordered list of (description, sql) for the bioact-perf migration —
+# all idempotent, safe to re-run, no row mutations beyond UPDATEs from
+# already-present FCC data. Lives here (rather than in src/etl/) so the
+# whole migration is one screen and easy to audit.
+_BIOACT_PERF_MIGRATION: list[tuple[str, str]] = [
+    (
+        "add mv_chemical_bioactivity.n_foods column (default 0)",
+        "ALTER TABLE mv_chemical_bioactivity "
+        "ADD COLUMN IF NOT EXISTS n_foods INTEGER DEFAULT 0",
+    ),
+    (
+        "backfill n_foods from distinct foods in mv_food_chemical_composition",
+        "UPDATE mv_chemical_bioactivity cb "
+        "SET n_foods = COALESCE(nf.n_foods, 0) "
+        "FROM ("
+        "  SELECT chemical_foodatlas_id, "
+        "         COUNT(DISTINCT food_foodatlas_id) AS n_foods "
+        "  FROM mv_food_chemical_composition "
+        "  GROUP BY chemical_foodatlas_id"
+        ") nf "
+        "WHERE cb.chemical_foodatlas_id = nf.chemical_foodatlas_id",
+    ),
+    (
+        "index FCC(chemical_foodatlas_id) — speeds n_foods + inferred-bio join",
+        "CREATE INDEX IF NOT EXISTS ix_mv_fcc_chemical_id "
+        "ON mv_food_chemical_composition(chemical_foodatlas_id)",
+    ),
+    (
+        "index CB(chemical_foodatlas_id) — speeds inferred-bioactivities join",
+        "CREATE INDEX IF NOT EXISTS ix_mv_cb_chemical_id "
+        "ON mv_chemical_bioactivity(chemical_foodatlas_id)",
+    ),
+    (
+        "composite CB(bioactivity_name, measurement_count) — default sort",
+        "CREATE INDEX IF NOT EXISTS ix_mv_cb_bio_mcount "
+        "ON mv_chemical_bioactivity(bioactivity_name, measurement_count)",
+    ),
+    (
+        "composite CB(chemical_name, measurement_count) — chem-bio default sort",
+        "CREATE INDEX IF NOT EXISTS ix_mv_cb_chem_mcount "
+        "ON mv_chemical_bioactivity(chemical_name, measurement_count)",
+    ),
+    (
+        "composite CB(bioactivity_name, n_foods) — sort by # foods column",
+        "CREATE INDEX IF NOT EXISTS ix_mv_cb_bio_nfoods "
+        "ON mv_chemical_bioactivity(bioactivity_name, n_foods)",
+    ),
+    (
+        "composite FB(food_name, measurement_count) — /food/bioactivities sort",
+        "CREATE INDEX IF NOT EXISTS ix_mv_fb_food_mcount "
+        "ON mv_food_bioactivity(food_name, measurement_count)",
+    ),
+    (
+        "composite FB(bioactivity_name, measurement_count) — bio-foods sort",
+        "CREATE INDEX IF NOT EXISTS ix_mv_fb_bio_mcount "
+        "ON mv_food_bioactivity(bioactivity_name, measurement_count)",
+    ),
+]
+
+
+@cli.command("migrate-bioact-perf")
+def migrate_bioact_perf() -> None:
+    """One-shot migration: add n_foods column + bioactivity perf indexes.
+
+    Idempotent — uses ADD COLUMN IF NOT EXISTS and CREATE INDEX IF NOT
+    EXISTS throughout. Brings an already-loaded RDS to the schema the
+    PR introducing materialised n_foods + composite indexes expects,
+    without waiting for a full ``db load`` rebuild. Triggered via the
+    same Fargate task definition as ``db load`` — see
+    ``infra/aws/scripts/run-migration.sh``.
+    """
+    settings = DBSettings()
+    engine = create_sync_engine(settings)
+    logger = logging.getLogger("migrate-bioact-perf")
+    with engine.connect() as conn:
+        for description, sql in _BIOACT_PERF_MIGRATION:
+            logger.info(">>> %s", description)
+            conn.execute(text(sql))
+        conn.commit()
     click.echo("Done.")
 
 

--- a/infra/aws/scripts/_lib.sh
+++ b/infra/aws/scripts/_lib.sh
@@ -10,7 +10,10 @@ if [[ -z "$REGION" ]]; then
     exit 1
 fi
 
-STACK="FoodAtlasJobsStack"
+# Default to prod when caller hasn't overridden — both env var and
+# `STACK=... ./script.sh` prefix work. Callers like run-migration.sh
+# pre-export STACK=*-Staging so prod is never the accidental target.
+STACK="${STACK:-FoodAtlasJobsStack}"
 CONTAINER_NAME="JobsContainer"
 
 _output() {

--- a/infra/aws/scripts/run-migration.sh
+++ b/infra/aws/scripts/run-migration.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# Run a one-shot db migration command against the staging RDS via the
+# Jobs Fargate task definition. Same shape as run-data-load.sh — just a
+# different db CLI subcommand and a default to the *staging* stack.
+#
+# Usage:
+#   ./run-migration.sh migrate-bioact-perf            # default: staging
+#   STACK=FoodAtlasJobsStack ./run-migration.sh ...   # explicit prod
+#   ./run-migration.sh --dry-run migrate-bioact-perf  # print task plan only
+#
+# Default target is staging because migrations on prod should be a
+# deliberate STACK= override, not the default.
+
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+# Default to staging — prod migrations require an explicit STACK env var.
+STACK="${STACK:-FoodAtlasJobsStack-Staging}"
+export STACK
+
+# shellcheck source=_lib.sh
+source ./_lib.sh
+
+DRY_RUN=""
+if [[ "${1:-}" == "--dry-run" ]]; then DRY_RUN=1; shift; fi
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 [--dry-run] <db-cli-subcommand> [args...]" >&2
+    echo "  e.g.  $0 migrate-bioact-perf" >&2
+    exit 1
+fi
+
+# Build the JSON command array (python main.py <args...>).
+cmd_json='["python","main.py"'
+for arg in "$@"; do
+    # Escape backslashes + double-quotes for JSON safety.
+    escaped=${arg//\\/\\\\}
+    escaped=${escaped//\"/\\\"}
+    cmd_json+=",\"$escaped\""
+done
+cmd_json+=']'
+
+description="$* (stack=$STACK)"
+
+if [[ -n "$DRY_RUN" ]]; then
+    load_jobs_stack_outputs
+    echo "[dry-run] stack:       $STACK"
+    echo "[dry-run] cluster:     $CLUSTER"
+    echo "[dry-run] task def:    $TASK_DEF"
+    echo "[dry-run] subnets:     $SUBNET_IDS"
+    echo "[dry-run] security:    $SG_ID"
+    echo "[dry-run] container:   $CONTAINER_NAME"
+    echo "[dry-run] command:     $cmd_json"
+    echo "[dry-run] description: $description"
+    exit 0
+fi
+
+run_jobs_task "$cmd_json" "$description"


### PR DESCRIPTION
## Summary
Adds a `db migrate-bioact-perf` CLI subcommand following the same pattern as `db load` / `db refresh` — the migration is **code in the repo**, ships through cd-staging into the db Docker image, and is triggered via `aws ecs run-task` against the JobsStack-Staging task definition (same pattern `run-data-load.sh` already uses for the full ETL).

## What the migration does
9 idempotent statements (ADD COLUMN IF NOT EXISTS, CREATE INDEX IF NOT EXISTS, one UPDATE FROM):
1. Add `mv_chemical_bioactivity.n_foods INTEGER DEFAULT 0`
2. Backfill it from `COUNT(DISTINCT food_foodatlas_id)` over FCC
3. `ix_mv_fcc_chemical_id` on FCC
4. `ix_mv_cb_chemical_id` on CB
5-7. Composite indexes on CB: `(bio, mcount)`, `(chem, mcount)`, `(bio, nfoods)`
8-9. Composite indexes on FB: `(food, mcount)`, `(bio, mcount)`

Brings an already-loaded staging RDS to the schema that PR #217 introduces, without waiting for a full `db load` rebuild. Re-running is a no-op.

## Runner script
`infra/aws/scripts/run-migration.sh` is a thin wrapper around the existing `_lib.sh` `run_jobs_task` helper. Defaults to `FoodAtlasJobsStack-Staging` so prod requires an explicit `STACK=` override. Supports `--dry-run` for previewing the task plan.

## Trigger
After this PR + cd-staging deploy:

```
cd infra/aws/scripts
./run-migration.sh migrate-bioact-perf
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)