### PR TITLE
fix(api): hotfix bioactivity endpoint/unit noise from upstream

### DIFF
--- a/backend/api/src/repositories/_bioact_hotfix.py
+++ b/backend/api/src/repositories/_bioact_hotfix.py
@@ -1,0 +1,146 @@
+"""HOTFIX 2026-06-26 — REMOVE WHEN upstream endpoint/unit cleanup lands.
+
+Surgical normaliser for ``base_attestations_bioactivity`` rows whose
+``evidence_endpoint_type`` and ``potency_unit`` columns carry data
+quality issues that haven't yet been fixed in KGC ingest. Tracked in
+memory ``bioactivity-endpoint-unit-cleanup``; Kaichi confirmed he'll
+clean these upstream — until then this module masks the noise from the
+frontend.
+
+Rules (per Kaichi 2026-06-26):
+
+- A. Unit aliases — fold variants to one canonical:
+     * ``ug.mL-1``, ``ug ml-1``, ``ug/ml`` → ``ug/mL``
+     * ``uM``, ``MICROMOLAR``, ``microM``, ``µM``, ``μM`` → ``uM``
+- B. Empty/garbage unit (``None`` literal or empty string) → ``"None"``
+     so downstream isn't confused by NULLs.
+- C. Drop rows whose endpoint is a leaked assay name (single-source
+     strings that aren't endpoints at all).
+- D. Drop rows whose endpoint is a generic outcome metric, not a
+     potency endpoint. Per Kaichi these can happen depending on target,
+     but the user wants them dropped from the bioactivity view until
+     they're segregated upstream.
+- E. Endpoint variants — leave alone (Kaichi will review case by case).
+- F. Numeric IC/EC/CC suffixes — leave alone (legit % inhibition
+     cutoffs).
+
+To remove this hotfix:
+1. Delete this file.
+2. Remove the three imports + call sites in ``bioactivity.py`` (search
+   for ``hotfix``).
+3. Re-enable the endpoint·unit filter UI per memory
+   ``bioactivity-endpoint-unit-cleanup``.
+4. Update / delete that memory.
+"""
+
+from __future__ import annotations
+
+# Unit normalisation (case-insensitive lookup, value is canonical form).
+_UNIT_ALIASES: dict[str, str] = {
+    "ug.ml-1": "ug/mL",
+    "ug ml-1": "ug/mL",
+    "ug/ml": "ug/mL",
+    "um": "uM",
+    "micromolar": "uM",
+    "microm": "uM",
+    "µm": "uM",
+    "μm": "uM",  # different Greek mu codepoint (U+03BC vs U+00B5)
+}
+
+# Endpoint strings that are actually assay-name leakage. Drop the row.
+_LEAKED_ASSAY_ENDPOINTS: frozenset[str] = frozenset(
+    {
+        "LUCIFERASE INFECTION ASSAY - IC50",
+        "HEPG2TOX ASSAY - CC50",
+        "LUCIFERASE EXPRESSION CONTROL - IC50",
+        "Maximum test concentration that did not exhibit cytotoxicity",
+        "ED50 / ED50 (taxol)",
+    }
+)
+
+# Endpoints that are outcome metrics, not potency endpoints. Drop the
+# row. Comparison is case-insensitive on the trimmed value.
+_OUTCOME_NOT_ENDPOINT: frozenset[str] = frozenset(
+    s.lower()
+    for s in (
+        "Mitotic index",
+        "Cell cycle",
+        "Drug uptake",
+        "Phosphorylation rate",
+        "T-cell",
+        "Optimal concentration",
+        "Effective concentration",
+        "Average",
+        "Cytotoxicity",
+        "Concentration",
+        "Stability",
+        "Cell toxicity",
+        "Cytotoxic endpoint",
+        "Tumor size",
+        "Growth inhibition",
+        "Toxicity",
+        "Dose",
+        "Inhibition",
+        "Diameter",
+        "Relative",
+        "Selectivity index",
+        "IP",
+    )
+)
+
+
+def normalize_unit(unit: str | None) -> str:
+    """Fold unit variants to canonical form. Empty/garbage → ``"None"``."""
+    if unit is None:
+        return "None"
+    stripped = unit.strip()
+    if not stripped or stripped.upper() == "NONE":
+        return "None"
+    return _UNIT_ALIASES.get(stripped.lower(), stripped)
+
+
+def should_drop(endpoint: str | None) -> bool:
+    """True for endpoint values that should be hidden until upstream cleans."""
+    if endpoint is None:
+        return False
+    stripped = endpoint.strip()
+    if stripped in _LEAKED_ASSAY_ENDPOINTS:
+        return True
+    return stripped.lower() in _OUTCOME_NOT_ENDPOINT
+
+
+def clean_measurements(measurements: list[dict] | None) -> list[dict]:
+    """Drop bad-endpoint rows and normalise units in the survivors.
+
+    Returns a new list — never mutates the input.
+    """
+    if not measurements:
+        return []
+    out: list[dict] = []
+    for m in measurements:
+        if should_drop(m.get("endpoint")):
+            continue
+        cleaned = dict(m)
+        cleaned["unit"] = normalize_unit(m.get("unit"))
+        out.append(cleaned)
+    return out
+
+
+def clean_endpoint_options(rows: list[dict]) -> list[dict]:
+    """For the endpoint-options endpoint: drop bad endpoints, fold units.
+
+    Folds duplicate (endpoint, unit) keys that arise from unit aliasing
+    by summing their counts.
+    """
+    folded: dict[tuple[str, str], int] = {}
+    for r in rows:
+        endpoint = (r.get("endpoint") or "").strip()
+        if should_drop(endpoint):
+            continue
+        unit = normalize_unit(r.get("unit"))
+        key = (endpoint, unit)
+        folded[key] = folded.get(key, 0) + int(r.get("count") or 0)
+    return [
+        {"endpoint": e, "unit": u, "count": c}
+        for (e, u), c in sorted(folded.items(), key=lambda kv: -kv[1])
+    ]

--- a/backend/api/src/repositories/bioactivity.py
+++ b/backend/api/src/repositories/bioactivity.py
@@ -18,6 +18,10 @@ from sqlalchemy import text
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
+# HOTFIX 2026-06-26 — REMOVE WHEN upstream endpoint/unit cleanup lands.
+# See _bioact_hotfix.py docstring for the rules + removal checklist.
+from src.repositories import _bioact_hotfix
+
 logger = logging.getLogger(__name__)
 
 ROWS_PER_PAGE_DEFAULT = 20
@@ -85,6 +89,10 @@ def _top_measurement_by_value(measurements: list | None) -> dict | None:
 
 def _attach_top_measurement(data: list[dict]) -> list[dict]:
     for row in data:
+        # HOTFIX 2026-06-26 — clean dirty endpoint/unit values in the
+        # inline measurements sample before downstream consumers see
+        # them. See _bioact_hotfix.py for the rules + removal note.
+        row["measurements"] = _bioact_hotfix.clean_measurements(row.get("measurements"))
         row["top_measurement"] = _top_measurement_by_value(row.get("measurements"))
     return data
 
@@ -498,7 +506,11 @@ async def get_endpoint_options(
         """),
         {"rel": rel, "pivot": pivot_id},
     )
-    data = [dict(r._mapping) for r in rows_result]
+    # HOTFIX 2026-06-26 — drop leaked-assay/outcome endpoints and fold
+    # unit aliases before exposing the chip list. See _bioact_hotfix.py.
+    data = _bioact_hotfix.clean_endpoint_options(
+        [dict(r._mapping) for r in rows_result]
+    )
     return {"data": data, "metadata": {"row_count": len(data)}}
 
 
@@ -541,7 +553,11 @@ async def get_measurements(
         """),
         {"rel": relationship, "head": head_id, "tail": tail_id},
     )
-    rows = [dict(r._mapping) for r in rows_result]
+    # HOTFIX 2026-06-26 — clean dirty endpoint/unit values before
+    # enrichment + return. See _bioact_hotfix.py for rules + removal.
+    rows = _bioact_hotfix.clean_measurements(
+        [dict(r._mapping) for r in rows_result]
+    )
 
     # Assay metadata is best-effort enrichment — base_bioassays may not exist
     # in environments that haven't yet migrated. Log and continue so the

--- a/backend/api/src/repositories/bioactivity.py
+++ b/backend/api/src/repositories/bioactivity.py
@@ -555,9 +555,7 @@ async def get_measurements(
     )
     # HOTFIX 2026-06-26 — clean dirty endpoint/unit values before
     # enrichment + return. See _bioact_hotfix.py for rules + removal.
-    rows = _bioact_hotfix.clean_measurements(
-        [dict(r._mapping) for r in rows_result]
-    )
+    rows = _bioact_hotfix.clean_measurements([dict(r._mapping) for r in rows_result])
 
     # Assay metadata is best-effort enrichment — base_bioassays may not exist
     # in environments that haven't yet migrated. Log and continue so the

--- a/backend/api/tests/test_bioact_hotfix.py
+++ b/backend/api/tests/test_bioact_hotfix.py
@@ -1,0 +1,90 @@
+"""HOTFIX 2026-06-26 — delete this whole file when the upstream cleanup
+lands and `_bioact_hotfix.py` is removed (see that module's docstring).
+"""
+
+from __future__ import annotations
+
+from src.repositories._bioact_hotfix import (
+    clean_endpoint_options,
+    clean_measurements,
+    normalize_unit,
+    should_drop,
+)
+
+
+class TestNormalizeUnit:
+    def test_micromolar_aliases_fold_to_uM(self) -> None:
+        for raw in ("uM", "UM", "MICROMOLAR", "microM", "µM", "μM"):
+            assert normalize_unit(raw) == "uM"
+
+    def test_ug_ml_aliases_fold(self) -> None:
+        for raw in ("ug.mL-1", "ug ml-1", "ug/ml", "UG/ML"):
+            assert normalize_unit(raw) == "ug/mL"
+
+    def test_empty_and_none_become_literal_None(self) -> None:
+        assert normalize_unit(None) == "None"
+        assert normalize_unit("") == "None"
+        assert normalize_unit("   ") == "None"
+        assert normalize_unit("NONE") == "None"
+        assert normalize_unit("none") == "None"
+
+    def test_unknown_units_pass_through_trimmed(self) -> None:
+        assert normalize_unit("  nM  ") == "nM"
+        assert normalize_unit("mol/L") == "mol/L"
+
+
+class TestShouldDrop:
+    def test_leaked_assay_endpoints_drop(self) -> None:
+        for ep in (
+            "LUCIFERASE INFECTION ASSAY - IC50",
+            "HEPG2TOX ASSAY - CC50",
+            "Maximum test concentration that did not exhibit cytotoxicity",
+        ):
+            assert should_drop(ep) is True
+
+    def test_outcome_endpoints_drop_case_insensitive(self) -> None:
+        for ep in ("Mitotic index", "MITOTIC INDEX", "  cytotoxicity  "):
+            assert should_drop(ep) is True
+
+    def test_legit_endpoints_keep(self) -> None:
+        for ep in ("IC50", "EC50", "Ki", "IC25", "EC90", None, ""):
+            assert should_drop(ep) is False
+
+
+class TestCleanMeasurements:
+    def test_drops_dirty_and_folds_units(self) -> None:
+        out = clean_measurements(
+            [
+                {"endpoint": "IC50", "unit": "MICROMOLAR", "value": 1.0},
+                {"endpoint": "Mitotic index", "unit": "uM", "value": 2.0},
+                {"endpoint": "HEPG2TOX ASSAY - CC50", "unit": "uM", "value": 3.0},
+                {"endpoint": "EC50", "unit": "", "value": 4.0},
+            ]
+        )
+        assert out == [
+            {"endpoint": "IC50", "unit": "uM", "value": 1.0},
+            {"endpoint": "EC50", "unit": "None", "value": 4.0},
+        ]
+
+    def test_empty_input(self) -> None:
+        assert clean_measurements(None) == []
+        assert clean_measurements([]) == []
+
+
+class TestCleanEndpointOptions:
+    def test_drops_dirty_and_folds_duplicate_keys(self) -> None:
+        out = clean_endpoint_options(
+            [
+                {"endpoint": "IC50", "unit": "uM", "count": 100},
+                {"endpoint": "IC50", "unit": "MICROMOLAR", "count": 50},
+                {"endpoint": "IC50", "unit": "microM", "count": 5},
+                {"endpoint": "Mitotic index", "unit": "uM", "count": 200},
+                {"endpoint": "EC50", "unit": "nM", "count": 30},
+            ]
+        )
+        # IC50·uM folds three aliases into one entry of 155; outcome
+        # endpoint dropped entirely; sorted by count desc.
+        assert out == [
+            {"endpoint": "IC50", "unit": "uM", "count": 155},
+            {"endpoint": "EC50", "unit": "nM", "count": 30},
+        ]


### PR DESCRIPTION
## Summary

API-layer hotfix that normalises noisy `evidence_endpoint_type` / `potency_unit` values in `base_attestations_bioactivity` until Kaichi pushes the upstream cleanup. Per Kaichi 2026-06-26:

- **A.** Fold unit aliases — `ug.mL-1`/`ug ml-1`/`ug/ml` → `ug/mL`; `uM`/`MICROMOLAR`/`microM`/`µM`/`μM` → `uM`.
- **B.** Empty/garbage units → literal `"None"`.
- **C.** Drop rows whose endpoint is a leaked assay name (`LUCIFERASE INFECTION ASSAY - IC50` etc.).
- **D.** Drop rows whose endpoint is an outcome metric, not a potency endpoint (`Mitotic index`, `Cytotoxicity`, etc.).
- **E/F.** Untouched (legit variants, Kaichi will review case-by-case).

Applied at three call sites in `bioactivity.py`:
- `_attach_top_measurement` (all list endpoints' inline sample)
- `get_measurements` (unbounded modal endpoint)
- `get_endpoint_options` (filter-chip endpoint — folds duplicate keys after aliasing)

Counts (`measurement_count`/`active_count`/`inactive_count`) are NOT recomputed — they still reflect raw row totals. Small UI discrepancy with the cleaned sample is acceptable for a hotfix; resolves itself once upstream is normalised.

## Removal checklist

When upstream cleanup lands, delete this hotfix in four steps (also in commit message + module docstring):

1. Delete `backend/api/src/repositories/_bioact_hotfix.py`
2. Delete `backend/api/tests/test_bioact_hotfix.py`
3. Remove the import + three call sites in `bioactivity.py` (grep for `HOTFIX 2026-06-26`)
4. Re-enable the endpoint·unit filter UI per memory `bioactivity-endpoint-unit-cleanup`

## Test plan

- [x] `pytest tests/test_bioact_hotfix.py` — 10 unit tests for the cleaner
- [x] `pytest tests/` — 191 passed, 84% coverage
- [ ] After cd-staging deploys: verify `/bioactivity/chemicals?common_name=antioxidant` measurements no longer contain `MICROMOLAR` or `Mitotic index`

🤖 Generated with [Claude Code](https://claude.com/claude-code)