### PR TITLE
feat(tables): subtle row-count caption above every paginated table

### DIFF
--- a/frontend/components/entities/bioactivity/BioactivityTable.tsx
+++ b/frontend/components/entities/bioactivity/BioactivityTable.tsx
@@ -229,6 +229,7 @@ const BioactivityTable = ({
 
   const [rows, setRows] = useState<BioactivityRow[]>([]);
   const [totalPages, setTotalPages] = useState(0);
+  const [totalRows, setTotalRows] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
 
   // Chemical Category options come from a dedicated endpoint that
@@ -302,6 +303,7 @@ const BioactivityTable = ({
       if (cancelled) return;
       setRows(payload?.data ?? []);
       setTotalPages(payload?.metadata?.total_pages ?? 0);
+      setTotalRows(payload?.metadata?.total_rows ?? 0);
       setIsLoading(false);
     })();
     return () => {
@@ -519,6 +521,14 @@ const BioactivityTable = ({
       )}
 
       <div className="flex flex-col gap-7">
+      <div>
+      {!isLoading && totalRows > 0 && (
+        <div className="mb-1.5 flex justify-end">
+          <span className="font-mono italic text-[11px] text-light-500 tabular-nums">
+            {totalRows.toLocaleString()} {totalRows === 1 ? "row" : "rows"}
+          </span>
+        </div>
+      )}
       <div className="overflow-x-auto">
         <table className="w-full table-fixed">
           <colgroup>
@@ -603,6 +613,7 @@ const BioactivityTable = ({
             )}
           </tbody>
         </table>
+      </div>
       </div>
 
       {showingPaginator && (

--- a/frontend/components/entities/bioactivity/FoodInferredBioactivitiesSection.tsx
+++ b/frontend/components/entities/bioactivity/FoodInferredBioactivitiesSection.tsx
@@ -90,6 +90,7 @@ const FoodInferredBioactivitiesSection = ({
 
   const [rows, setRows] = useState<InferredRow[]>([]);
   const [totalPages, setTotalPages] = useState(0);
+  const [totalRows, setTotalRows] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [selected, setSelected] = useState<InferredRow | null>(null);
 
@@ -108,6 +109,7 @@ const FoodInferredBioactivitiesSection = ({
       if (cancelled) return;
       setRows((payload?.data as InferredRow[] | undefined) ?? []);
       setTotalPages(payload?.metadata?.total_pages ?? 0);
+      setTotalRows(payload?.metadata?.total_rows ?? 0);
       setIsLoading(false);
     })();
     return () => {
@@ -199,6 +201,13 @@ const FoodInferredBioactivitiesSection = ({
         </div>
       )}
 
+      {!isLoading && totalRows > 0 && (
+        <div className="mb-1.5 flex justify-end">
+          <span className="font-mono italic text-[11px] text-light-500 tabular-nums">
+            {totalRows.toLocaleString()} {totalRows === 1 ? "row" : "rows"}
+          </span>
+        </div>
+      )}
       <div className="overflow-x-auto">
         <table className="w-full table-fixed">
           <colgroup>

--- a/frontend/components/entities/food/FoodCompositionSection.tsx
+++ b/frontend/components/entities/food/FoodCompositionSection.tsx
@@ -603,10 +603,18 @@ const FoodCompositionSection = ({
           </div>
 
           <div className="flex flex-col gap-7">
+          <div>
+          {!isLoading && numberOfRows > 0 && (
+            <div className="mb-1.5 mt-3 flex justify-end">
+              <span className="font-mono italic text-[11px] text-light-500 tabular-nums">
+                {numberOfRows.toLocaleString()} {numberOfRows === 1 ? "row" : "rows"}
+              </span>
+            </div>
+          )}
           {/* table */}
           <div
             ref={tableWrapperRef}
-            className="mt-3 overflow-x-auto relative"
+            className="overflow-x-auto relative"
           >
             {highlightName && overlayRect && (
               <div
@@ -843,6 +851,7 @@ const FoodCompositionSection = ({
                   ))}
               </tbody>
             </table>
+          </div>
           </div>
           {/* pagination */}
           {(numberOfPages > 1 || isLoading) && (


### PR DESCRIPTION
## Summary
Adds a small right-aligned mono-italic caption \"N rows\" above every paginated table, using the \`total_rows\` metadata already returned by each list endpoint. Rendered only after a successful fetch so it doesn't flash during load.

Covers:
- All 4 bioactivity tables via \`BioactivityTable\`
- \`FoodCompositionSection\`
- \`FoodInferredBioactivitiesSection\`

## Test plan
- [ ] Row count appears above each table once loaded.
- [ ] Skeleton shows nothing (no flash).
- [ ] Count updates as filters change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)