### PR TITLE
fix(assay-links): recognise "ChEMBL: CHEMBLxxxx" prefix format

### DIFF
--- a/frontend/utils/utils.tsx
+++ b/frontend/utils/utils.tsx
@@ -78,9 +78,12 @@ export const EXTERNAL_REFERENCE_LOOKUP = {
 // one URL template. Returns null when we don't recognise the id
 // scheme so callers can render plain text as a fallback.
 //
-// Recognised schemes:
+// Recognised schemes (both bare + upstream "prefix: id" formats, since
+// the KGC parquet stores the display label — e.g. "ChEMBL: CHEMBL...",
+// "AID: 364" — not the bare id):
 // - PubChem BioAssay: "AID 364", "AID: 364", "AID:364"
-// - ChEMBL assay:     "CHEMBL329341"
+// - ChEMBL assay:     "CHEMBL329341", "ChEMBL: CHEMBL329341",
+//                     "ChEMBL:CHEMBL329341", "ChEMBL CHEMBL329341"
 export const assayExternalUrl = (
   raw: string | null | undefined
 ): { url: string; source: "PubChem" | "ChEMBL" } | null => {
@@ -93,10 +96,10 @@ export const assayExternalUrl = (
       source: "PubChem",
     };
   }
-  const chembl = id.match(/^CHEMBL\d+$/i);
+  const chembl = id.match(/^(?:ChEMBL[\s:]*)?(CHEMBL\d+)$/i);
   if (chembl) {
     return {
-      url: `https://www.ebi.ac.uk/chembl/explore/assay/${id.toUpperCase()}`,
+      url: `https://www.ebi.ac.uk/chembl/explore/assay/${chembl[1].toUpperCase()}`,
       source: "ChEMBL",
     };
   }


### PR DESCRIPTION
## Summary

Real staging data stores assay ids as the upstream display label — \`ChEMBL: CHEMBL2382889\`, not the bare \`CHEMBL2382889\`. The previous regex (\`/^CHEMBL\\d+$/i\`) required the bare form and produced **no link for 100% of real ChEMBL rows**.

Regex now accepts both forms and uses the captured bare id for the URL template.

## Verified against real staging strings

| Input | Extracted id | URL |
|-|-|-|
| \`ChEMBL: CHEMBL2382889\` | \`CHEMBL2382889\` | https://www.ebi.ac.uk/chembl/explore/assay/CHEMBL2382889 |
| \`ChEMBL:CHEMBL999\` | \`CHEMBL999\` | https://www.ebi.ac.uk/chembl/explore/assay/CHEMBL999 |
| \`CHEMBL3369572\` (bare) | \`CHEMBL3369572\` | https://www.ebi.ac.uk/chembl/explore/assay/CHEMBL3369572 |
| \`AID: 1094593\` | untouched | (PubChem branch handles this) |

## Test plan
- [x] Lint clean.
- [ ] After merge, open any measurements modal on a bioactivity/chemical page and click an assay id — should open the ChEMBL assay report page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)