### PR TITLE
feat: document bioactivity /v1/ endpoints; hide Explore nav

### DIFF
--- a/frontend/app/(everything-else)/developers/page.tsx
+++ b/frontend/app/(everything-else)/developers/page.tsx
@@ -58,6 +58,36 @@ const ENDPOINTS: Array<{ method: string; path: string; summary: string }> = [
   },
   {
     method: "GET",
+    path: "/v1/bioactivities",
+    summary: "List bioactivities (paginated, filterable)",
+  },
+  {
+    method: "GET",
+    path: "/v1/bioactivities/{id}",
+    summary: "Get one bioactivity + parents/children hierarchy",
+  },
+  {
+    method: "GET",
+    path: "/v1/bioactivities/{id}/chemicals",
+    summary: "Chemicals measured for a bioactivity (r6)",
+  },
+  {
+    method: "GET",
+    path: "/v1/bioactivities/{id}/foods",
+    summary: "Foods that exhibit a bioactivity (r5)",
+  },
+  {
+    method: "GET",
+    path: "/v1/chemicals/{id}/bioactivities",
+    summary: "Bioactivities measured for a chemical",
+  },
+  {
+    method: "GET",
+    path: "/v1/foods/{id}/bioactivities",
+    summary: "Bioactivities exhibited by a food",
+  },
+  {
+    method: "GET",
     path: "/v1/triplets",
     summary: "Knowledge-graph edges (head, relationship, tail)",
   },

--- a/frontend/components/navigation/Navbar.tsx
+++ b/frontend/components/navigation/Navbar.tsx
@@ -11,7 +11,9 @@ import FoodAtlasIcon from "@/components/icons/FoodAltasIcon";
 import { SearchContext } from "@/context/searchContext";
 
 const NAV_ITEMS = [
-  { text: "Explore", href: "/" },
+  // "Explore" hidden 2026-07-02 (the "/" landing is still reachable
+  // via the logo click; nav slot removed while the landing is being
+  // reworked).
   { text: "Background", href: "/technical-background" },
   { text: "API", href: "/developers" },
   { text: "Downloads", href: "/food-composition-downloads" },


### PR DESCRIPTION
## Summary

Two small tweaks bundled together:

- **`/developers`** picks up the six /v1/bioactivities entries that shipped in #229 — the auto-generated `https://api.foodatlas.ai/docs` already surfaces them, this just catches the hand-maintained summary table on the marketing page up.
- **Navbar** drops the "Explore" nav slot. Landing (`/`) is still reachable via the logo click; slot removed while the landing is being reworked.

## Test plan

- [x] Lint clean.
- [ ] After merge, verify `/developers` lists all 6 bioact endpoints and the top nav no longer shows "Explore".

🤖 Generated with [Claude Code](https://claude.com/claude-code)