### PR TITLE
chore(dev): sync hotfix #252 (search-assoc-count DMD filter)

### DIFF
--- a/backend/api/src/repositories/chemical.py
+++ b/backend/api/src/repositories/chemical.py
@@ -34,12 +34,18 @@ async def get_composition(session: AsyncSession, common_name: str) -> dict[str, 
     but have no attestation for this chemical are filtered out so the banner
     stays consistent with what the page actually shows.
     """
+    # Filter DMD-only rows unconditionally — the public API stopped
+    # exposing dmd_evidences in the 2026-07-06 DMD removal (PR #249),
+    # so a row with only DMD evidence would appear here with no visible
+    # evidence. The `chem_foods` CTE gets the same filter so ambiguity
+    # siblings stay consistent with what actually shows in the table.
     with_conc = await session.execute(
         text("""
             WITH chem_foods AS (
                 SELECT food_foodatlas_id AS id
                 FROM mv_food_chemical_composition
                 WHERE chemical_name = :name
+                  AND (fdc_evidences IS NOT NULL OR foodatlas_evidences IS NOT NULL)
             )
             SELECT c.food_foodatlas_id AS id, c.food_name AS name,
                    c.median_concentration,
@@ -51,7 +57,9 @@ async def get_composition(session: AsyncSession, common_name: str) -> dict[str, 
             FROM mv_food_chemical_composition c
             LEFT JOIN mv_food_entities fe
                 ON fe.foodatlas_id = c.food_foodatlas_id
-            WHERE c.chemical_name = :name AND c.median_concentration IS NOT NULL
+            WHERE c.chemical_name = :name
+              AND c.median_concentration IS NOT NULL
+              AND (c.fdc_evidences IS NOT NULL OR c.foodatlas_evidences IS NOT NULL)
         """),
         {"name": common_name},
     )
@@ -61,6 +69,7 @@ async def get_composition(session: AsyncSession, common_name: str) -> dict[str, 
                 SELECT food_foodatlas_id AS id
                 FROM mv_food_chemical_composition
                 WHERE chemical_name = :name
+                  AND (fdc_evidences IS NOT NULL OR foodatlas_evidences IS NOT NULL)
             )
             SELECT c.food_foodatlas_id AS id, c.food_name AS name,
                    COALESCE(jsonb_array_length(c.fdc_evidences), 0)
@@ -74,7 +83,9 @@ async def get_composition(session: AsyncSession, common_name: str) -> dict[str, 
             FROM mv_food_chemical_composition c
             LEFT JOIN mv_food_entities fe
                 ON fe.foodatlas_id = c.food_foodatlas_id
-            WHERE c.chemical_name = :name AND c.median_concentration IS NULL
+            WHERE c.chemical_name = :name
+              AND c.median_concentration IS NULL
+              AND (c.fdc_evidences IS NOT NULL OR c.foodatlas_evidences IS NOT NULL)
             ORDER BY COALESCE(jsonb_array_length(c.fdc_evidences), 0)
                    + COALESCE(jsonb_array_length(c.foodatlas_evidences), 0) DESC
         """),

--- a/backend/api/src/repositories/food.py
+++ b/backend/api/src/repositories/food.py
@@ -105,6 +105,7 @@ async def get_composition_counts(
                 CASE WHEN foodatlas_evidences IS NOT NULL THEN 1 ELSE 0 END AS has_fa
             FROM mv_food_chemical_composition
             WHERE food_name = :name
+              AND (fdc_evidences IS NOT NULL OR foodatlas_evidences IS NOT NULL)
         """),
         {"name": common_name},
     )
@@ -250,7 +251,16 @@ def _build_query_parts(
     else:
         select_cols = BASE_SELECT + ", " + valid[0] + "_evidences"
 
-    conditions = ["food_name = :name"]
+    conditions = [
+        "food_name = :name",
+        # Filter DMD-only rows unconditionally — the public API stopped
+        # exposing dmd_evidences in the 2026-07-06 DMD removal (PR #249)
+        # so a row with only DMD evidence renders as an empty row on the
+        # composition table. Redundant with the single-source clause
+        # below when a user picks exactly one source, harmless when both
+        # are selected.
+        "(fdc_evidences IS NOT NULL OR foodatlas_evidences IS NOT NULL)",
+    ]
     params: dict = {"name": common_name}
 
     if len(valid) == 1:

--- a/backend/db/src/etl/materializer_search.py
+++ b/backend/db/src/etl/materializer_search.py
@@ -117,6 +117,11 @@ def _load_assoc_counts(conn: Connection) -> dict[str, int]:
     bioactivity_foodatlas_id) so adding all groupings never cross-contaminates
     entity types.
 
+    Composition groupings filter out DMD-only rows so the autocomplete
+    `associations` count matches what the composition endpoint actually
+    returns (DMD was stripped from the public API in the 2026-07-06
+    DMD removal — see hotfix PR #249).
+
     Previously foods and chemicals were missing their bioactivity-edge counts:
     a food like tomato didn't get credit for the bioactivity measurements from
     mv_food_bioactivity, and a chemical like quercetin didn't get credit for its
@@ -126,9 +131,13 @@ def _load_assoc_counts(conn: Connection) -> dict[str, int]:
     queries = (
         # Composition: food ↔ chemical
         "SELECT food_foodatlas_id AS fid, COUNT(*) AS n"
-        " FROM mv_food_chemical_composition GROUP BY food_foodatlas_id",
+        " FROM mv_food_chemical_composition"
+        " WHERE fdc_evidences IS NOT NULL OR foodatlas_evidences IS NOT NULL"
+        " GROUP BY food_foodatlas_id",
         "SELECT chemical_foodatlas_id AS fid, COUNT(*) AS n"
-        " FROM mv_food_chemical_composition GROUP BY chemical_foodatlas_id",
+        " FROM mv_food_chemical_composition"
+        " WHERE fdc_evidences IS NOT NULL OR foodatlas_evidences IS NOT NULL"
+        " GROUP BY chemical_foodatlas_id",
         # Correlation: chemical ↔ disease
         "SELECT chemical_foodatlas_id AS fid, COUNT(*) AS n"
         " FROM mv_chemical_disease_correlation GROUP BY chemical_foodatlas_id",

--- a/backend/db/tests/test_materializer_search.py
+++ b/backend/db/tests/test_materializer_search.py
@@ -185,11 +185,15 @@ class TestLoadAssocCounts:
         return conn
 
     def test_food_counts_from_composition(self):
+        # Composition queries filter DMD-only rows (WHERE fdc_evidences
+        # IS NOT NULL OR foodatlas_evidences IS NOT NULL) so match on
+        # the SELECT + FROM prefix; the GROUP BY still identifies which
+        # column drives the count.
         conn = self._conn_with_results(
             {
                 "food_foodatlas_id AS fid,"
-                " COUNT(*) AS n FROM mv_food_chemical_composition"
-                " GROUP BY food_foodatlas_id": [("f1", 3), ("f2", 5)],
+                " COUNT(*) AS n FROM mv_food_chemical_composition":
+                    [("f1", 3), ("f2", 5)],
             }
         )
         counts = _load_assoc_counts(conn)
@@ -199,9 +203,10 @@ class TestLoadAssocCounts:
     def test_chemical_sums_composition_and_correlation(self):
         conn = self._conn_with_results(
             {
+                # Composition query — filtered by evidence WHERE clause.
                 "chemical_foodatlas_id AS fid,"
-                " COUNT(*) AS n FROM mv_food_chemical_composition"
-                " GROUP BY chemical_foodatlas_id": [("c1", 4)],
+                " COUNT(*) AS n FROM mv_food_chemical_composition":
+                    [("c1", 4)],
                 "chemical_foodatlas_id AS fid,"
                 " COUNT(*) AS n FROM mv_chemical_disease_correlation"
                 " GROUP BY chemical_foodatlas_id": [("c1", 10)],

--- a/backend/db/tests/test_materializer_search.py
+++ b/backend/db/tests/test_materializer_search.py
@@ -192,8 +192,10 @@ class TestLoadAssocCounts:
         conn = self._conn_with_results(
             {
                 "food_foodatlas_id AS fid,"
-                " COUNT(*) AS n FROM mv_food_chemical_composition":
-                    [("f1", 3), ("f2", 5)],
+                " COUNT(*) AS n FROM mv_food_chemical_composition": [
+                    ("f1", 3),
+                    ("f2", 5),
+                ],
             }
         )
         counts = _load_assoc_counts(conn)
@@ -205,8 +207,7 @@ class TestLoadAssocCounts:
             {
                 # Composition query — filtered by evidence WHERE clause.
                 "chemical_foodatlas_id AS fid,"
-                " COUNT(*) AS n FROM mv_food_chemical_composition":
-                    [("c1", 4)],
+                " COUNT(*) AS n FROM mv_food_chemical_composition": [("c1", 4)],
                 "chemical_foodatlas_id AS fid,"
                 " COUNT(*) AS n FROM mv_chemical_disease_correlation"
                 " GROUP BY chemical_foodatlas_id": [("c1", 10)],


### PR DESCRIPTION
Cherry-pick of the hotfix that landed on `main` as PR #252.

Keeps `dev` in sync with `main` on the composition endpoint + search autocomplete DMD filter. Merge conflict on `materializer_search.py` resolved to preserve both dev's bioactivity-side count additions and main's new evidence-filter WHERE clauses on the two composition queries.

- Same code changes as #252: `backend/db/src/etl/materializer_search.py`, `backend/api/src/repositories/{food,chemical}.py`, `backend/db/tests/test_materializer_search.py`.
- Backend tests locally: db 266 pass / 82%, api 209 pass / 83%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)