### PR TITLE
feat(bioact): Assay Source single-select radio; row count reflects filter

### DIFF
--- a/backend/api/src/repositories/bioactivity.py
+++ b/backend/api/src/repositories/bioactivity.py
@@ -86,7 +86,21 @@ def _top_measurement_by_value(measurements: list | None) -> dict | None:
     return top
 
 
-def _attach_top_measurement(data: list[dict], evidence_type: str = "") -> list[dict]:
+def _source_kind_of(measurement: dict) -> str:
+    """Classify a single measurement as experimental / predicted / ''."""
+    src = (measurement.get("evidence_source") or "").lower()
+    if src.startswith("exp"):
+        return "experimental"
+    if src.startswith("pred") or src.startswith("comp"):
+        return "predicted"
+    return ""
+
+
+def _attach_top_measurement(
+    data: list[dict],
+    evidence_type: str = "",
+    source_kind: str = "",
+) -> list[dict]:
     for row in data:
         # HOTFIX 2026-06-26 — clean dirty endpoint/unit values in the
         # inline measurements sample before downstream consumers see
@@ -101,6 +115,15 @@ def _attach_top_measurement(data: list[dict], evidence_type: str = "") -> list[d
             cleaned = [
                 m for m in cleaned if (m.get("evidence_type") or "") == evidence_type
             ]
+        # Same treatment for the single-select Assay Source filter:
+        # keep only measurements matching the selected kind so the
+        # displayed "N assays" (and top_measurement, and the modal
+        # preview) reflect that subset. Also rewrite the row's
+        # measurement_count so the "Assays (experimental)" column
+        # renders the filtered number instead of the total.
+        if source_kind in ("experimental", "predicted"):
+            cleaned = [m for m in cleaned if _source_kind_of(m) == source_kind]
+            row["measurement_count"] = len(cleaned)
         row["measurements"] = cleaned
         row["top_measurement"] = _top_measurement_by_value(cleaned)
     return data
@@ -182,34 +205,31 @@ def _apply_source_kind_filter(
     filter_source_kind: str,
     measurements_col: str,
 ) -> None:
-    """Row classification per evidence_source values in the capped sample.
+    """Single-select provenance filter.
 
-    "experimental" = only exp*, "predicted" = only pred*/comp*, "mixed" =
-    both present. A row can only match one, so OR-ing three across the
-    multi-select is safe.
+    ``"experimental"`` keeps rows with AT LEAST ONE experimental
+    measurement (source LIKE 'exp%'); ``"predicted"`` keeps rows with
+    at least one predicted/computational measurement
+    (source LIKE 'pred%'/'comp%'). Any other value — most importantly
+    ``"both"`` and the empty string (the frontend default) — is a
+    no-op, i.e. no filter applied.
+
+    Row exclusion at the SQL level is by EXISTS over the capped
+    measurements sample; the per-row count returned to the UI is
+    narrowed to the same subset in ``_attach_top_measurement`` so the
+    "Assays (experimental)" column reads consistently.
     """
-    if not filter_source_kind:
-        return
-    kinds = [k for k in filter_source_kind.split("+") if k]
-    if not kinds:
-        return
-    exp_expr = (
-        f"EXISTS (SELECT 1 FROM jsonb_array_elements({measurements_col}) m"
-        " WHERE lower(m->>'evidence_source') LIKE 'exp%')"
-    )
-    pred_expr = (
-        f"EXISTS (SELECT 1 FROM jsonb_array_elements({measurements_col}) m"
-        " WHERE lower(m->>'evidence_source') LIKE 'pred%'"
-        " OR lower(m->>'evidence_source') LIKE 'comp%')"
-    )
-    kind_to_clause = {
-        "experimental": f"({exp_expr} AND NOT {pred_expr})",
-        "predicted": f"({pred_expr} AND NOT {exp_expr})",
-        "mixed": f"({exp_expr} AND {pred_expr})",
-    }
-    clauses = [kind_to_clause[k] for k in kinds if k in kind_to_clause]
-    if clauses:
-        where_parts.append("(" + " OR ".join(clauses) + ")")
+    if filter_source_kind == "experimental":
+        where_parts.append(
+            f"EXISTS (SELECT 1 FROM jsonb_array_elements({measurements_col}) m"
+            " WHERE lower(m->>'evidence_source') LIKE 'exp%')"
+        )
+    elif filter_source_kind == "predicted":
+        where_parts.append(
+            f"EXISTS (SELECT 1 FROM jsonb_array_elements({measurements_col}) m"
+            " WHERE lower(m->>'evidence_source') LIKE 'pred%'"
+            " OR lower(m->>'evidence_source') LIKE 'comp%')"
+        )
 
 
 async def _paginated(
@@ -304,6 +324,7 @@ async def _paginated(
     data = _attach_top_measurement(
         [dict(r._mapping) for r in rows_result],
         evidence_type=filter_evidence_type,
+        source_kind=filter_source_kind,
     )
     return {
         "data": data,
@@ -578,7 +599,10 @@ async def get_food_inferred_bioactivities(
         """),
         {**params, "offset": offset, "limit": rows_per_page},
     )
-    data = _attach_top_measurement([dict(r._mapping) for r in rows_result])
+    data = _attach_top_measurement(
+        [dict(r._mapping) for r in rows_result],
+        source_kind=filter_source_kind,
+    )
     return {
         "data": data,
         "metadata": _build_meta(total, page, rows_per_page, len(data)),

--- a/frontend/components/entities/bioactivity/BioactivityTable.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityTable.tsx
@@ -161,7 +161,11 @@ const BioactivityTable = ({
     { unit: string; count: number }[]
   >([]);
   const [selectedCategories, setSelectedCategories] = useState<string[]>([]);
-  const [selectedSourceKinds, setSelectedSourceKinds] = useState<string[]>([]);
+  // Single-select Assay Source filter. Value is one of:
+  //   "" — "both" (no filter, default)
+  //   "experimental"
+  //   "predicted"
+  const [selectedSourceKind, setSelectedSourceKind] = useState<string>("");
   const filterActive = Boolean(filter.endpoint && filter.unit);
   const unitFilterParam = selectedUnits.join("+");
   const categoryFilterParam = selectedCategories.join("+");
@@ -171,9 +175,7 @@ const BioactivityTable = ({
   const effectiveSearchTerm =
     externalSearch !== undefined ? externalSearch : searchTerm;
   const effectiveSourceKindParam =
-    externalSourceKind !== undefined
-      ? externalSourceKind
-      : selectedSourceKinds.join("+");
+    externalSourceKind !== undefined ? externalSourceKind : selectedSourceKind;
   const effectiveUnitParam =
     externalUnit !== undefined
       ? externalUnit
@@ -260,23 +262,18 @@ const BioactivityTable = ({
     setSelectedCategories([]);
   };
 
-  // Row-level measurement provenance. Kinds are fixed, not derived —
-  // the backend does the exp/pred/mixed classification against the
-  // per-row measurements sample.
-  const SOURCE_KINDS = [
+  // Single-select Assay Source. "both" (key="") is the default = no
+  // filter; the other two narrow rows to those with ≥1 measurement of
+  // the chosen kind (backend classifies against the capped
+  // measurements sample by evidence_source prefix).
+  const SOURCE_KINDS: { key: string; label: string }[] = [
+    { key: "", label: "both" },
     { key: "experimental", label: "experimental" },
     { key: "predicted", label: "predicted" },
-    { key: "mixed", label: "mixed" },
   ];
-  const toggleSourceKind = (kind: string) => {
+  const chooseSourceKind = (kind: string) => {
     setTablePaginations(tableId, 1, 20);
-    setSelectedSourceKinds((prev) =>
-      prev.includes(kind) ? prev.filter((k) => k !== kind) : [...prev, kind]
-    );
-  };
-  const clearSourceKinds = () => {
-    setTablePaginations(tableId, 1, 20);
-    setSelectedSourceKinds([]);
+    setSelectedSourceKind(kind);
   };
 
   const [selected, setSelected] = useState<BioactivityRow | null>(null);
@@ -451,25 +448,20 @@ const BioactivityTable = ({
       <div className="flex flex-col gap-1.5">
         <div className="flex items-baseline justify-between gap-2">
           <span className="font-mono italic text-[11px] uppercase tracking-wider text-light-400 min-w-[3.5rem]">
-            Source
+            Assay Source
           </span>
-          {selectedSourceKinds.length > 0 && (
-            <button
-              type="button"
-              onClick={clearSourceKinds}
-              className="text-[11px] font-mono italic text-light-400 hover:text-light-100 underline-offset-4 hover:underline transition-colors"
-            >
-              clear
-            </button>
-          )}
         </div>
-        <div className="flex flex-col -mx-1">
+        <div
+          className="flex flex-col -mx-1"
+          role="radiogroup"
+          aria-label="Assay Source"
+        >
           {SOURCE_KINDS.map(({ key, label }) => (
             <SourceKindRow
-              key={key}
+              key={label}
               label={label}
-              selected={selectedSourceKinds.includes(key)}
-              onClick={() => toggleSourceKind(key)}
+              selected={selectedSourceKind === key}
+              onClick={() => chooseSourceKind(key)}
             />
           ))}
         </div>
@@ -531,37 +523,48 @@ const BioactivityTable = ({
           </colgroup>
           <thead className="text-light-400 text-left">
             <tr>
-              {columns.map((c, idx) => (
-                <th
-                  key={c.key}
-                  className={`h-9 border-b border-light-700 leading-none break-all md:break-normal py-1.5 ${
-                    idx === 0
-                      ? "pr-4"
-                      : idx === columns.length - 1
-                      ? "pl-4"
-                      : "px-4"
-                  } ${c.align === "right" ? "text-right" : "text-left"}`}
-                >
-                  {c.sortable ? (
-                    <SortableHeader
-                      label={c.label}
-                      align={c.align}
-                      active={sort.by === c.key}
-                      dir={sort.dir}
-                      onClick={() => handleSortClick(c.key)}
-                      disabledHint={
-                        c.key === TOP_VALUE_SORT_KEY && !filterActive
-                          ? "Pick an endpoint · unit chip to sort by potency"
-                          : undefined
-                      }
-                    />
-                  ) : (
-                    <span className="select-none uppercase text-xs font-medium">
-                      {c.label}
-                    </span>
-                  )}
-                </th>
-              ))}
+              {columns.map((c, idx) => {
+                // The Assays column gets a "(experimental)" /
+                // "(predicted)" suffix when a source kind filter is
+                // active, so readers know the count reflects only
+                // that subset. Applies whether the column is sortable
+                // (bioactivity's chemicals table) or not (all others).
+                const label =
+                  c.label === "Assays" && effectiveSourceKindParam
+                    ? `Assays (${effectiveSourceKindParam})`
+                    : c.label;
+                return (
+                  <th
+                    key={c.key}
+                    className={`h-9 border-b border-light-700 leading-none break-all md:break-normal py-1.5 ${
+                      idx === 0
+                        ? "pr-4"
+                        : idx === columns.length - 1
+                        ? "pl-4"
+                        : "px-4"
+                    } ${c.align === "right" ? "text-right" : "text-left"}`}
+                  >
+                    {c.sortable ? (
+                      <SortableHeader
+                        label={label}
+                        align={c.align}
+                        active={sort.by === c.key}
+                        dir={sort.dir}
+                        onClick={() => handleSortClick(c.key)}
+                        disabledHint={
+                          c.key === TOP_VALUE_SORT_KEY && !filterActive
+                            ? "Pick an endpoint · unit chip to sort by potency"
+                            : undefined
+                        }
+                      />
+                    ) : (
+                      <span className="select-none uppercase text-xs font-medium">
+                        {label}
+                      </span>
+                    )}
+                  </th>
+                );
+              })}
             </tr>
           </thead>
           <tbody className="text-sm font-light">
@@ -909,8 +912,9 @@ const SourceKindRow = ({
 }) => (
   <button
     type="button"
+    role="radio"
+    aria-checked={selected}
     onClick={onClick}
-    aria-pressed={selected}
     className={twMerge(
       "group w-full flex items-center gap-2 pl-1 pr-2 py-1 rounded transition-colors text-left",
       selected
@@ -921,13 +925,15 @@ const SourceKindRow = ({
     <span
       aria-hidden
       className={twMerge(
-        "w-3.5 h-3.5 rounded-[3px] border flex-shrink-0 flex items-center justify-center transition-colors",
+        "w-3.5 h-3.5 rounded-full border flex-shrink-0 flex items-center justify-center transition-colors",
         selected
-          ? "border-accent-600 bg-accent-600/20 text-accent-600"
+          ? "border-accent-600 bg-accent-600/20"
           : "border-light-700 group-hover:border-light-500"
       )}
     >
-      {selected && <MdCheck className="w-3 h-3" />}
+      {selected && (
+        <span className="w-1.5 h-1.5 rounded-full bg-accent-600" aria-hidden />
+      )}
     </span>
     <span className="font-mono italic text-xs capitalize flex-1">{label}</span>
   </button>

--- a/frontend/components/entities/bioactivity/FoodBioactivitiesTab.tsx
+++ b/frontend/components/entities/bioactivity/FoodBioactivitiesTab.tsx
@@ -21,17 +21,17 @@ interface Props {
   anchorId?: string | null;
 }
 
-const SOURCE_KINDS = [
+const SOURCE_KINDS: { key: string; label: string }[] = [
+  { key: "", label: "both" },
   { key: "experimental", label: "experimental" },
   { key: "predicted", label: "predicted" },
-  { key: "mixed", label: "mixed" },
-] as const;
+];
 
 const TOP_UNITS = 5;
 
 const FoodBioactivitiesTab = ({ commonName, anchorId }: Props) => {
   const [searchTerm, setSearchTerm] = useState("");
-  const [selectedSourceKinds, setSelectedSourceKinds] = useState<string[]>([]);
+  const [selectedSourceKind, setSelectedSourceKind] = useState<string>("");
   const [selectedUnits, setSelectedUnits] = useState<string[]>([]);
   const [showAllUnits, setShowAllUnits] = useState(false);
   const [unitOptions, setUnitOptions] = useState<
@@ -39,7 +39,7 @@ const FoodBioactivitiesTab = ({ commonName, anchorId }: Props) => {
   >([]);
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false);
 
-  const sourceKindParam = selectedSourceKinds.join("+");
+  const sourceKindParam = selectedSourceKind;
   const unitParam = selectedUnits.join("+");
 
   // Aggregated unit list across BOTH tables — direct (food-level
@@ -75,12 +75,7 @@ const FoodBioactivitiesTab = ({ commonName, anchorId }: Props) => {
     };
   }, [commonName]);
 
-  const toggleSourceKind = (kind: string) => {
-    setSelectedSourceKinds((prev) =>
-      prev.includes(kind) ? prev.filter((k) => k !== kind) : [...prev, kind]
-    );
-  };
-  const clearSourceKinds = () => setSelectedSourceKinds([]);
+  const chooseSourceKind = (kind: string) => setSelectedSourceKind(kind);
   const toggleUnit = (unit: string) => {
     setSelectedUnits((prev) =>
       prev.includes(unit) ? prev.filter((u) => u !== unit) : [...prev, unit]
@@ -120,27 +115,23 @@ const FoodBioactivitiesTab = ({ commonName, anchorId }: Props) => {
     <div className="flex flex-col gap-1.5">
       <div className="flex items-baseline justify-between gap-2">
         <span className="font-mono italic text-[11px] uppercase tracking-wider text-light-400 min-w-[3.5rem]">
-          Source
+          Assay Source
         </span>
-        {selectedSourceKinds.length > 0 && (
-          <button
-            type="button"
-            onClick={clearSourceKinds}
-            className="text-[11px] font-mono italic text-light-400 hover:text-light-100 underline-offset-4 hover:underline transition-colors"
-          >
-            clear
-          </button>
-        )}
       </div>
-      <div className="flex flex-col -mx-1">
+      <div
+        className="flex flex-col -mx-1"
+        role="radiogroup"
+        aria-label="Assay Source"
+      >
         {SOURCE_KINDS.map(({ key, label }) => {
-          const selected = selectedSourceKinds.includes(key);
+          const selected = selectedSourceKind === key;
           return (
             <button
-              key={key}
+              key={label}
               type="button"
-              onClick={() => toggleSourceKind(key)}
-              aria-pressed={selected}
+              role="radio"
+              aria-checked={selected}
+              onClick={() => chooseSourceKind(key)}
               className={twMerge(
                 "group w-full flex items-center gap-2 pl-1 pr-2 py-1 rounded transition-colors text-left",
                 selected
@@ -151,13 +142,18 @@ const FoodBioactivitiesTab = ({ commonName, anchorId }: Props) => {
               <span
                 aria-hidden
                 className={twMerge(
-                  "w-3.5 h-3.5 rounded-[3px] border flex-shrink-0 flex items-center justify-center transition-colors",
+                  "w-3.5 h-3.5 rounded-full border flex-shrink-0 flex items-center justify-center transition-colors",
                   selected
-                    ? "border-accent-600 bg-accent-600/20 text-accent-600"
+                    ? "border-accent-600 bg-accent-600/20"
                     : "border-light-700 group-hover:border-light-500"
                 )}
               >
-                {selected && <MdCheck className="w-3 h-3" />}
+                {selected && (
+                  <span
+                    className="w-1.5 h-1.5 rounded-full bg-accent-600"
+                    aria-hidden
+                  />
+                )}
               </span>
               <span className="font-mono italic text-xs capitalize flex-1">
                 {label}


### PR DESCRIPTION
## Summary

Reshapes the "Source" filter per your spec.

- Rename group to **"Assay Source"**.
- Radio group, not checkboxes.
- New default **"both"** option (was "mixed") — semantically "no filter, include everything". The old "mixed = rows with both exp AND pred" semantic is gone; that concept isn't reachable in the UI any more.
- **experimental** / **predicted** now mean "row has ≥1 measurement of the chosen kind" (was: "row has ONLY that kind"). This matches your description: "if experimental is selected, rows w/ 0 don't show".
- When a kind is picked, the row's \`measurement_count\` is rewritten to the sample-count of matching measurements, and the Assays column header picks up the suffix — **"Assays (experimental)"** / **"Assays (predicted)"** — so the number is clearly a filtered subset.

## Test plan

- [x] Ruff clean, 209 API tests pass.
- [x] Frontend lint clean, 25/25 vitest.
- [ ] After merge + cd-staging, verify:
  - Radio group shows both / experimental / predicted, default "both".
  - Selecting "experimental" narrows rows and changes the count + header.
  - Selecting "both" restores the full set.
  - Standalone use (chemical page → bioactivities) works the same as the shared food-page Bioactivities tab.

## Caveats

- The filtered count is computed from the capped 25-row measurements sample, not full data. For rows with more than ~25 measurements the count is an approximation. If that matters, next step is to precompute per-kind counts on the MV during materialisation and have the API return the exact number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)