### PR TITLE
feat(frontend): session UI recovery

### DIFF
--- a/frontend/app/(everything-else)/about/page.tsx
+++ b/frontend/app/(everything-else)/about/page.tsx
@@ -60,7 +60,7 @@ const TEAM: TeamMember[] = [
   },
   {
     name: "Lukas Masopust",
-    position: "Frontend Engineer",
+    position: "Fullstack Engineer",
     pathToPortrait: "/images/lukas.webp",
     section: "development",
     linkToWebsite: "https://www.aifs.ucdavis.edu/about/people?s=lukas-masopust",
@@ -68,9 +68,9 @@ const TEAM: TeamMember[] = [
   },
   {
     name: "Kaichi Xie",
-    position: "Backend Engineer",
+    position: "Graduate Student Researcher",
     pathToPortrait: "/images/kaichi.webp",
-    section: "development",
+    section: "research",
     linkToLinkedIn: "https://www.linkedin.com/in/kaichi-xie-nicholas/",
   },
 ];

--- a/frontend/app/(home)/page.tsx
+++ b/frontend/app/(home)/page.tsx
@@ -1,10 +1,6 @@
 import { Metadata } from "next";
 
 import HeroSection from "@/components/landing/HeroSection";
-import NumbersSection from "@/components/landing/NumbersSection";
-import NewsletterSection from "@/components/landing/NewsletterSection";
-import AIFSResourcesSection from "@/components/landing/AIFSResourcesSection";
-import DemoSection from "@/components/landing/DemoSection";
 
 export const metadata: Metadata = {
   title: "FoodAtlas | Evidence-Based Food Composition Database",
@@ -12,31 +8,7 @@ export const metadata: Metadata = {
     "Access extensive food composition data sourced by AI from peer-reviewed research. Apply reliable data to your research using the API or downloadable data sets.",
 };
 
-const Landing = () => {
-  return (
-    <>
-      <div className="px-3 md:px-12 pt-4">
-        <div className="max-w-6xl mx-auto">
-          <div className="border-l-4 border-accent-500 bg-light-900/60 rounded-r-md px-5 py-4">
-            <div className="text-accent-500 text-xs font-semibold uppercase tracking-wider">
-              News
-            </div>
-            <div className="mt-1 text-light-200 text-base md:text-lg">
-              <span className="text-light-400">6/05/2026 — </span>
-              FoodAtlas Knowledge Graph <strong>v4.1</strong> has been
-              released with improved data quality and expanded coverage.
-            </div>
-          </div>
-        </div>
-      </div>
-      <HeroSection />
-      <NumbersSection />
-      <NewsletterSection />
-      <AIFSResourcesSection />
-      {/* <DemoSection /> */}
-    </>
-  );
-};
+const Landing = () => <HeroSection />;
 
 export default Landing;
 

--- a/frontend/components/basic/Modal.tsx
+++ b/frontend/components/basic/Modal.tsx
@@ -1,6 +1,7 @@
 // modal wrapper for headless ui dialog
 
 import { Dialog, DialogPanel } from "@headlessui/react";
+import { useEffect } from "react";
 import { MdClose } from "react-icons/md";
 import { twMerge } from "tailwind-merge";
 
@@ -31,9 +32,19 @@ const Modal = ({
   fullHeight,
   footer,
 }: ModalProps) => {
-  // Headless UI Dialog handles scroll locking internally.
-  // scrollbar-gutter: stable on <html> (globals.css) reserves scrollbar
-  // space, preventing layout shift when the scrollbar is hidden.
+  // Lock page scroll while the dialog is open — Headless UI's Dialog
+  // doesn't do this on its own in v2. The scroll container in this app
+  // is <html> (globals.css forces `overflow-y: scroll !important`),
+  // and inline-style `!important` doesn't reliably beat the stylesheet
+  // rule across browsers, so we toggle a class that the stylesheet
+  // raises above it via higher specificity.
+  useEffect(() => {
+    if (!isOpen) return;
+    document.documentElement.classList.add("modal-open");
+    return () => {
+      document.documentElement.classList.remove("modal-open");
+    };
+  }, [isOpen]);
 
   return (
     <Dialog

--- a/frontend/components/entities/EntityTabs.tsx
+++ b/frontend/components/entities/EntityTabs.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ReactNode } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { Tab, TabGroup, TabList, TabPanel, TabPanels } from "@headlessui/react";
 import { twMerge } from "tailwind-merge";
@@ -34,13 +34,33 @@ const EntityTabs = ({ tabs, defaultTabId }: Props) => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
 
-  const requestedId = searchParams.get("tab") ?? defaultTabId;
-  const idx = tabs.findIndex((t) => t.id === requestedId);
-  const selectedIndex = idx >= 0 ? idx : 0;
+  // Derive initial index from URL, then hold local state so the tab
+  // switches immediately on click. Previously this was derived from
+  // useSearchParams on every render, but `router.replace` doesn't
+  // reliably update useSearchParams synchronously inside Headless UI's
+  // controlled TabGroup — the tab would visually "revert" and the user
+  // had to click twice. Local state avoids the round-trip.
+  const urlId = searchParams.get("tab") ?? defaultTabId;
+  const urlIdx = tabs.findIndex((t) => t.id === urlId);
+  const [selectedIndex, setSelectedIndex] = useState(
+    urlIdx >= 0 ? urlIdx : 0,
+  );
+
+  // Keep local state in sync when the URL changes from OUTSIDE this
+  // component (e.g. browser back/forward, deep link).
+  useEffect(() => {
+    if (urlIdx >= 0 && urlIdx !== selectedIndex) {
+      setSelectedIndex(urlIdx);
+    }
+    // We intentionally don't depend on selectedIndex — that would flip
+    // the tab back if the URL update lags the click.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [urlIdx]);
 
   const handleChange = (next: number) => {
     const id = tabs[next]?.id;
     if (!id) return;
+    setSelectedIndex(next);
     const params = new URLSearchParams(searchParams.toString());
     params.set("tab", id);
     router.replace(`${pathname}?${params.toString()}`, { scroll: false });

--- a/frontend/components/entities/bioactivity/BioactivityMeasurementsModal.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityMeasurementsModal.tsx
@@ -17,8 +17,9 @@
 
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { Fragment, useEffect, useMemo, useState } from "react";
 import {
+  MdChevronRight,
   MdClose,
   MdInfoOutline,
   MdKeyboardArrowLeft,
@@ -40,6 +41,21 @@ import type {
 } from "@/types";
 
 type ModalRow = Partial<BioactivityMeasurementFull> & BioactivityMeasurement;
+
+// A row qualifies for the accordion expand only when all four 4PL Hill
+// parameters are present. ChEMBL / PubChem rows usually carry just a
+// logAC50 + raw value; only ToxCast-style measurements have zero /
+// infinite / slope too.
+const hasHillFit = (m: ModalRow): boolean => {
+  const { efficacy_zeroactivity: z, efficacy_infiniteactivity: inf } = m;
+  const { efficacy_logac50_value: lac, efficacy_hillslope: s } = m;
+  return [z, inf, lac, s].every(
+    (v) => v != null && Number.isFinite(v),
+  ) && z !== inf && s !== 0;
+};
+
+const rowKey = (m: ModalRow, i: number): string =>
+  m.bioactivity_metadata_id ?? `row-${i}`;
 
 const PAGE_SIZE = 20;
 const OUTCOME_OPTIONS = ["all", "active", "inactive", "unspecified", "inconclusive"] as const;
@@ -109,13 +125,17 @@ const BioactivityMeasurementsModal = ({
   const [searchTerm, setSearchTerm] = useState("");
   const [outcomeFilter, setOutcomeFilter] = useState<OutcomeFilter>("all");
   const [currentPage, setCurrentPage] = useState(1);
+  // Accordion expansion — at most one row open at a time. Stored by
+  // stable row key so re-renders + page changes don't desync it.
+  const [expandedKey, setExpandedKey] = useState<string | null>(null);
 
-  // Reset filters/page when the modal closes or the underlying selection
-  // changes (different chemical/food clicked).
+  // Reset filters/page/expand when the modal closes or the underlying
+  // selection changes (different chemical/food clicked).
   useEffect(() => {
     setSearchTerm("");
     setOutcomeFilter("all");
     setCurrentPage(1);
+    setExpandedKey(null);
   }, [isOpen, selectedId]);
 
   // Outcomes computed from the FULL row set (not filtered) so the chip
@@ -323,6 +343,10 @@ const BioactivityMeasurementsModal = ({
           rows={visible}
           placeholderCount={placeholderCount}
           skeleton={showSkeleton}
+          expandedKey={expandedKey}
+          onToggleExpand={(k) =>
+            setExpandedKey((prev) => (prev === k ? null : k))
+          }
         />
         {showEmptyState && (
           <div className="absolute inset-0 flex items-center justify-center bg-light-950/80 text-light-300 gap-2 text-sm pointer-events-none">
@@ -341,33 +365,48 @@ const MeasurementsTable = ({
   rows,
   placeholderCount,
   skeleton,
+  expandedKey,
+  onToggleExpand,
 }: {
   rows: ModalRow[];
   placeholderCount: number;
   skeleton: boolean;
+  expandedKey: string | null;
+  onToggleExpand: (key: string) => void;
 }) => {
   // When in skeleton mode we draw PAGE_SIZE shimmer rows; otherwise we
   // draw the real rows and pad up to PAGE_SIZE with empty <tr>s so the
   // last-page case doesn't shrink the table height.
   const dataRows = skeleton ? [] : rows;
-  const padCount = skeleton ? PAGE_SIZE : placeholderCount;
+  // Each expanded row takes one extra slot — reduce pads to keep the
+  // total slot count visually stable.
+  const expandedInView = skeleton
+    ? 0
+    : dataRows.some((m, i) => rowKey(m, i) === expandedKey)
+      ? 1
+      : 0;
+  const padCount = skeleton
+    ? PAGE_SIZE
+    : Math.max(0, placeholderCount - expandedInView);
   return (
     <table className="w-full table-fixed">
       <colgroup>
-        <col className="w-[26%]" />
-        <col className="w-[14%]" />
+        <col className="w-[28%]" />
+        <col className="w-[16%]" />
         <col className="w-[10%]" />
         <col className="w-[12%]" />
-        <col className="w-[20%]" />
-        <col className="w-[18%]" />
+        <col className="w-[34%]" />
       </colgroup>
-      <thead className="text-light-400 text-left">
+      <thead className="text-light-400 text-left sticky top-0 z-10 bg-light-950">
         <tr>
-          {["Assay", "Endpoint", "Outcome", "Source", "Value", "Curve"].map(
-            (h) => (
+          {["Assay", "Endpoint", "Outcome", "Source", "Value"].map(
+            (h, idx) => (
               <th
                 key={h}
-                className="h-9 border-b border-light-700 leading-none py-1.5 px-2 first:pl-0 last:pr-0"
+                className={twMerge(
+                  "h-9 border-b border-light-700 leading-none py-1.5 px-2 first:pl-0 last:pr-0 bg-light-950",
+                  idx === 4 && "text-right",
+                )}
               >
                 <span className="select-none uppercase text-xs font-medium">
                   {h}
@@ -378,51 +417,103 @@ const MeasurementsTable = ({
         </tr>
       </thead>
       <tbody className="text-sm font-light">
-        {dataRows.map((m, i) => (
-          <tr key={`${m.assay ?? "row"}-${i}`}>
-            <td className="py-1.5 pr-2 align-top">
-              <div
-                className="font-mono text-xs text-light-200 truncate"
-                title={m.assay ?? undefined}
+        {dataRows.map((m, i) => {
+          const key = rowKey(m, i);
+          const canExpand = hasHillFit(m);
+          const isExpanded = expandedKey === key;
+          return (
+            <Fragment key={key}>
+              <tr
+                onClick={canExpand ? () => onToggleExpand(key) : undefined}
+                aria-expanded={canExpand ? isExpanded : undefined}
+                className={twMerge(
+                  "transition-colors",
+                  canExpand && "cursor-pointer hover:bg-light-900/50",
+                  isExpanded && "bg-light-900/50",
+                )}
               >
-                {m.assay ?? "—"}
-              </div>
-            </td>
-            <td className="py-1.5 px-2 align-top text-light-200">
-              {m.endpoint || "—"}
-            </td>
-            <td className="py-1.5 px-2 align-top">
-              <OutcomeBadge outcome={m.outcome} />
-            </td>
-            <td className="py-1.5 px-2 align-top">
-              <SourceBadge source={m.evidence_source} />
-            </td>
-            <td className="py-1.5 px-2 align-top font-mono text-xs text-light-200 tabular-nums text-right">
-              {m.value === null || m.value === undefined ? (
-                <span className="text-light-600">—</span>
-              ) : (
-                <>
-                  {formatNumberShort(m.value)}{" "}
-                  <span className="text-light-500">
-                    {m.unit && m.unit !== "None" ? m.unit : ""}
-                  </span>
-                </>
+                <td className="py-1.5 pr-2 align-top">
+                  <div
+                    className="font-mono text-xs text-light-200 truncate"
+                    title={m.assay ?? undefined}
+                  >
+                    {m.assay ?? "—"}
+                  </div>
+                </td>
+                <td className="py-1.5 px-2 align-top text-light-200">
+                  {m.endpoint || "—"}
+                </td>
+                <td className="py-1.5 px-2 align-top">
+                  <OutcomeBadge outcome={m.outcome} />
+                </td>
+                <td className="py-1.5 px-2 align-top">
+                  <SourceBadge source={m.evidence_source} />
+                </td>
+                <td className="py-1.5 pl-2 align-top">
+                  <div className="flex items-center justify-between gap-3">
+                    {canExpand ? (
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onToggleExpand(key);
+                        }}
+                        aria-label={
+                          isExpanded
+                            ? "Hide Hill curve"
+                            : "Show Hill curve"
+                        }
+                        className={twMerge(
+                          "inline-flex items-center gap-1 px-2 py-0.5 rounded-full border font-mono italic text-xs whitespace-nowrap transition-colors",
+                          isExpanded
+                            ? "border-accent-600/60 bg-accent-600/10 text-accent-600"
+                            : "border-light-700/60 text-light-400 hover:text-light-100 hover:border-light-500",
+                        )}
+                      >
+                        <span>
+                          {isExpanded ? "Hide" : "Show"} Hill Curve
+                        </span>
+                        <MdChevronRight
+                          className={twMerge(
+                            "transition-transform duration-150",
+                            isExpanded && "rotate-90",
+                          )}
+                        />
+                      </button>
+                    ) : (
+                      <span aria-hidden />
+                    )}
+                    <span className="font-mono text-xs text-light-200 tabular-nums text-right">
+                      {m.value === null || m.value === undefined ? (
+                        <span className="text-light-600">—</span>
+                      ) : (
+                        <>
+                          {formatNumberShort(m.value)}{" "}
+                          <span className="text-light-500">
+                            {m.unit && m.unit !== "None" ? m.unit : ""}
+                          </span>
+                        </>
+                      )}
+                    </span>
+                  </div>
+                </td>
+              </tr>
+              {isExpanded && (
+                <tr>
+                  <td
+                    colSpan={5}
+                    className="py-3 px-3 bg-light-900/30 border-l-2 border-l-accent-600 border-b border-light-700/40"
+                  >
+                    <ExpandedHillFit m={m} />
+                  </td>
+                </tr>
               )}
-            </td>
-            <td className="py-1.5 pl-2 align-top text-light-300">
-              <HillCurveSparkline
-                zero={m.efficacy_zeroactivity}
-                infinite={m.efficacy_infiniteactivity}
-                logAC50={m.efficacy_logac50_value}
-                slope={m.efficacy_hillslope}
-                unit={m.unit}
-              />
-            </td>
-          </tr>
-        ))}
+            </Fragment>
+          );
+        })}
         {Array.from({ length: padCount }).map((_, i) => (
           <tr key={`pad-${i}`}>
-            <td className="py-1.5 pr-2" colSpan={6}>
+            <td className="py-1.5 pr-2" colSpan={5}>
               {skeleton ? (
                 <LoadingCard className="h-5" />
               ) : (
@@ -433,6 +524,81 @@ const MeasurementsTable = ({
         ))}
       </tbody>
     </table>
+  );
+};
+
+// Inline expanded view for one (assay × bioactivity) measurement —
+// shown below the row when its accordion is open. Large Hill curve on
+// the left, four-parameter fit metadata on the right. Only rendered
+// for rows that pass `hasHillFit`, so all four numbers are guaranteed
+// finite here.
+const ExpandedHillFit = ({ m }: { m: ModalRow }) => {
+  const lac = m.efficacy_logac50_value;
+  const ac50 = lac != null ? 10 ** lac : null;
+  const fmtNum = (v: number | null | undefined, digits = 2): string =>
+    v == null || !Number.isFinite(v) ? "—" : v.toFixed(digits);
+  const fmtSig = (v: number | null | undefined): string =>
+    v == null || !Number.isFinite(v)
+      ? "—"
+      : v.toLocaleString(undefined, { maximumSignificantDigits: 3 });
+  const unitLabel = m.unit && m.unit !== "None" ? m.unit : "";
+  return (
+    <div className="flex flex-col md:flex-row gap-6 items-stretch w-full">
+      {/* Important values — left, fixed-width column for fast scan. */}
+      <dl className="md:w-48 flex-shrink-0 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-xs font-mono content-start">
+        <dt className="italic uppercase text-light-500">AC50</dt>
+        <dd className="text-light-100 tabular-nums">
+          {fmtSig(ac50)}
+          {unitLabel && <span className="text-light-500"> {unitLabel}</span>}
+        </dd>
+        <dt className="italic uppercase text-light-500">log AC50</dt>
+        <dd className="text-light-100 tabular-nums">{fmtNum(lac, 3)}</dd>
+        <dt className="italic uppercase text-light-500">Hill slope</dt>
+        <dd className="text-light-100 tabular-nums">
+          {fmtNum(m.efficacy_hillslope, 2)}
+        </dd>
+        <dt className="italic uppercase text-light-500">top</dt>
+        <dd className="text-light-100 tabular-nums">
+          {fmtNum(m.efficacy_infiniteactivity, 1)}
+        </dd>
+        <dt className="italic uppercase text-light-500">bottom</dt>
+        <dd className="text-light-100 tabular-nums">
+          {fmtNum(m.efficacy_zeroactivity, 1)}
+        </dd>
+        {m.evidence_fit_r2 != null && (
+          <>
+            <dt className="italic uppercase text-light-500">R²</dt>
+            <dd className="text-light-100 tabular-nums">
+              {fmtNum(m.evidence_fit_r2, 3)}
+            </dd>
+          </>
+        )}
+        {m.evidence_fit_curveclass && (
+          <>
+            <dt className="italic uppercase text-light-500">curve class</dt>
+            <dd className="text-light-100">{m.evidence_fit_curveclass}</dd>
+          </>
+        )}
+      </dl>
+      {/* Curve — right, fills remaining horizontal space. Wrapper has
+       * an explicit aspect ratio matching the viewBox so the
+       * preserveAspectRatio default (meet) doesn't letterbox. */}
+      <div
+        className="flex-1 min-w-0 text-light-300"
+        style={{ aspectRatio: "720 / 320" }}
+      >
+        <HillCurveSparkline
+          zero={m.efficacy_zeroactivity}
+          infinite={m.efficacy_infiniteactivity}
+          logAC50={m.efficacy_logac50_value}
+          slope={m.efficacy_hillslope}
+          unit={m.unit}
+          width={720}
+          height={320}
+          fluid
+        />
+      </div>
+    </div>
   );
 };
 

--- a/frontend/components/entities/bioactivity/HillCurveSparkline.tsx
+++ b/frontend/components/entities/bioactivity/HillCurveSparkline.tsx
@@ -29,6 +29,11 @@ interface Props {
   unit?: string | null;
   width?: number;
   height?: number;
+  // When true, the SVG fills its container (width/height = 100%) while
+  // keeping the supplied width/height as the internal viewBox. Used
+  // for the accordion's expanded view so the curve takes whatever
+  // horizontal space the layout offers.
+  fluid?: boolean;
 }
 
 const SAMPLES = 80;
@@ -61,6 +66,7 @@ const HillCurveSparkline = ({
   unit,
   width = 160,
   height = 64,
+  fluid = false,
 }: Props) => {
   const svgRef = useRef<SVGSVGElement | null>(null);
   const [hoverPx, setHoverPx] = useState<number | null>(null);
@@ -136,8 +142,8 @@ const HillCurveSparkline = ({
   return (
     <svg
       ref={svgRef}
-      width={width}
-      height={height}
+      width={fluid ? "100%" : width}
+      height={fluid ? "100%" : height}
       viewBox={`0 0 ${width} ${height}`}
       role="img"
       aria-label={`Hill curve fit, AC50 at 10^${logAC50.toFixed(2)}, slope ${slope.toFixed(2)}`}
@@ -248,7 +254,10 @@ const HillCurveSparkline = ({
       {/* AC50 dot at midpoint */}
       <circle cx={midPx} cy={midPy} r="2" fill="currentColor" />
 
-      {/* hover crosshair — vertical line through the curve + dot on it */}
+      {/* hover crosshair — vertical + horizontal lines through the
+       * cursor's curve intersection, dot on the curve, and axis ticks
+       * + value labels so the user can read the concentration / activity
+       * straight off the axes without going to the top-right readout. */}
       {hoverLogX != null && hoverY != null && (
         <>
           <line
@@ -259,12 +268,58 @@ const HillCurveSparkline = ({
             stroke="currentColor"
             strokeOpacity="0.5"
           />
+          <line
+            x1={PAD_LEFT}
+            x2={toPx(hoverLogX)}
+            y1={toPy(hoverY)}
+            y2={toPy(hoverY)}
+            stroke="currentColor"
+            strokeOpacity="0.5"
+            strokeDasharray="2 2"
+          />
           <circle
             cx={toPx(hoverLogX)}
             cy={toPy(hoverY)}
             r="2.5"
             fill="currentColor"
           />
+          {/* X-axis tick + concentration label at the cursor */}
+          <line
+            x1={toPx(hoverLogX)}
+            x2={toPx(hoverLogX)}
+            y1={PAD_TOP + plotH}
+            y2={PAD_TOP + plotH + 3}
+            stroke="currentColor"
+          />
+          <text
+            x={toPx(hoverLogX)}
+            y={height - 1}
+            fontSize="8"
+            fontFamily={labelFont}
+            fill="currentColor"
+            textAnchor="middle"
+          >
+            {fmtConc(hoverLogX)}
+            {unit ? ` ${unit}` : ""}
+          </text>
+          {/* Y-axis tick + activity label at the curve intersection */}
+          <line
+            x1={PAD_LEFT - 3}
+            x2={PAD_LEFT}
+            y1={toPy(hoverY)}
+            y2={toPy(hoverY)}
+            stroke="currentColor"
+          />
+          <text
+            x={PAD_LEFT - 4}
+            y={toPy(hoverY) + 3}
+            fontSize="8"
+            fontFamily={labelFont}
+            fill="currentColor"
+            textAnchor="end"
+          >
+            {fmtY(hoverY)}
+          </text>
         </>
       )}
     </svg>
@@ -272,5 +327,77 @@ const HillCurveSparkline = ({
 };
 
 HillCurveSparkline.displayName = "HillCurveSparkline";
+
+// Tiny line-only glyph for the accordion indicator column — just the
+// curve trace, no axes, labels, AC50 marker, or hover. Carries enough
+// information (slope direction + steepness) to telegraph at a glance
+// that the row has a fitted curve to expand. Defaults sized for a
+// table cell (~50×18). Returns null when the fit is incomplete so the
+// call site can render an em-dash instead.
+export const HillCurveGlyph = ({
+  zero,
+  infinite,
+  logAC50,
+  slope,
+  width = 50,
+  height = 18,
+}: {
+  zero: number | null | undefined;
+  infinite: number | null | undefined;
+  logAC50: number | null | undefined;
+  slope: number | null | undefined;
+  width?: number;
+  height?: number;
+}) => {
+  if (
+    zero == null ||
+    infinite == null ||
+    logAC50 == null ||
+    slope == null ||
+    !Number.isFinite(zero) ||
+    !Number.isFinite(infinite) ||
+    !Number.isFinite(logAC50) ||
+    !Number.isFinite(slope) ||
+    slope === 0 ||
+    zero === infinite
+  ) {
+    return null;
+  }
+  const logXMin = logAC50 - DECADES;
+  const logXMax = logAC50 + DECADES;
+  const yMin = Math.min(zero, infinite);
+  const yMax = Math.max(zero, infinite);
+  const yRange = yMax - yMin;
+  // Leave 1px gutter so the line doesn't touch the edge.
+  const points: string[] = [];
+  for (let i = 0; i < SAMPLES; i++) {
+    const t = i / (SAMPLES - 1);
+    const logX = logXMin + t * (logXMax - logXMin);
+    const y = zero + (infinite - zero) / (1 + 10 ** ((logAC50 - logX) * slope));
+    const px = 1 + t * (width - 2);
+    const py = 1 + ((yMax - y) / yRange) * (height - 2);
+    points.push(`${px.toFixed(1)},${py.toFixed(1)}`);
+  }
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      aria-hidden
+      className="block"
+    >
+      <polyline
+        points={points.join(" ")}
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+};
+
+HillCurveGlyph.displayName = "HillCurveGlyph";
 
 export default HillCurveSparkline;

--- a/frontend/components/entities/food/Synonyms.tsx
+++ b/frontend/components/entities/food/Synonyms.tsx
@@ -67,9 +67,9 @@ const SynonymsModal = ({
     // a single chip. Low vertical padding keeps the row svelte.
     body = (
       <div className="flex flex-wrap gap-1 min-w-0">
-        {previewList.map((name) => (
+        {previewList.map((name, i) => (
           <span
-            key={name}
+            key={`${name}-${i}`}
             className="capitalize text-xs leading-tight px-2 py-0.5 rounded-full border border-light-700/70 bg-light-900/40 text-light-200 break-all max-w-full"
           >
             {name}

--- a/frontend/components/landing/HeroSection.tsx
+++ b/frontend/components/landing/HeroSection.tsx
@@ -3,61 +3,93 @@ import { FaMicroscope } from "react-icons/fa6";
 
 import Badge from "@/components/basic/Badge";
 import AIIcon from "@/components/icons/AIIcon";
-import SearchWrapper from "@/components/landing/SearchWrapper";
 import Heading from "@/components/basic/Heading";
+import HeroStatsLine from "@/components/landing/HeroStatsLine";
+import SearchWrapper from "@/components/landing/SearchWrapper";
 
+// Hero is a single centred flex column. Each child sits in normal
+// flow with one consistent gap so the entire stack scales together
+// when content changes. The portaled <SearchBar/> overlays the
+// SearchWrapper spacer via a measured offset, so there are no magic
+// pixel positions anywhere in this file.
 const HeroSection = () => {
   return (
-    <div className="h-[47rem] relative">
-      {/* background image */}
+    <section className="relative">
       <Image
-        className="object-cover h-full -z-10 max-w-[130rem] mx-auto blur-sm"
+        className="object-cover -z-10 max-w-[130rem] mx-auto blur-sm"
         fill
         alt="Background wallpaper of a graph resembling a neural network"
         src="/images/hero_wallpaper_color.webp"
         priority
         quality={100}
       />
-      {/* container */}
-      <div className="flex flex-col relative">
-        {/* heading container */}
-        <div className="px-3 md:px-12">
-          <div className="max-w-6xl mt-[3.3rem] md:mt-20 lg:mt-16 flex flex-col items-center mx-auto gap-6">
-            {/* badge container */}
-            <div className="flex gap-2 md:gap-3 lg:gap-4">
-              <Badge
-                leftIcon={
-                  <AIIcon height={"1em"} width={"1em"} color="#FF5722" />
-                }
-              >
-                AI-Powered
-              </Badge>
-              <Badge
-                leftIcon={
-                  <FaMicroscope height={"1em"} width={"1em"} color="#FF5722" />
-                }
-              >
-                Research-Based
-              </Badge>
-            </div>
-            <Heading
-              type="h1"
-              className="text-[2.3rem] leading-[2.4rem] md:leading-[3rem] md:text-[2.9rem] lg:text-6xl text-center text-shadow-lg text-light-50 max-w-sm md:max-w-none font-semibold"
+      <div className="relative min-h-[44rem] md:min-h-[48rem] flex flex-col justify-center px-3 md:px-12 py-14 md:py-20">
+        <div className="max-w-4xl w-full mx-auto flex flex-col items-center gap-6 md:gap-8">
+          {/* News line — typeset (no chrome), accent eyebrow + serif
+           * italic body. Sits closest to the top edge. */}
+          <div className="flex items-center gap-2 md:gap-3 leading-none">
+            <span className="font-mono italic text-[10px] md:text-xs uppercase tracking-[0.22em] text-accent-500">
+              News
+            </span>
+            <span className="block h-3 w-px bg-accent-500/40" aria-hidden />
+            <span className="font-serif italic text-xs md:text-sm text-light-200">
+              FoodAtlas Knowledge Graph{" "}
+              <strong className="not-italic font-semibold text-white">
+                v4.1
+              </strong>{" "}
+              released
+            </span>
+          </div>
+
+          {/* Credentials */}
+          <div className="flex gap-2 md:gap-3">
+            <Badge
+              size="sm"
+              leftIcon={<AIIcon height="1em" width="1em" color="#FF5722" />}
             >
-              Explore the links between <br /> foods, chemicals & diseases
-            </Heading>
-            {/* separator */}
-            <div className="w-32 md:w-48 h-[0.1rem] md:h-1 rounded-full  bg-gradient-to-r from-accent-400/50 via-accent-600/80 to-accent-400/50 border border-accent-500" />
-            {/* tagline */}
-            <p className="max-w-xl lg:max-w-none text-lg md:text-2xl text-light-300 text-center">
-              Introducing <i>FoodAtlas</i>, the world&apos;s first
-              evidence-based food knowledge base.
-            </p>
+              AI-Powered
+            </Badge>
+            <Badge
+              size="sm"
+              leftIcon={
+                <FaMicroscope height={"1em"} width={"1em"} color="#FF5722" />
+              }
+            >
+              Peer-Reviewed
+            </Badge>
+          </div>
+
+          {/* Headline */}
+          <Heading
+            type="h1"
+            className="text-[2rem] leading-[2.2rem] md:leading-[2.8rem] md:text-[2.5rem] lg:text-5xl text-center text-shadow-lg text-light-50 font-semibold"
+          >
+            The evidence-based <br className="hidden md:block" /> food knowledge
+            graph.
+          </Heading>
+
+          <div className="w-32 md:w-48 h-[0.1rem] md:h-1 rounded-full bg-gradient-to-r from-accent-400/50 via-accent-600/80 to-accent-400/50 border border-accent-500" />
+
+          {/* Subhead */}
+          <p className="max-w-xl lg:max-w-3xl text-lg md:text-2xl text-light-300 text-center">
+            Search bioactivities, foods, chemicals &amp; diseases &mdash; every
+            link traced to peer-reviewed sources.
+          </p>
+
+          {/* Search spacer — reserves vertical space matching the
+           * portaled SearchBar + TryChips and reports its position
+           * back through SearchContext so the overlay aligns. */}
+          <SearchWrapper />
+
+          {/* Stats — hidden on phones; the row would either scroll
+           * horizontally or wrap into 3+ lines, neither of which feels
+           * good on a small viewport. */}
+          <div className="hidden md:block">
+            <HeroStatsLine />
           </div>
         </div>
-        <SearchWrapper />
       </div>
-    </div>
+    </section>
   );
 };
 

--- a/frontend/components/landing/HeroStatsLine.tsx
+++ b/frontend/components/landing/HeroStatsLine.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+// Compact mono-italic stats line that lives under the hero search.
+// Replaces the previous standalone `NumbersSection` (stat cards) —
+// the cards were redundant signal once the same numbers are in the
+// hero. Falls back to zeros on fetch failure (per the graceful API
+// rule in memory).
+
+import { useLandingStats } from "@/components/landing/useLandingStats";
+
+const fmt = (n: number): string => n.toLocaleString();
+const fmtCompact = (n: number): string => {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return n.toLocaleString();
+};
+
+// Order matters: associations leads (it's the headline metric — every
+// link in the graph counted at the row level). Within the entity-type
+// block, bioactivities goes first per the same ordering rule used in
+// the search placeholder + the `<TryChips>` row.
+const ITEMS: {
+  key: keyof Awaited<ReturnType<typeof useLandingStats>>;
+  label: string;
+  compact?: boolean;
+}[] = [
+  { key: "associations", label: "Associations", compact: true },
+  { key: "bioactivities", label: "Bioactivities" },
+  { key: "foods", label: "Foods" },
+  { key: "chemicals", label: "Chemicals" },
+  { key: "diseases", label: "Diseases" },
+  { key: "publications", label: "Publications" },
+];
+
+const HeroStatsLine = () => {
+  const stats = useLandingStats();
+  return (
+    <div className="flex justify-center">
+      <div
+        className={
+          // Glass bar — black/40 + backdrop blur to lift the row off the
+          // busy hero image; soft white outline matches the chip row
+          // above. `flex-nowrap` keeps all six stacked pairs on a single
+          // row; `overflow-x-auto` on very narrow viewports lets the bar
+          // scroll horizontally instead of breaking the layout.
+          "inline-flex flex-nowrap items-end justify-center gap-x-8 md:gap-x-12 " +
+          "px-5 md:px-8 py-3 rounded-2xl border border-white/10 " +
+          "bg-black/40 backdrop-blur-md max-w-full overflow-x-auto"
+        }
+      >
+        {ITEMS.map((item) => {
+          const value = stats[item.key];
+          return (
+            <div
+              key={item.key}
+              className="flex flex-col items-center leading-none whitespace-nowrap"
+            >
+              <span className="text-white text-base md:text-lg font-semibold tabular-nums">
+                {item.compact ? fmtCompact(value) : fmt(value)}
+              </span>
+              <span className="mt-1.5 font-mono italic text-[10px] md:text-xs uppercase tracking-wider text-light-300">
+                {item.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+HeroStatsLine.displayName = "HeroStatsLine";
+export default HeroStatsLine;

--- a/frontend/components/landing/SearchWrapper.tsx
+++ b/frontend/components/landing/SearchWrapper.tsx
@@ -1,20 +1,50 @@
 "use client";
 
-import { useContext, useEffect } from "react";
+import { useContext, useEffect, useRef } from "react";
 
 import { SearchContext } from "@/context/searchContext";
 
+// Reserves space for the SearchBar inside the hero's normal flow and
+// measures its own position so the portaled <SearchBar/> can align
+// itself via SearchContext.offsetTop. Removes the previous magic
+// pixel offsets — when the hero copy resizes (longer h1, smaller
+// breakpoint, etc.) the search overlay tracks automatically.
+//
+// Height covers: 3rem search input (h-12) + ~0.75rem mt-3 gap + ~2rem
+// TryChips row + ~0.5rem breathing room ≈ 6.5rem on desktop.
 const SearchWrapper = () => {
-  const { containerRef, setIsVisible, setIsFocused, setOffsetTop } =
-    useContext(SearchContext);
+  const ref = useRef<HTMLDivElement>(null);
+  const { setOffsetTop, setIsVisible, setIsFocused } = useContext(SearchContext);
 
   useEffect(() => {
-    setOffsetTop(540);
     setIsVisible(true);
     setIsFocused(false);
-  }, [setIsFocused, setIsVisible, setOffsetTop]);
+  }, [setIsVisible, setIsFocused]);
 
-  return <></>;
+  useEffect(() => {
+    const measure = () => {
+      if (!ref.current) return;
+      const rect = ref.current.getBoundingClientRect();
+      setOffsetTop(Math.round(rect.top + window.scrollY));
+    };
+    measure();
+    // Re-measure on resize + after fonts settle so the overlay tracks
+    // any reflow of the hero copy above the spacer.
+    window.addEventListener("resize", measure);
+    const raf = requestAnimationFrame(measure);
+    return () => {
+      window.removeEventListener("resize", measure);
+      cancelAnimationFrame(raf);
+    };
+  }, [setOffsetTop]);
+
+  return (
+    <div
+      ref={ref}
+      aria-hidden
+      className="w-full max-w-2xl h-[6.5rem] md:h-[7rem]"
+    />
+  );
 };
 
 SearchWrapper.displayName = "SearchWrapper";

--- a/frontend/components/landing/useLandingStats.ts
+++ b/frontend/components/landing/useLandingStats.ts
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+// apiBase is not exported from fetching.ts — use env directly.
+
+export interface LandingStats {
+  foods: number;
+  chemicals: number;
+  diseases: number;
+  bioactivities: number;
+  associations: number;
+  publications: number;
+}
+
+const EMPTY: LandingStats = {
+  foods: 0,
+  chemicals: 0,
+  diseases: 0,
+  bioactivities: 0,
+  associations: 0,
+  publications: 0,
+};
+
+// Shared client-side stats fetch for the landing variants. Returns
+// zeros on any error so the page still renders cleanly (per the
+// graceful-failure rule in memory).
+export const useLandingStats = (): LandingStats => {
+  const [stats, setStats] = useState<LandingStats>(EMPTY);
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/metadata/statistics`, {
+          headers: {
+            Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY}`,
+          },
+        });
+        if (!res.ok) return;
+        const json = await res.json();
+        const s = json?.data?.statistics ?? {};
+        if (cancelled) return;
+        setStats({
+          foods: s.foods ?? 0,
+          chemicals: s.chemicals ?? 0,
+          diseases: s.diseases ?? 0,
+          bioactivities: s.bioactivities ?? 0,
+          associations: s.connections ?? 0,
+          publications: s.publications ?? 0,
+        });
+      } catch {
+        // Keep zeros.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+  return stats;
+};

--- a/frontend/components/navigation/Navbar.tsx
+++ b/frontend/components/navigation/Navbar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useContext } from "react";
 import { usePathname, useRouter } from "next/navigation";
-import { MdMenu } from "react-icons/md";
+import { MdMenu, MdSearch } from "react-icons/md";
 import { twMerge } from "tailwind-merge";
 
 import NavbarLink from "@/components/navigation/NavbarLink";
@@ -11,6 +11,7 @@ import FoodAtlasIcon from "@/components/icons/FoodAltasIcon";
 import { SearchContext } from "@/context/searchContext";
 
 const NAV_ITEMS = [
+  { text: "Explore", href: "/" },
   { text: "Background", href: "/technical-background" },
   { text: "API", href: "/developers" },
   { text: "Downloads", href: "/food-composition-downloads" },
@@ -24,7 +25,7 @@ interface NavbarProps {
 
 const Navbar = ({ className }: NavbarProps) => {
   const [isNavMenuOpen, setIsNavMenuOpen] = useState(false);
-  const { isFocused, setIsFocused, inputRef, isVisible, setIsVisible } =
+  const { setIsFocused, inputRef, setIsVisible, setOffsetTop } =
     useContext(SearchContext);
   const [isScrolled, setIsScrolled] = useState(false);
   const router = useRouter();
@@ -34,79 +35,48 @@ const Navbar = ({ className }: NavbarProps) => {
     const handleScroll = () => {
       setIsScrolled(window.scrollY > 0);
     };
-
     window.addEventListener("scroll", handleScroll);
     return () => window.removeEventListener("scroll", handleScroll);
   }, []);
 
   const handleNavButtonClick = () => setIsNavMenuOpen(!isNavMenuOpen);
 
-  const handleSearchButtonClick = (
-    event: React.MouseEvent<HTMLButtonElement>
-  ) => {
-    if (pathname === "/") {
-      event.stopPropagation();
-      event.preventDefault();
-
-      if (isFocused) {
-        // @ts-ignore
-        inputRef.current.blur();
-        // setIsFocused((prev) => {
-        //   inputRef.current.blur();
-        //   return !prev;
-        // });
-      } else {
-        // @ts-ignore
-        inputRef.current.focus();
-      }
-      // inputRef.current.focus();
-      // setIsVisible(!isVisible);
-      setIsFocused(!isFocused);
-    } else {
-      // @ts-ignore
-      setIsVisible((prev) => !prev);
-      setIsFocused(true);
+  // Opens the global search overlay no matter what route we're on:
+  // - On a hosting route (`/` or `/results`) the bar is already
+  //   mounted at a layout-anchored position — we just focus it.
+  // - On an entity page the bar is mounted but invisible; we
+  //   re-anchor it just below the navbar and fade it back in.
+  const handleSearchButtonClick = () => {
+    const hostsSearch = pathname === "/" || pathname.startsWith("/results");
+    if (!hostsSearch) {
+      setOffsetTop(64);
     }
-
-    // if (isFocused) {
-    //   setIsFocused(false);
-    //   setIsVisible(false);
-    // } else {
-    //   setIsVisible(true);
-    //   setIsFocused(true);
-    // }
-
-    // setIsFocused((prev) => {
-    //   // setIsVisible(!isVisible);
-    //   setIsVisible(true);
-    //   return !prev;
-    // });
+    setIsVisible(true);
+    setIsFocused(true);
+    setIsNavMenuOpen(false);
+    // Wait one paint so the fade-in / re-anchor has taken effect.
+    requestAnimationFrame(() => inputRef.current?.focus());
   };
-
-  useEffect(() => {
-    if (isFocused && inputRef.current) {
-    }
-  }, [isFocused, inputRef]);
 
   return (
     <div
       className={twMerge(
         "fixed top-0 w-[100vw] bg-[#0a0a09]/30 backdrop-blur-2xl saturate-200 z-40 px-3 md:px-12",
         isScrolled ? "border-b border-light-800" : "",
-        className
+        className,
       )}
     >
       <div className="max-w-6xl mx-auto">
-        <div className="py-1.5 w-full h-11 sm:h-12 md:h-14 mx-auto flex justify-between items-center">
+        <div className="py-1.5 w-full h-11 sm:h-12 md:h-14 mx-auto flex justify-between items-center gap-3">
           <Button
             className="relative flex-shrink-0 cursor-pointer min-h-9 min-w-9 p-1 m-0"
             isIconOnly
             onClick={() => router.push("/")}
             aria-label="FoodAtlas home"
           >
-            <FoodAtlasIcon height={30} width={""} color={"#FFFBF7"} />
+            <FoodAtlasIcon height={30} width={120} color={"#FFFBF7"} />
           </Button>
-          <div className="hidden md:flex md:gap-8 lg:gap-20">
+          <div className="hidden md:flex md:gap-8 lg:gap-14">
             {NAV_ITEMS.map((navItem) => (
               <NavbarLink
                 key={navItem.href}
@@ -116,10 +86,20 @@ const Navbar = ({ className }: NavbarProps) => {
               />
             ))}
           </div>
-          {/* search & menu button container */}
-          <div className="md:hidden flex items-center">
-            {/* menu button */}
-            <div className="">
+          <div className="flex items-center gap-1">
+            {/* Search button — always visible, opens the global
+             * overlay (re-anchored under the navbar on entity pages).
+             */}
+            <Button
+              className="min-h-9 min-w-9"
+              isIconOnly
+              onClick={handleSearchButtonClick}
+              aria-label="Open search"
+            >
+              <MdSearch className="w-5 h-5" />
+            </Button>
+            {/* Mobile menu */}
+            <div className="md:hidden">
               <Button
                 className="min-h-9 min-w-9"
                 onClick={handleNavButtonClick}

--- a/frontend/components/search/SearchBar.tsx
+++ b/frontend/components/search/SearchBar.tsx
@@ -6,20 +6,22 @@ import { ThreeDot } from "react-loading-indicators";
 import { MdClose, MdSearch } from "react-icons/md";
 
 import Button from "@/components/basic/Button";
-import SearchInfo from "@/components/search/SearchInfo";
 import SearchSuggestions from "@/components/search/SearchSuggestions";
+import TryChips from "@/components/search/TryChips";
 import { AutocompleteContext } from "@/context/autocompleteContext";
 import { SearchContext } from "@/context/searchContext";
 import useSearchAutocompleteOptions from "@/hooks/useSearchAutocompleteOptions";
 import { usePaginations } from "@/context/paginationsContext";
 import { encodeSpace } from "@/utils/utils";
 
-const placeholderTexts = ["Tomato", "Sodium", "Alzheimer"];
+// Static placeholder — replaces the previous typewriter-cycler effect.
+// Curated examples now live in the `<TryChips>` row below the input.
+const SEARCH_PLACEHOLDER =
+  "Search bioactivities, foods, chemicals, diseases…";
 
 const SearchBar = () => {
   const router = useRouter();
   const pathname = usePathname();
-  const [activeElement, setActiveElement] = useState<Element | null>(null);
   const { setAutocompleteTerm } = useContext(AutocompleteContext);
   const {
     inputRef,
@@ -59,52 +61,54 @@ const SearchBar = () => {
     setAutocompleteTerm(searchTerm);
   }, [searchTerm, setAutocompleteTerm]);
 
-  // The search bar is opt-in: only the landing page and /results host it. On
-  // every route change, hide it unless we land on one of those routes. Without
-  // this, browser back/forward leaves a stale `isVisible=true` from a prior
-  // landing/results mount and the search bar overlays entity pages.
+  // Route-change cleanup. Runs ONLY when pathname changes (no
+  // `isVisible` dep) — otherwise the effect would also fire when the
+  // navbar search button flips isVisible true on an entity page, and
+  // the !hostsSearch branch would immediately undo it.
+  // - Hosting route arrival (`/`, `/results`): reset focus/selection
+  //   so the bar lands in its compact unfocused state.
+  // - Entity page arrival: fade the bar out (it stayed mounted from
+  //   the previous page), leave focus state untouched so the fade
+  //   doesn't visually morph mid-transition.
+  // Also: clear the search term on every route change EXCEPT
+  // `/results` (which needs to keep the term to render the result
+  // list). Otherwise a stale term persists across navigations.
   useEffect(() => {
     const hostsSearch = pathname === "/" || pathname.startsWith("/results");
-    if (!hostsSearch && isVisible) {
-      setIsVisible(false);
-      setIsFocused(false);
+    if (!pathname.startsWith("/results")) {
+      setSearchTerm("");
     }
-  }, [pathname, isVisible, setIsVisible, setIsFocused]);
+    if (hostsSearch) {
+      setIsFocused(false);
+      setSelectedSuggestion(-1);
+    } else {
+      setIsVisible(false);
+    }
+  }, [
+    pathname,
+    setIsVisible,
+    setIsFocused,
+    setSelectedSuggestion,
+    setSearchTerm,
+  ]);
 
+  // On entity pages the bar is an overlay with no anchor section — if
+  // the user blurs out of it (Esc, click outside) the bar should
+  // dismiss entirely instead of sitting around dim and inactive.
+  // Hosting routes (`/`, `/results`) keep the bar permanently mounted.
   useEffect(() => {
-    if (isFocused) return;
+    const hostsSearch = pathname === "/" || pathname.startsWith("/results");
+    if (!hostsSearch && !isFocused && isVisible) {
+      setIsVisible(false);
+    }
+  }, [pathname, isFocused, isVisible, setIsVisible]);
 
-    let currentTextIndex = 0;
-    let isDeleting = false;
-    let placeholderText = "";
-    let charIndex = 0;
-
-    const updatePlaceholder = () => {
-      const currentPlaceholder = placeholderTexts[currentTextIndex];
-
-      if (isDeleting) {
-        if (charIndex > 0) {
-          placeholderText = currentPlaceholder.slice(0, charIndex - 1);
-          charIndex--;
-        } else {
-          isDeleting = false;
-          currentTextIndex = (currentTextIndex + 1) % placeholderTexts.length;
-        }
-      } else {
-        if (charIndex < currentPlaceholder.length) {
-          placeholderText = currentPlaceholder.slice(0, charIndex + 1);
-          charIndex++;
-        } else {
-          isDeleting = true;
-        }
-      }
-
-      setPlaceholder(placeholderText);
-    };
-
-    const interval = setInterval(updatePlaceholder, 200);
-    return () => clearInterval(interval);
-  }, [isFocused, setPlaceholder]);
+  // Set the static placeholder once. The SearchContext still owns the
+  // value so the input can read it through the same prop as before;
+  // removing the typewriter loop just leaves a single useEffect.
+  useEffect(() => {
+    setPlaceholder(SEARCH_PLACEHOLDER);
+  }, [setPlaceholder]);
 
   // @ts-ignore
   const handleInputChange = (event) => {
@@ -116,6 +120,16 @@ const SearchBar = () => {
 
   const handleSearchButtonClick = () => {
     setTablePaginations("results-page", 1, 20);
+    // The Search button carries id="foodatlas-search" so handleBlur
+    // intentionally SKIPS tearing down focus when the user clicks it
+    // (otherwise the dropdown would unmount mid-click and the
+    // navigation would never fire). That same suppression means we
+    // have to clean up focus state ourselves here — without this,
+    // clicking Search a second time on /results does nothing because
+    // pathname is unchanged and the route-change effect doesn't fire.
+    setIsFocused(false);
+    setSelectedSuggestion(-1);
+    inputRef.current?.blur();
     router.push(`/results?term=${searchTerm}`);
   };
 
@@ -151,52 +165,64 @@ const SearchBar = () => {
         prevIndex > 0 ? prevIndex - 1 : prevIndex
       );
     } else if (event.key === "Escape") {
-      // @ts-ignore
-      handleBlur();
+      // Was: `handleBlur()` directly, which threw because handleBlur
+      // dereferences `e.relatedTarget`. Calling .blur() on the input
+      // dispatches a real blur event (with relatedTarget=null), which
+      // falls through to handleBlur's close branch and dismisses the
+      // suggestion dropdown / unfocuses the bar.
+      inputRef.current?.blur();
     }
   };
 
   const handleFocus = () => {
+    // Track focus directly off the input's onFocus event. The previous
+    // approach polled `document.activeElement` through a useEffect with
+    // a non-reactive dependency, which only re-synced on unrelated
+    // re-renders — so after a programmatic blur (Esc, X) clicking the
+    // input back wouldn't re-flip `isFocused` until the user typed.
     setSelectedSuggestion(-1);
+    setIsFocused(true);
   };
 
   const handleBlur = (e: React.MouseEvent<HTMLDivElement>) => {
     // @ts-ignore
     if (e.relatedTarget?.id !== "foodatlas-search") {
       setSelectedSuggestion(-1);
-      // @ts-ignore
-      setActiveElement(null);
-      setTablePaginations("results-page", 1, 20);
+      // Do NOT call setTablePaginations("results-page") here — that
+      // update cascades through PaginationsContext and causes every
+      // usePaginations() consumer (BioactivityTable etc.) to re-render,
+      // which re-triggers their data-fetch useEffect and shows a
+      // loading skeleton. Resetting results-page pagination only needs
+      // to happen when actually navigating to /results (handled in
+      // handleSearchButtonClick and the Enter branch).
       setIsFocused(false);
     }
   };
 
-  // TODO: can this be moved to onfocus?
-  useEffect(() => {
-    if (activeElement === inputRef.current) {
-      setIsFocused(true);
-    } else {
-      setIsFocused(false);
-    }
-  }, [setIsFocused, inputRef, activeElement]);
-
-  useEffect(() => {
-    setActiveElement(document.activeElement);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [document.activeElement]);
-
   const isResultsPage = pathname.startsWith("/results");
 
+  // Keep the bar mounted across route transitions and fade it via
+  // opacity instead — without this, navigating from / to an entity
+  // page unmounts the bar instantly while the destination is still
+  // loading, so the user sees a bar-less landing for a few hundred
+  // milliseconds. `pointer-events-none` while hidden so the invisible
+  // markup doesn't intercept clicks behind it on entity pages.
   return (
-    isVisible && (
-      <div role="search" aria-label="Site search">
-        <div
-          className={`z-10 w-full absolute ] px-3md:px-12 ${
-            isFocused ? "absolute inset-0 top-24 -right-4" : ""
-          } ${isResultsPage ? "" : "duration-[250ms]"}`}
-          ref={containerRef}
-          style={{ top: offsetTop || 50 }}
-        >
+    <div
+      role="search"
+      aria-label="Site search"
+      className={`transition-opacity duration-300 ${
+        isVisible ? "opacity-100" : "opacity-0 pointer-events-none"
+      }`}
+      aria-hidden={!isVisible}
+    >
+      <div
+        className={`z-50 w-full absolute px-3md:px-12 ${
+          isFocused ? "absolute inset-0 top-24 -right-4" : ""
+        } ${isResultsPage ? "" : "duration-[250ms]"}`}
+        ref={containerRef}
+        style={{ top: offsetTop || 50 }}
+      >
           <div className="px-3 md:px-12">
             <div className="mx-auto max-w-6xl" id="search-component">
               {/* search input */}
@@ -223,12 +249,26 @@ const SearchBar = () => {
                 <div className="absolute right-3 flex items-center gap-3">
                   {/* search input clear */}
                   {searchTerm && (
-                    <div
-                      className="z-50 cursor-pointer"
-                      onClick={handleSearchBarClear}
+                    <button
+                      type="button"
+                      aria-label="Clear search"
+                      className="z-50 cursor-pointer focus:outline-none"
+                      // Stop mousedown so the input doesn't blur
+                      // BEFORE the click reaches us — without this the
+                      // bar collapses mid-click and the X handler
+                      // misses. Then in the click: clear the term and
+                      // explicitly blur the input so the bar
+                      // deactivates after — clicking X means "I'm done
+                      // with this query", not "focus the empty input".
+                      onMouseDown={(e) => e.preventDefault()}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleSearchBarClear();
+                        inputRef.current?.blur();
+                      }}
                     >
                       <MdClose className="w-6 h-6 text-light-400 hover:text-light-300 transition duration-300 ease-in-out" />
-                    </div>
+                    </button>
                   )}
                   {/* search button */}
                   {isFocused && (
@@ -264,29 +304,28 @@ const SearchBar = () => {
                   onKeyDown={handleKeyDown}
                 />
               </div>
-              {/* search info  */}
-              {!isFocused && (
-                <div className="mt-3">
-                  <SearchInfo />
-                </div>
-              )}
-              {/* search suggestions */}
+              {/* Try-out chips — always visible so the entry-points
+               * are discoverable even mid-session. */}
+              <div className="mt-3">
+                <TryChips />
+              </div>
+              {/* Suggestions appear below the chips when focused,
+               * with a small gap so the two rows feel distinct. */}
               {isFocused && (
-                <div>
+                <div className="mt-3">
                   <SearchSuggestions />
                 </div>
               )}
             </div>
           </div>
         </div>
-        <div
-          className={`absolute inset-0 h-screen transition-all duration-300 backdrop-blur-md bg-black/30 saturate-150 pointer-events-none ${
-            isFocused ? "opacity-100" : "opacity-0"
-          }`}
-          aria-hidden="true"
-        />
-      </div>
-    )
+      <div
+        className={`fixed inset-0 z-30 transition-all duration-300 backdrop-blur-md bg-black/30 saturate-150 pointer-events-none ${
+          isFocused ? "opacity-100" : "opacity-0"
+        }`}
+        aria-hidden="true"
+      />
+    </div>
   );
 };
 

--- a/frontend/components/search/SearchSuggestions.tsx
+++ b/frontend/components/search/SearchSuggestions.tsx
@@ -32,7 +32,10 @@ const SearchSuggestions = () => {
   return (
     <div className="w-full rounded z-50 foodatlas-search">
       {cachedSuggestions?.length > 0 && autocompleteTerm.length > 0 && (
-        <div className="flex flex-col max-h-[80vh] overflow-y-auto border-[1.5px] border-t-0 bg-light-950/50 border-light-600 rounded-t-none rounded-lg backdrop-blur-3xl">
+        <div
+          className="flex flex-col max-h-[65vh] overflow-y-auto rounded-xl border border-light-50/10 bg-light-950/80 backdrop-blur-xl shadow-xl shadow-black/40"
+          onMouseLeave={() => setSelectedSuggestion(-1)}
+        >
           {cachedSuggestions?.map((suggestion: Suggestion, index: number) => (
             <SuggestionItem
               key={index}

--- a/frontend/components/search/SuggestionItem.tsx
+++ b/frontend/components/search/SuggestionItem.tsx
@@ -1,20 +1,20 @@
 "use client";
 
-import { useContext } from "react";
 import { useRouter } from "next/navigation";
 
 import BioactivityIcon from "@/components/icons/BioactivityIcon";
 import ChemicalIcon from "@/components/icons/ChemicalIcon";
 import DiseaseIcon from "@/components/icons/DiseaseIcon";
 import FoodIcon from "@/components/icons/FoodIcon";
-import { SearchContext } from "@/context/searchContext";
 import { Suggestion } from "@/types/Suggestion";
 import { encodeSpace } from "@/utils/utils";
 
-const icon = {
-  food: <FoodIcon color="#d97706" />,
-  chemical: <ChemicalIcon color="#0891b2" />,
-  disease: <DiseaseIcon color="#9333ea" />,
+// Same icon colours as HeaderSection so the type marker in the search
+// dropdown reads as the same visual language as the entity page.
+const entityIcon: Record<string, React.ReactNode> = {
+  food:        <FoodIcon color="#d97706" />,
+  chemical:    <ChemicalIcon color="#0891b2" />,
+  disease:     <DiseaseIcon color="#a855f7" />,
   bioactivity: <BioactivityIcon color="#10b981" />,
 };
 
@@ -30,10 +30,12 @@ const SuggestionItem = ({
   onMouseMove,
 }: SuggestionItemProps) => {
   const router = useRouter();
-  const { setIsVisible } = useContext(SearchContext);
+  const icon = entityIcon[suggestion.entity_type] ?? null;
 
   const navigate = () => {
-    setIsVisible(false);
+    // Let SearchBar's route-change effect handle isVisible teardown —
+    // doing it here fires before navigation and causes the bar to
+    // morph back to its compact position mid-fade.
     router.push(
       `/${suggestion.entity_type}/${encodeURIComponent(
         encodeSpace(suggestion.common_name)
@@ -56,65 +58,52 @@ const SuggestionItem = ({
   };
 
   const hasCommonName = !!suggestion.common_name?.trim();
-  // The API currently returns an empty string when the scientific name
-  // isn't populated upstream (the KGC pipeline doesn't carry one for most
-  // rows on the current staging build). Treat "" the same as null so the
-  // column header doesn't render with no value beside it.
   const hasScientificName = !!suggestion.scientific_name?.trim();
-
-  const label = [
-    hasCommonName ? suggestion.common_name : null,
-    hasScientificName ? suggestion.scientific_name : null,
-  ]
-    .filter(Boolean)
-    .join(" — ");
 
   return (
     <div
       id="foodatlas-search"
-      className={`flex gap-6 px-5 py-5 cursor-pointer border-b-light-50/20 border-b ${
-        isSelected && "bg-light-50/15 border-light-50/15"
-      }`}
       role="button"
       tabIndex={0}
-      aria-label={`Open ${suggestion.entity_type} ${label}`}
+      aria-label={`Open ${suggestion.entity_type} ${suggestion.common_name}`}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       onMouseMove={onMouseMove}
+      className={`flex items-center gap-3 px-4 py-2.5 cursor-pointer border-b border-light-50/[0.06] transition-colors ${
+        isSelected ? "bg-light-50/10" : "hover:bg-light-50/5"
+      }`}
     >
-      {/* left */}
-      <div className="mt-1 w-8 flex justify-center">
-        {/* @ts-ignore */}
-        <div className="text-3xl">{icon[suggestion.entity_type]}</div>
-      </div>
-      {/* middle */}
-      <div className="w-full">
-        <div>
-          {(hasCommonName || hasScientificName) && (
-            <p className="text-xs text-light-400 font-mono italic">
-              {hasCommonName && "Common Name"}
-              {hasCommonName && hasScientificName && (
-                <span className="not-italic">｜</span>
-              )}
-              {hasScientificName && "Scientific Name"}
-            </p>
-          )}
-          <p className="capitalize break-all">
-            {hasCommonName && <span>{suggestion.common_name}</span>}
-            {hasCommonName && hasScientificName && "｜"}
-            {hasScientificName && <span>{suggestion.scientific_name}</span>}
+      {/* Entity icon — left, consistent size */}
+      {icon && <span className="text-xl flex-shrink-0">{icon}</span>}
+
+      {/* Name block */}
+      <div className="min-w-0 flex-1">
+        {hasCommonName && (
+          <p className="text-sm text-light-100 capitalize leading-tight truncate">
+            {suggestion.common_name}
           </p>
+        )}
+        {hasScientificName && (
+          <p className="text-xs text-light-500 italic font-mono leading-tight truncate mt-0.5">
+            {suggestion.scientific_name}
+          </p>
+        )}
+      </div>
+
+      {/* Right: associations count stacked with label */}
+      {suggestion.associations != null && (
+        <div className="flex flex-col items-end leading-none flex-shrink-0">
+          <span className="font-mono text-xs text-light-100 tabular-nums">
+            {Number(suggestion.associations).toLocaleString()}
+          </span>
+          <span className="font-mono italic text-[9px] text-light-500 mt-0.5">
+            associations
+          </span>
         </div>
-      </div>
-      {/* right */}
-      <div className="w-20  flex flex-col text-center">
-        <span className="text-xs text-light-400">Associations</span>
-        <span className="">{suggestion.associations}</span>
-      </div>
+      )}
     </div>
   );
 };
 
 SuggestionItem.displayName = "SuggestionItem";
-
 export default SuggestionItem;

--- a/frontend/components/search/TryChips.tsx
+++ b/frontend/components/search/TryChips.tsx
@@ -1,0 +1,88 @@
+"use client";
+
+// Static example chips below the search bar — replaces the previous
+// rolling cursor placeholder + the SearchInfo helper text. One chip
+// per entity type, each routes to the entity page on click. Curated
+// (not data-driven) so the landing always shows the same examples and
+// doesn't churn.
+
+import { useRouter } from "next/navigation";
+import { useContext } from "react";
+import { twMerge } from "tailwind-merge";
+
+import BioactivityIcon from "@/components/icons/BioactivityIcon";
+import ChemicalIcon from "@/components/icons/ChemicalIcon";
+import DiseaseIcon from "@/components/icons/DiseaseIcon";
+import FoodIcon from "@/components/icons/FoodIcon";
+import { SearchContext } from "@/context/searchContext";
+import { encodeSpace } from "@/utils/utils";
+
+type EntityType = "food" | "chemical" | "bioactivity" | "disease";
+
+const EXAMPLES: {
+  type: EntityType;
+  label: string;
+  slug: string;
+  icon: React.ReactNode;
+}[] = [
+  {
+    type: "bioactivity",
+    label: "Antioxidant",
+    slug: "antioxidant",
+    icon: <BioactivityIcon color="#10b981" />,
+  },
+  {
+    type: "food",
+    label: "Strawberry",
+    slug: "strawberry",
+    icon: <FoodIcon color="#d97706" />,
+  },
+  {
+    type: "chemical",
+    label: "Quercetin",
+    slug: "quercetin",
+    icon: <ChemicalIcon color="#0891b2" />,
+  },
+  {
+    type: "disease",
+    label: "Diabetes mellitus",
+    slug: "diabetes mellitus",
+    icon: <DiseaseIcon color="#9333ea" />,
+  },
+];
+
+const TryChips = () => {
+  const router = useRouter();
+  const { setIsVisible } = useContext(SearchContext);
+
+  const go = (type: EntityType, slug: string) => {
+    setIsVisible(false);
+    router.push(`/${type}/${encodeURIComponent(encodeSpace(slug))}`);
+  };
+
+  return (
+    <div className="flex flex-wrap items-center justify-center gap-2 select-none">
+      <span className="font-mono italic text-xs uppercase tracking-wider text-light-200 mr-1">
+        Try out
+      </span>
+      {EXAMPLES.map((ex) => (
+        <button
+          key={ex.type}
+          type="button"
+          onClick={() => go(ex.type, ex.slug)}
+          className={twMerge(
+            "inline-flex items-center gap-1.5 pl-1.5 pr-2.5 py-1 rounded-full border border-white/10",
+            "bg-black/40 backdrop-blur-md text-light-100 text-xs font-mono transition-colors",
+            "hover:bg-black/60 hover:border-white/25 hover:text-white",
+          )}
+        >
+          <span className="text-sm">{ex.icon}</span>
+          {ex.label}
+        </button>
+      ))}
+    </div>
+  );
+};
+
+TryChips.displayName = "TryChips";
+export default TryChips;

--- a/frontend/hooks/useSearchAutocompleteOptions.tsx
+++ b/frontend/hooks/useSearchAutocompleteOptions.tsx
@@ -29,7 +29,8 @@ const useSearchAutocompleteOptions = () => {
     "term=" +
     encodeURIComponent(autocompleteTerm) +
     "&page=" +
-    currentPage;
+    currentPage +
+    "&rows_per_page=20";
 
   const { data, error, isLoading } = useSWR(
     autocompleteTerm.length > 0 ? url : null,

--- a/frontend/styles/globals.css
+++ b/frontend/styles/globals.css
@@ -17,6 +17,15 @@ html {
   overflow-y: scroll !important;
 }
 
+/* Toggled by Modal.tsx to lock page scroll while a dialog is open.
+ * Higher specificity than `html` so it wins regardless of the
+ * !important on the base rule. `scrollbar-gutter: stable` on <html>
+ * keeps layout from shifting when the scrollbar disappears. */
+html.modal-open,
+html.modal-open body {
+  overflow: hidden !important;
+}
+
 @keyframes fadeSlide {
   from {
     opacity: 0;

--- a/infra/aws/scripts/exec-api-shell.sh
+++ b/infra/aws/scripts/exec-api-shell.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+# Open a shell inside a running API container via ECS exec (SSM Session
+# Manager under the hood) — no SSH bastion, no RDS port-forward setup.
+# The container already has DB credentials in env (DB_HOST/DB_USER/
+# DB_PASSWORD/DB_NAME) and VPC reach to the RDS, so once you're in:
+#
+#   $ python -c 'from sqlalchemy import create_engine, text; from src.config import Settings; s=Settings(); e=create_engine(s.db_url); c=e.connect(); c.execute(text("SELECT 1")); c.commit()'
+#
+# …becomes the canonical way to run ad-hoc SQL against the live RDS.
+#
+# Usage:
+#   ./exec-api-shell.sh                       # staging by default
+#   ./exec-api-shell.sh prod                  # explicit prod target
+#   STACK=FoodAtlasApiStack ./exec-api-shell.sh
+#
+# Prereqs: aws sso login --profile <profile>; AWS Session Manager
+# plugin installed locally (https://docs.aws.amazon.com/systems-manager/
+# latest/userguide/session-manager-working-with-install-plugin.html).
+
+set -euo pipefail
+
+ENV_ARG="${1:-staging}"
+case "$ENV_ARG" in
+    staging) STACK="${STACK:-FoodAtlasApiStack-Staging}";;
+    prod | production) STACK="${STACK:-FoodAtlasApiStack}";;
+    *)
+        echo "Usage: $0 [staging|prod]" >&2
+        exit 1
+        ;;
+esac
+
+REGION="${AWS_REGION:-us-west-1}"
+
+# Resolve cluster + service from the stack's ApiService construct.
+CLUSTER=$(aws cloudformation describe-stack-resources \
+    --stack-name "$STACK" \
+    --region "$REGION" \
+    --query "StackResources[?LogicalResourceId=='ApiCluster'].PhysicalResourceId" \
+    --output text)
+SERVICE=$(aws cloudformation describe-stack-resources \
+    --stack-name "$STACK" \
+    --region "$REGION" \
+    --query "StackResources[?starts_with(LogicalResourceId, 'ApiService') && ResourceType=='AWS::ECS::Service'].PhysicalResourceId" \
+    --output text)
+
+if [[ -z "$CLUSTER" || -z "$SERVICE" ]]; then
+    echo "Couldn't resolve cluster/service from $STACK. Is the stack deployed?" >&2
+    exit 1
+fi
+
+# Pick the first running task — for ad-hoc ops it doesn't matter which.
+TASK_ARN=$(aws ecs list-tasks \
+    --cluster "$CLUSTER" \
+    --service-name "$SERVICE" \
+    --desired-status RUNNING \
+    --region "$REGION" \
+    --query "taskArns[0]" \
+    --output text)
+
+if [[ -z "$TASK_ARN" || "$TASK_ARN" == "None" ]]; then
+    echo "No running tasks in $SERVICE." >&2
+    exit 1
+fi
+
+# Container name in the ApplicationLoadBalancedFargateService pattern
+# is "web" by default. Override via CONTAINER env if your task is different.
+CONTAINER_NAME="${CONTAINER:-web}"
+
+echo "stack:     $STACK"
+echo "cluster:   $CLUSTER"
+echo "service:   $SERVICE"
+echo "task:      $TASK_ARN"
+echo "container: $CONTAINER_NAME"
+echo
+
+exec aws ecs execute-command \
+    --cluster "$CLUSTER" \
+    --task "$TASK_ARN" \
+    --container "$CONTAINER_NAME" \
+    --command "/bin/bash" \
+    --interactive \
+    --region "$REGION"


### PR DESCRIPTION
## Summary

Bundles the frontend work recovered during the layout-edits session that never made it off my machine — 19 files, 1023 insertions / 341 deletions. Rebased onto current \`dev\` so it composes with #229 and #230.

Everything user-visible you see going "old" on staging that's not the composition filter block from #230 lives in this PR.

## Highlights

**Search**
- \`SearchBar\` overhaul: static placeholder (typewriter cycler removed), \`TryChips\` row surfacing curated example queries, focus/blur/escape wiring reworked so the bar dismisses correctly on entity pages and keeps state on hosting routes.
- \`SuggestionItem\` rebuilt with a per-entity-type icon map (bioactivity icon added).
- \`TryChips\` (new): curated food/chemical/disease/bioactivity chips below the search input.

**Nav + landing**
- \`Navbar\` bug fixes surfaced during recovery (SVG \`width\` prop, search overlay teardown).
- \`HeroStatsLine\` (new) + \`useLandingStats\` (new) drive landing counts without a page-level fetch.

**Entity pages**
- \`EntityTabs\`: multi-click bug fix (URL derivation + local state so \`router.replace\` doesn't cause visual revert).
- Restored inferred-bioactivities section on food and chemical pages.
- \`Synonyms\`: duplicate-key fix (\`\${name}-\${i}\`).

**Bioactivity**
- \`BioactivityMeasurementsModal\` layout + source badge tweaks.
- \`Bioactivity\` type carries the extra measurement fields the modal reads.

**Infra**
- \`next.config.mjs\`: restore the \`/_proxy-api\` rewrite (its absence was silently 404-ing staging API calls).
- \`infra/aws/scripts/exec-api-shell.sh\` (new): open a shell in a running API container via ECS Exec — no SSH bastion, no RDS port forward. Handy for ad-hoc SQL against staging/prod RDS.

**About page**
- Lukas → "Fullstack Engineer"; Kaichi → "Graduate Student Researcher" in the research section.

## Test plan

- [x] \`npm run lint\` (next lint + tsc --noEmit): clean apart from a pre-existing warning in \`ConcentrationCompositionPlot\`.
- [x] \`npm test\`: 25/25 pass.
- [ ] Once merged, staging Vercel picks up the branch — verify the recovered search bar, TryChips row, tab click behaviour, and inferred bioactivities show up on real entity pages.

## Notes on branching

This is off \`origin/dev\` (not off \`layout-edits\`) — the local \`layout-edits\` branch had a lot of stale committed history that would have reverted work already merged via #219-228 and #230. What's in this PR is the recovered file state, applied cleanly on top of current \`dev\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)