### PR TITLE
fix(bioact): unify assay action to "View N assays →" across all sections

### DIFF
--- a/frontend/components/entities/bioactivity/BioactivityChemicalsSection.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityChemicalsSection.tsx
@@ -6,12 +6,12 @@ import { getBioactivityChemicals } from "@/utils/fetching";
 import type { BioactivityListParams } from "@/utils/fetching";
 import type { BioactivityChemicalRow } from "@/types";
 import BioactivityTable, {
-  AssayCountCell,
   CategoryCell,
   NameLinkCell,
   NumberCell,
   TOP_MEASUREMENT_SORT_KEY,
   TopMeasurementCell,
+  ViewAssaysCell,
   type SortableColumn,
 } from "@/components/entities/bioactivity/BioactivityTable";
 
@@ -86,15 +86,16 @@ const BioactivityChemicalsSection = ({ commonName, anchorId }: Props) => {
         sortable: true,
         render: (row) => <TopMeasurementCell row={row} />,
       },
-      // The former "Assays" View-button column becomes a sortable
-      // measurement_count cell that doubles as the modal opener.
+      // Assays column: sortable by measurement_count, and each cell is
+      // the same "View N assays →" pill used across every bioactivity
+      // section so the affordance reads consistently.
       {
         key: "measurement_count",
         label: "Assays",
         align: "right",
-        width: "w-[12%]",
+        width: "w-[14%]",
         sortable: true,
-        render: (row, ctx) => <AssayCountCell row={row} ctx={ctx} />,
+        render: (row, ctx) => <ViewAssaysCell row={row} ctx={ctx} />,
       },
     ],
     []

--- a/frontend/components/entities/bioactivity/BioactivityTable.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityTable.tsx
@@ -799,28 +799,6 @@ export const ViewAssaysCell = ({
   </button>
 );
 
-// Compact numeric assay count that doubles as the modal opener. Same
-// affordance as ViewAssaysCell but takes less horizontal room — the
-// column is now a sortable numeric column that just happens to be
-// clickable. Uses <button> so the whole cell stays in the tab order.
-export const AssayCountCell = ({
-  row,
-  ctx,
-}: {
-  row: BioactivityRow;
-  ctx: ColumnContext;
-}) => (
-  <button
-    type="button"
-    onClick={ctx.openModal}
-    disabled={row.measurement_count === 0}
-    className="font-mono text-xs tabular-nums text-light-200 hover:text-light-100 underline-offset-4 hover:underline disabled:no-underline disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-    aria-label={`View ${row.measurement_count} assays`}
-  >
-    {row.measurement_count.toLocaleString()}
-  </button>
-);
-
 // Chemical classification (["flavonoid", "polyphenol"] → "flavonoid,
 // polyphenol"). Trims to the first entry + "N more" once we have more
 // than two so the column stays narrow. Silent em-dash for empty/null

--- a/frontend/components/entities/bioactivity/FoodInferredBioactivitiesSection.tsx
+++ b/frontend/components/entities/bioactivity/FoodInferredBioactivitiesSection.tsx
@@ -421,7 +421,8 @@ const Row = ({ row, onOpen }: { row: InferredRow; onOpen: () => void }) => {
             disabled={row.measurement_count === 0}
             className="font-mono italic text-xs px-2.5 py-0.5 rounded-full border border-light-700/60 text-light-300 hover:text-light-100 hover:border-light-500 transition-colors disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
           >
-            View {row.measurement_count.toLocaleString()} →
+            View {row.measurement_count.toLocaleString()} assay
+            {row.measurement_count === 1 ? "" : "s"} →
           </button>
         </div>
       </td>


### PR DESCRIPTION
## Summary

The "view assays" affordance had three different shapes across the four bioactivity tables:

| Section | Rendered as |
|-|-|
| BioactivityFoods / ChemicalBioactivities / FoodBioactivities | pill \`View 755 assays →\` |
| BioactivityChemicalsSection | bare number \`755\` (via AssayCountCell) |
| FoodInferredBioactivitiesSection | pill \`View 755 →\` (missing "assay(s)") |

Consolidates to the ViewAssaysCell pill \`View N assays →\` everywhere with singular/plural handling. \`AssayCountCell\` is deleted (unused after BioactivityChemicalsSection switches to ViewAssaysCell). The column is still sortable by \`measurement_count\` — the sortable header handles sort, the cell click opens the modal.

Also bumps the Assays column width in BioactivityChemicalsSection from 12% → 14% so the full label doesn't wrap.

## Test plan

- [x] Lint clean, 25/25 vitest.
- [ ] After merge, verify all four bioactivity tables (bioactivity's chemicals, bioactivity's foods, chemical's bioactivities, food's bioactivities) + the inferred section render the same "View N assays →" pill in the Assays column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)