### PR TITLE
fix(bioactivity): drop Top measurement sort chevrons

### DIFF
--- a/frontend/components/entities/bioactivity/BioactivityChemicalsSection.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityChemicalsSection.tsx
@@ -83,7 +83,6 @@ const BioactivityChemicalsSection = ({ commonName, anchorId }: Props) => {
         label: "Top measurement",
         align: "right",
         width: "w-[22%]",
-        sortable: true,
         render: (row) => <TopMeasurementCell row={row} />,
       },
       // Assays column: sortable by measurement_count, and each cell is

--- a/frontend/components/entities/bioactivity/BioactivityFoodsSection.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityFoodsSection.tsx
@@ -38,7 +38,6 @@ const BioactivityFoodsSection = ({ commonName, anchorId }: Props) => {
         label: "Top measurement",
         align: "right",
         width: "w-[35%]",
-        sortable: true,
         render: (row) => <TopMeasurementCell row={row} />,
       },
       {

--- a/frontend/components/entities/bioactivity/ChemicalBioactivitiesSection.tsx
+++ b/frontend/components/entities/bioactivity/ChemicalBioactivitiesSection.tsx
@@ -61,7 +61,6 @@ const ChemicalBioactivitiesSection = ({ commonName, anchorId }: Props) => {
         label: "Top measurement",
         align: "right",
         width: "w-[28%]",
-        sortable: true,
         render: (row) => <TopMeasurementCell row={row} />,
       },
       {

--- a/frontend/components/entities/bioactivity/FoodBioactivitiesSection.tsx
+++ b/frontend/components/entities/bioactivity/FoodBioactivitiesSection.tsx
@@ -53,7 +53,6 @@ const FoodBioactivitiesSection = ({
         label: "Top measurement",
         align: "right",
         width: "w-[35%]",
-        sortable: true,
         render: (row) => <TopMeasurementCell row={row} />,
       },
       {


### PR DESCRIPTION
## Summary
- Top measurement is a display-only summary; sorting by it across heterogeneous endpoints/units is undefined and the header currently renders grayed-out chevrons.
- Removes \`sortable: true\` from the four bioactivity section column defs (chemicals/foods/chemical-bioactivities/food-bioactivities).
- FoodInferredBioactivitiesSection already renders Top measurement as a plain \`<th>\` — no change needed.

## Test plan
- [ ] Header no longer renders sort chevrons on any of the 4 bioactivity tables.
- [ ] Sort still works on Assays / Active / Inactive / # Foods columns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)