### PR TITLE
fix(db): stop counting bioactivity measurements as associations

### DIFF
--- a/backend/db/src/etl/materializer_search.py
+++ b/backend/db/src/etl/materializer_search.py
@@ -263,14 +263,13 @@ def _materialize_statistics(conn: Connection) -> None:
         or 0
     )
 
-    # Associations = every empirical evidence row in the graph: the four
-    # entity-pair relationships (food↔chem, chem↔disease, food/chem↔
-    # bioactivity), the IS_A ontology edges, AND every individual
-    # bioactivity measurement (each assay-level data point is an
-    # association between a chemical/food and the bioactivity).
-    associations = (
-        len(r1) + len(scoped_r3r4) + assoc_r2 + len(r5) + len(r6) + measurement_count
-    )
+    # Associations = distinct entity-pair relationships in the graph:
+    # r1 (food↔chem), scoped r3/r4 (chem↔disease), r2 IS_A ontology edges,
+    # r5 (food↔bioactivity), r6 (chemical↔bioactivity). Each row is one
+    # unique pair. Individual bioactivity measurements are evidence for
+    # r5/r6 edges — not associations themselves — and are reported
+    # separately as "number of bioactivity measurements".
+    associations = len(r1) + len(scoped_r3r4) + assoc_r2 + len(r5) + len(r6)
 
     rows = [
         {"field": "number of foods", "count": len(food_ids)},

--- a/backend/db/tests/test_materialize_statistics.py
+++ b/backend/db/tests/test_materialize_statistics.py
@@ -109,6 +109,65 @@ class TestMaterializeStatistics:
 
     @patch("src.etl.materializer_search.bulk_copy")
     @patch("src.etl.materializer_search.pd.read_sql", side_effect=_mock_read_sql)
+    def test_measurement_count_excluded_from_associations(
+        self, _mock_sql, mock_copy
+    ):
+        """measurement_count is evidence, not associations.
+
+        Regression test: an earlier version of the formula summed
+        ``measurement_count`` into ``associations``, inflating the
+        headline number by ~1.8M on staging. The bioactivity measurement
+        count must be surfaced only as its own stat.
+        """
+        conn = MagicMock()
+        # pmcid=0, ctd pmid=0, bioactivity measurement count=1_800_000
+        conn.execute.return_value.scalar.side_effect = [0, 0, 1_800_000]
+        _materialize_statistics(conn)
+
+        df = mock_copy.call_args[0][2]
+        stats = dict(zip(df["field"], df["count"], strict=True))
+        # Same 6 associations as test_association_count — the 1.8M
+        # measurements must NOT be added to the associations total.
+        assert stats["number of associations"] == 6
+        # But the measurement count is still exposed as its own stat.
+        assert stats["number of bioactivity measurements"] == 1_800_000
+
+    @patch("src.etl.materializer_search.bulk_copy")
+    @patch("src.etl.materializer_search.pd.read_sql", side_effect=_mock_read_sql)
+    def test_r5_r6_included_in_associations(self, _mock_sql, mock_copy):
+        """r5/r6 are entity-pair triplets and count as associations."""
+        extra = pd.DataFrame(
+            {
+                "head_id": ["f1", "c1"],
+                "tail_id": ["b1", "b1"],
+                "relationship_id": ["r5", "r6"],
+            }
+        )
+        patched = pd.concat([_TRIPLETS, extra], ignore_index=True)
+
+        def read_sql_with_bioact(query, _conn):
+            sql = str(query)
+            if "base_triplets" in sql:
+                return patched.copy()
+            if "base_entities" in sql:
+                return _ENTITIES.copy()
+            return pd.DataFrame()
+
+        with patch(
+            "src.etl.materializer_search.pd.read_sql",
+            side_effect=read_sql_with_bioact,
+        ):
+            conn = MagicMock()
+            conn.execute.return_value.scalar.return_value = 0
+            _materialize_statistics(conn)
+
+        df = mock_copy.call_args[0][2]
+        stats = dict(zip(df["field"], df["count"], strict=True))
+        # Baseline 6 + 1 r5 + 1 r6 = 8.
+        assert stats["number of associations"] == 8
+
+    @patch("src.etl.materializer_search.bulk_copy")
+    @patch("src.etl.materializer_search.pd.read_sql", side_effect=_mock_read_sql)
     def test_unscoped_r3r4_excluded(self, _mock_sql, mock_copy):
         """r3/r4 where head is NOT an r1 tail should not count."""
         # Add an unscoped r3/r4 triplet (c3 is not in r1 tails)

--- a/backend/db/tests/test_materialize_statistics.py
+++ b/backend/db/tests/test_materialize_statistics.py
@@ -109,9 +109,7 @@ class TestMaterializeStatistics:
 
     @patch("src.etl.materializer_search.bulk_copy")
     @patch("src.etl.materializer_search.pd.read_sql", side_effect=_mock_read_sql)
-    def test_measurement_count_excluded_from_associations(
-        self, _mock_sql, mock_copy
-    ):
+    def test_measurement_count_excluded_from_associations(self, _mock_sql, mock_copy):
         """measurement_count is evidence, not associations.
 
         Regression test: an earlier version of the formula summed


### PR DESCRIPTION
## Summary

The front-page **"associations"** stat was being inflated by ~1.8M on staging because `_materialize_statistics` summed `measurement_count` into the associations total. `measurement_count = COUNT(*) FROM base_attestations_bioactivity` is the raw assay-reading count — those rows are **evidence** supporting r5/r6 edges, not distinct associations. Each measurement is one experiment result on a specific bioassay, providing evidence for a (food/chemical) -exhibits/measured-> (bioactivity) association; the association itself is already counted once as an r5/r6 triplet row.

## Change

Associations now = `len(r1) + len(scoped_r3r4) + assoc_r2 + len(r5) + len(r6)`. Each term counts distinct entity-pair relationships:
- `r1` — food ↔ chemical (CONTAINS)
- `scoped_r3r4` — chemical ↔ disease (CTD), scoped to chemicals that appear in r1
- `assoc_r2` — IS_A ontology edges reachable from seed foods/chemicals/diseases
- `r5` — food EXHIBITS bioactivity (one row per pair)
- `r6` — chemical MEASURED bioactivity (one row per pair)

The `measurement_count` is still computed and surfaced as its own stat (`"number of bioactivity measurements"`), so the frontend tile that renders it is unaffected.

## Impact

Order of magnitude on currently-loaded staging data:
- **Before**: associations ≈ (empirical triplet sum) + 1,804,781 measurements — headline reads ~1.8M
- **After**: associations = empirical triplet sum only — headline should drop to the ~O(10k–100k) range that reflects distinct graph edges

## Test plan

- [x] `backend/db/tests/test_materialize_statistics.py` — added `test_measurement_count_excluded_from_associations` pinning the semantic (feeds a mocked 1.8M measurement count and asserts associations stays at 6)
- [x] Added `test_r5_r6_included_in_associations` documenting that r5/r6 triplets DO count as associations (they're entity-pair edges, not evidence)
- [x] Full `backend/db` suite: 266 passed, 81.83% coverage
- [x] `backend/api` `TestStatsRepo::test_maps_known_fields` still green — response shape unchanged
- [ ] After merge: run `cd backend/db && uv run python main.py load` against staging to reload `mv_metadata_statistics` and confirm the front page renders the corrected number

🤖 Generated with [Claude Code](https://claude.com/claude-code)