### PR TITLE
fix(bioact): drop "assays" from View button label

### DIFF
--- a/frontend/__tests__/bioactivity-sections.test.tsx
+++ b/frontend/__tests__/bioactivity-sections.test.tsx
@@ -98,7 +98,7 @@ describe("BioactivityChemicalsSection", () => {
     // sidebar-filter redesign). The count is rendered as its own text
     // node with commas, so match on the exact label.
     expect(
-      screen.getByRole("button", { name: /View 755 assays/i })
+      screen.getByRole("button", { name: /View 755/i })
     ).toBeInTheDocument();
     expect(screen.getByText("83")).toBeInTheDocument();
     expect(screen.getByText("261")).toBeInTheDocument();
@@ -116,7 +116,7 @@ describe("BioactivityFoodsSection", () => {
     expect(await screen.findByText(/snail/i)).toBeInTheDocument();
     expect(screen.getByText(/Activity: 0\.519 mmol\/100g/)).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /view 1 assay/i })
+      screen.getByRole("button", { name: /view 1/i })
     ).toBeInTheDocument();
   });
 });

--- a/frontend/components/entities/bioactivity/BioactivityTable.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityTable.tsx
@@ -794,8 +794,7 @@ export const ViewAssaysCell = ({
     disabled={row.measurement_count === 0}
     className="font-mono italic text-xs px-2.5 py-0.5 rounded-full border border-light-700/60 text-light-300 hover:text-light-100 hover:border-light-500 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
   >
-    View {row.measurement_count.toLocaleString()} assay
-    {row.measurement_count === 1 ? "" : "s"} →
+    View {row.measurement_count.toLocaleString()} →
   </button>
 );
 

--- a/frontend/components/entities/bioactivity/FoodInferredBioactivitiesSection.tsx
+++ b/frontend/components/entities/bioactivity/FoodInferredBioactivitiesSection.tsx
@@ -421,8 +421,7 @@ const Row = ({ row, onOpen }: { row: InferredRow; onOpen: () => void }) => {
             disabled={row.measurement_count === 0}
             className="font-mono italic text-xs px-2.5 py-0.5 rounded-full border border-light-700/60 text-light-300 hover:text-light-100 hover:border-light-500 transition-colors disabled:opacity-40 disabled:cursor-not-allowed whitespace-nowrap"
           >
-            View {row.measurement_count.toLocaleString()} assay
-            {row.measurement_count === 1 ? "" : "s"} →
+            View {row.measurement_count.toLocaleString()} →
           </button>
         </div>
       </td>


### PR DESCRIPTION
Should read `View 755 →`, not `View 755 assays →`. Updates ViewAssaysCell + FoodInferredBioactivitiesSection button + the two vitest assertions. Lint clean, 25/25 vitest.