### PR TITLE
feat(bioactivity): global counts for category filter

### DIFF
--- a/backend/api/src/repositories/bioactivity.py
+++ b/backend/api/src/repositories/bioactivity.py
@@ -710,6 +710,35 @@ async def get_endpoint_options(
     return {"data": data, "metadata": {"row_count": len(data)}}
 
 
+async def get_category_options(
+    session: AsyncSession, common_name: str
+) -> dict[str, object]:
+    """Global chemical-classification counts for the bioactivity-chemicals
+    direction — so the sidebar's Category filter can show counts across
+    ALL matching chemicals, not just the ones on the current page.
+
+    Only meaningful when the pivot is a bioactivity and rows are chemicals
+    (mv_chemical_bioactivity); other directions have no per-row
+    classification. Returns an empty list for those.
+    """
+    rows_result = await session.execute(
+        text("""
+            SELECT category, COUNT(*) AS count
+            FROM mv_chemical_bioactivity mv
+            JOIN mv_chemical_entities ce
+              ON ce.foodatlas_id = mv.chemical_foodatlas_id
+            CROSS JOIN LATERAL UNNEST(ce.chemical_classification) AS category
+            WHERE mv.bioactivity_name = :name
+              AND category <> ''
+            GROUP BY category
+            ORDER BY COUNT(*) DESC
+        """),
+        {"name": common_name},
+    )
+    data = [dict(r._mapping) for r in rows_result]
+    return {"data": data, "metadata": {"row_count": len(data)}}
+
+
 # ---------------------------------------------------------------------
 # Unbounded measurements endpoint (no MV cap)
 # ---------------------------------------------------------------------

--- a/backend/api/src/routes/bioactivity.py
+++ b/backend/api/src/routes/bioactivity.py
@@ -93,6 +93,19 @@ async def bioactivity_endpoint_options(
     return await bioactivity.get_endpoint_options(db, common_name, direction)
 
 
+@router.get("/categories")
+async def bioactivity_category_options(
+    common_name: str = Query(..., description="Bioactivity common_name"),
+    db: AsyncSession = Depends(get_db),
+):
+    """Global (category, count) counts for the bioactivity's chemicals.
+
+    Powers the chemicals-table sidebar Category filter with counts that
+    reflect ALL matching chemicals rather than only the current page.
+    """
+    return await bioactivity.get_category_options(db, common_name)
+
+
 @router.get("/measurements")
 async def bioactivity_measurements(
     head_id: str = Query(..., description="Chemical or food foodatlas_id"),

--- a/frontend/__tests__/bioactivity-sections.test.tsx
+++ b/frontend/__tests__/bioactivity-sections.test.tsx
@@ -12,9 +12,10 @@ vi.mock("@/utils/fetching", () => ({
   getBioactivityFoods: vi.fn(),
   getChemicalBioactivities: vi.fn(),
   getFoodBioactivities: vi.fn(),
-  // BioactivityTable calls this on mount to populate the endpoint·unit
-  // filter chips; stub it so the mock graph is complete.
+  // BioactivityTable calls these on mount to populate the sidebar's
+  // unit chips + Category filter; stub both so the mock graph is complete.
   getBioactivityEndpointOptions: vi.fn().mockResolvedValue([]),
+  getBioactivityCategoryOptions: vi.fn().mockResolvedValue([]),
 }));
 
 // next/navigation isn't mounted in the vitest jsdom env; Button uses

--- a/frontend/components/entities/bioactivity/BioactivityTable.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityTable.tsx
@@ -7,7 +7,7 @@
 
 "use client";
 
-import { ReactNode, useEffect, useMemo, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import {
   MdCheck,
   MdClose,
@@ -29,6 +29,7 @@ import { formatTopMeasurement, topMeasurementOf } from "@/components/entities/bi
 import { usePaginations } from "@/context/paginationsContext";
 import { encodeSpace } from "@/utils/utils";
 import {
+  getBioactivityCategoryOptions,
   getBioactivityEndpointOptions,
   type BioactivityDirection,
   type BioactivityListParams,
@@ -230,24 +231,28 @@ const BioactivityTable = ({
   const [totalPages, setTotalPages] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
 
-  // Chemical Category options — derived from the current page's rows.
-  // Uses a stable memo so filtering by a category that's not on the
-  // current page still resolves server-side (we send the raw category
-  // string; the sidebar just surfaces what the user has already seen).
-  const categoryOptions = useMemo(() => {
-    const totals = new Map<string, number>();
-    for (const r of rows) {
-      const cats = (r as BioactivityChemicalRow).chemical_classification;
-      if (!Array.isArray(cats)) continue;
-      for (const c of cats) {
-        if (!c) continue;
-        totals.set(c, (totals.get(c) ?? 0) + 1);
-      }
+  // Chemical Category options come from a dedicated endpoint that
+  // aggregates classifications across ALL matching chemicals for the
+  // pivot bioactivity — so counts reflect the full result set, not just
+  // the current page. Only meaningful for the bioactivity-chemicals
+  // direction; other directions get []).
+  const [categoryOptions, setCategoryOptions] = useState<
+    { category: string; count: number }[]
+  >([]);
+  useEffect(() => {
+    if (direction !== "bioactivity-chemicals" || !pivotName) {
+      setCategoryOptions([]);
+      return;
     }
-    return Array.from(totals.entries())
-      .map(([category, count]) => ({ category, count }))
-      .sort((a, b) => b.count - a.count);
-  }, [rows]);
+    let cancelled = false;
+    (async () => {
+      const opts = await getBioactivityCategoryOptions(pivotName);
+      if (!cancelled) setCategoryOptions(opts);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [direction, pivotName]);
 
   const toggleCategory = (category: string) => {
     setTablePaginations(tableId, 1, 20);

--- a/frontend/utils/fetching.ts
+++ b/frontend/utils/fetching.ts
@@ -483,6 +483,32 @@ export async function getBioactivityEndpointOptions(
   }
 }
 
+// Global chemical-classification counts for the bioactivity-chemicals
+// sidebar. Only the bioactivity → chemicals direction has a category
+// filter, so a single fetcher covers all its consumers.
+export async function getBioactivityCategoryOptions(
+  commonName: string
+): Promise<{ category: string; count: number }[]> {
+  try {
+    const res = await fetch(
+      `${apiBase()}/bioactivity/categories?common_name=${encodeURIComponent(
+        commonName
+      )}`,
+      {
+        headers: {
+          Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY}`,
+        },
+        next: { revalidate: 86400 },
+      }
+    );
+    if (!res.ok) return [];
+    const payload = await res.json();
+    return (payload?.data ?? []) as { category: string; count: number }[];
+  } catch {
+    return [];
+  }
+}
+
 // cache & fetching testing function
 export async function getTime() {
   const response = await fetch("https://worldtimeapi.org/api/timezone/Etc/UTC");


### PR DESCRIPTION
## Summary
- The bioactivity-chemicals sidebar's **Category** filter was aggregating counts from the current page's rows only, so numbers shrank as users paged through results.
- New \`/bioactivity/categories?common_name=...\` returns global (category, count) tuples across all chemicals matched by the pivot bioactivity (query joins \`mv_chemical_bioactivity\` → \`mv_chemical_entities\`, unnests \`chemical_classification\`).
- Frontend fetcher \`getBioactivityCategoryOptions\`; \`BioactivityTable\` swaps the page-derived \`useMemo\` for a list fetched once per (direction, pivotName). Non-chemical directions get \`[]\` and hide the section.

## Test plan
- [ ] Category counts on a chemicals-side bioactivity table (e.g. antioxidant) stay constant across pages.
- [ ] Categories not shown on page 1 now appear in the sidebar.
- [ ] Category filter still narrows results server-side (\`filter_category\` param unchanged).
- [ ] Non-chemical directions (bioactivity-foods etc.) don't render the Category section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)