### PR TITLE
fix(landing): route stats fetch through /_proxy-api

### DIFF
--- a/frontend/components/landing/useLandingStats.ts
+++ b/frontend/components/landing/useLandingStats.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from "react";
 
-// apiBase is not exported from fetching.ts — use env directly.
+import { apiBase } from "@/utils/fetching";
 
 export interface LandingStats {
   foods: number;
@@ -31,7 +31,7 @@ export const useLandingStats = (): LandingStats => {
     let cancelled = false;
     (async () => {
       try {
-        const res = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/metadata/statistics`, {
+        const res = await fetch(`${apiBase()}/metadata/statistics`, {
           headers: {
             Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY}`,
           },


### PR DESCRIPTION
## Summary

`useLandingStats` was calling `process.env.NEXT_PUBLIC_API_URL` directly — the HTTP ALB. On `https://dev.foodatlas.ai` the browser blocks the request as mixed content, so every landing stat renders as 0.

Switch to `apiBase()`; on the client it returns \`\"/_proxy-api\"\` which the \`next.config.mjs\` rewrite forwards to the same ALB server-side, so the browser only ever sees same-origin HTTPS.

## Root cause

\`NumbersSection\` already used \`apiBase()\` correctly — this hook was the only landing consumer that hadn't been converted when the same-origin proxy was introduced. A stale comment even said \"apiBase is not exported from fetching.ts\" — it is (has been for a while).

## Test plan

- [x] Lint clean.
- [ ] After merge / cd-staging (backend rebuild not required; this is a frontend-only change), verify \`dev.foodatlas.ai\` no longer logs the Mixed Content warning and the tiles render real numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)