### PR TITLE
hotfix(api+db): drop DMD-only rows from composition endpoints + autocomplete

### DIFF
--- a/backend/api/src/repositories/chemical.py
+++ b/backend/api/src/repositories/chemical.py
@@ -34,12 +34,18 @@ async def get_composition(session: AsyncSession, common_name: str) -> dict[str, 
     but have no attestation for this chemical are filtered out so the banner
     stays consistent with what the page actually shows.
     """
+    # Filter DMD-only rows unconditionally — the public API stopped
+    # exposing dmd_evidences in the 2026-07-06 DMD removal (PR #249),
+    # so a row with only DMD evidence would appear here with no visible
+    # evidence. The `chem_foods` CTE gets the same filter so ambiguity
+    # siblings stay consistent with what actually shows in the table.
     with_conc = await session.execute(
         text("""
             WITH chem_foods AS (
                 SELECT food_foodatlas_id AS id
                 FROM mv_food_chemical_composition
                 WHERE chemical_name = :name
+                  AND (fdc_evidences IS NOT NULL OR foodatlas_evidences IS NOT NULL)
             )
             SELECT c.food_foodatlas_id AS id, c.food_name AS name,
                    c.median_concentration,
@@ -51,7 +57,9 @@ async def get_composition(session: AsyncSession, common_name: str) -> dict[str, 
             FROM mv_food_chemical_composition c
             LEFT JOIN mv_food_entities fe
                 ON fe.foodatlas_id = c.food_foodatlas_id
-            WHERE c.chemical_name = :name AND c.median_concentration IS NOT NULL
+            WHERE c.chemical_name = :name
+              AND c.median_concentration IS NOT NULL
+              AND (c.fdc_evidences IS NOT NULL OR c.foodatlas_evidences IS NOT NULL)
         """),
         {"name": common_name},
     )
@@ -61,6 +69,7 @@ async def get_composition(session: AsyncSession, common_name: str) -> dict[str, 
                 SELECT food_foodatlas_id AS id
                 FROM mv_food_chemical_composition
                 WHERE chemical_name = :name
+                  AND (fdc_evidences IS NOT NULL OR foodatlas_evidences IS NOT NULL)
             )
             SELECT c.food_foodatlas_id AS id, c.food_name AS name,
                    COALESCE(jsonb_array_length(c.fdc_evidences), 0)
@@ -74,7 +83,9 @@ async def get_composition(session: AsyncSession, common_name: str) -> dict[str, 
             FROM mv_food_chemical_composition c
             LEFT JOIN mv_food_entities fe
                 ON fe.foodatlas_id = c.food_foodatlas_id
-            WHERE c.chemical_name = :name AND c.median_concentration IS NULL
+            WHERE c.chemical_name = :name
+              AND c.median_concentration IS NULL
+              AND (c.fdc_evidences IS NOT NULL OR c.foodatlas_evidences IS NOT NULL)
             ORDER BY COALESCE(jsonb_array_length(c.fdc_evidences), 0)
                    + COALESCE(jsonb_array_length(c.foodatlas_evidences), 0) DESC
         """),

--- a/backend/api/src/repositories/food.py
+++ b/backend/api/src/repositories/food.py
@@ -100,6 +100,7 @@ async def get_composition_counts(
                 CASE WHEN foodatlas_evidences IS NOT NULL THEN 1 ELSE 0 END AS has_fa
             FROM mv_food_chemical_composition
             WHERE food_name = :name
+              AND (fdc_evidences IS NOT NULL OR foodatlas_evidences IS NOT NULL)
         """),
         {"name": common_name},
     )
@@ -245,7 +246,16 @@ def _build_query_parts(
     else:
         select_cols = BASE_SELECT + ", " + valid[0] + "_evidences"
 
-    conditions = ["food_name = :name"]
+    conditions = [
+        "food_name = :name",
+        # Filter DMD-only rows unconditionally — the public API stopped
+        # exposing dmd_evidences in the 2026-07-06 DMD removal (PR #249)
+        # so a row with only DMD evidence renders as an empty row on the
+        # composition table. Redundant with the single-source clause
+        # below when a user picks exactly one source, harmless when both
+        # are selected.
+        "(fdc_evidences IS NOT NULL OR foodatlas_evidences IS NOT NULL)",
+    ]
     params: dict = {"name": common_name}
 
     if len(valid) == 1:

--- a/backend/db/src/etl/materializer_search.py
+++ b/backend/db/src/etl/materializer_search.py
@@ -115,12 +115,21 @@ def _load_assoc_counts(conn: Connection) -> dict[str, int]:
 
     Each MV uses type-specific ID columns (food_/chemical_/disease_foodatlas_id)
     so adding all four groupings never cross-contaminates entity types.
+
+    Composition groupings filter out DMD-only rows so the autocomplete
+    `associations` count matches what the composition endpoint actually
+    returns (DMD was stripped from the public API in the 2026-07-06
+    DMD removal — see hotfix PR #249).
     """
     queries = (
         "SELECT food_foodatlas_id AS fid, COUNT(*) AS n"
-        " FROM mv_food_chemical_composition GROUP BY food_foodatlas_id",
+        " FROM mv_food_chemical_composition"
+        " WHERE fdc_evidences IS NOT NULL OR foodatlas_evidences IS NOT NULL"
+        " GROUP BY food_foodatlas_id",
         "SELECT chemical_foodatlas_id AS fid, COUNT(*) AS n"
-        " FROM mv_food_chemical_composition GROUP BY chemical_foodatlas_id",
+        " FROM mv_food_chemical_composition"
+        " WHERE fdc_evidences IS NOT NULL OR foodatlas_evidences IS NOT NULL"
+        " GROUP BY chemical_foodatlas_id",
         "SELECT chemical_foodatlas_id AS fid, COUNT(*) AS n"
         " FROM mv_chemical_disease_correlation GROUP BY chemical_foodatlas_id",
         "SELECT disease_foodatlas_id AS fid, COUNT(*) AS n"

--- a/backend/db/tests/test_materializer_search.py
+++ b/backend/db/tests/test_materializer_search.py
@@ -185,11 +185,15 @@ class TestLoadAssocCounts:
         return conn
 
     def test_food_counts_from_composition(self):
+        # Composition queries filter DMD-only rows (WHERE fdc_evidences
+        # IS NOT NULL OR foodatlas_evidences IS NOT NULL) so match on
+        # the SELECT + FROM prefix; the GROUP BY still identifies which
+        # column drives the count.
         conn = self._conn_with_results(
             {
                 "food_foodatlas_id AS fid,"
-                " COUNT(*) AS n FROM mv_food_chemical_composition"
-                " GROUP BY food_foodatlas_id": [("f1", 3), ("f2", 5)],
+                " COUNT(*) AS n FROM mv_food_chemical_composition":
+                    [("f1", 3), ("f2", 5)],
             }
         )
         counts = _load_assoc_counts(conn)
@@ -199,9 +203,10 @@ class TestLoadAssocCounts:
     def test_chemical_sums_composition_and_correlation(self):
         conn = self._conn_with_results(
             {
+                # Composition query — filtered by evidence WHERE clause.
                 "chemical_foodatlas_id AS fid,"
-                " COUNT(*) AS n FROM mv_food_chemical_composition"
-                " GROUP BY chemical_foodatlas_id": [("c1", 4)],
+                " COUNT(*) AS n FROM mv_food_chemical_composition":
+                    [("c1", 4)],
                 "chemical_foodatlas_id AS fid,"
                 " COUNT(*) AS n FROM mv_chemical_disease_correlation"
                 " GROUP BY chemical_foodatlas_id": [("c1", 10)],


### PR DESCRIPTION
## Summary

DMD evidence was stripped from the public API in the 2026-07-06 DMD removal ([hotfix #249](https://github.com/AI-Institute-Food-Systems/foodatlas/pull/249)), but the underlying `mv_food_chemical_composition` still carries DMD-only rows by design. Two visible consequences remained in production:

- **`mv_search_auto_complete.associations` still counted DMD-only rows.** e.g. tomato showed ~470 associations; actual visible set is ~67.
- **`/food/{name}/composition` and `/chemical/{name}/composition`** returned DMD-only rows as empty-evidence rows on the composition table (both `fdc_evidences` and `foodatlas_evidences` `NULL`).

Same fix in every place — filter for:
```sql
fdc_evidences IS NOT NULL OR foodatlas_evidences IS NOT NULL
```

Touches only:
- `backend/db/src/etl/materializer_search.py` — the two composition queries in `_load_assoc_counts`.
- `backend/api/src/repositories/food.py::_build_query_parts` — always applied (was single-source-only).
- `backend/api/src/repositories/food.py::get_composition_counts` — so classification counts don't include DMD-only rows.
- `backend/api/src/repositories/chemical.py::get_composition` — both `with_conc` / `without_conc` queries + the `chem_foods` CTE (so ambiguity siblings stay consistent with what's shown).
- `backend/db/tests/test_materializer_search.py` — substrings updated to accommodate the new `WHERE` clause.

## Post-merge

After CD deploys, re-materialise `mv_search_auto_complete` on prod via Fargate so the autocomplete counts pick up the fix. The composition endpoints benefit immediately from the API changes.

## Test plan

- [x] `cd backend/db && uv run pytest` — 264 passed, 82% coverage
- [x] `cd backend/api && uv run pytest` — 181 passed, 86% coverage
- [ ] Post-deploy: `curl -s -H "Authorization: Bearer \$KEY" "https://api.foodatlas.ai/metadata/search?term=tomato" | jq '.data[0].associations'` — expect a dramatically lower number after the Fargate re-mat
- [ ] Post-deploy: `/food/tomato` composition table — no empty-evidence rows

## Delivery

Branched off `main` directly (admin-bypass path, per [hotfix #249](https://github.com/AI-Institute-Food-Systems/foodatlas/pull/249)) so the fix reaches prod without dev → main lag. I'll cherry-pick to `dev` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)