### PR TITLE
feat(frontend): dynamic home notification + iOS Safari mobile fixes

### DIFF
--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -11,6 +11,19 @@ import { fontMono, fontSans, fontSerif } from "@/styles/fonts";
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
+  // `interactive-widget=resizes-content` tells iOS Safari to resize the
+  // layout viewport when the soft keyboard opens instead of shifting
+  // the visual viewport upward. Without this, focusing the SearchBar
+  // input triggers a jarring "background scrolls up including navbar"
+  // animation. Only newer Safari respects the flag; older versions
+  // fall back to the default `resizes-visual`.
+  interactiveWidget: "resizes-content",
+  // `viewport-fit=cover` lets the webview extend behind the dynamic
+  // island / notch and the home-indicator gutter, so fullscreen
+  // sheets (mobile modals) hit the screen edges instead of stopping
+  // at Safari's chrome. `env(safe-area-inset-*)` inside components
+  // keeps content clear of those regions.
+  viewportFit: "cover",
 };
 
 interface ClientLayoutProps {

--- a/frontend/components/basic/Modal.tsx
+++ b/frontend/components/basic/Modal.tsx
@@ -64,18 +64,24 @@ const Modal = ({
       {/* backdrop   */}
       <div className="fixed inset-0 w-screen backdrop-blur-md bg-neutral-800/50" />
       {/* modal */}
-      <div className="fixed inset-0 overflow-y-auto p-3 sm:p-6 md:p-12">
+      <div className="fixed inset-0 overflow-y-auto sm:p-6 md:p-12">
         {/* center content */}
         <div className="flex min-h-full items-center justify-center">
           <DialogPanel
             className={twMerge(
-              "relative w-full max-w-5xl rounded-xl border border-light-50/5 bg-light-950 backdrop-blur-2xl shadow-inner shadow-light-700/20 p-5 md:p-7",
-              // Mobile: fill nearly the whole dynamic viewport (minus
-              // the wrapper's p-3 = 1.5rem). sm: use minus p-6 (3rem).
-              // Desktop: 85vh capped at 800px — leaves gutters for
-              // the sidebar affordance.
+              // Mobile (base): edge-to-edge sheet — no rounding, no
+              // border, min-h fills the dynamic viewport so the
+              // background hits the dynamic island / home indicator
+              // area instead of leaving a Safari-chrome gap. Safe-area
+              // padding keeps content clear of those regions.
+              // sm+: card style returns — rounded, bordered, gutters.
+              "relative w-full max-w-5xl bg-light-950 backdrop-blur-2xl shadow-inner shadow-light-700/20",
+              "min-h-[100dvh] sm:min-h-0 sm:rounded-xl sm:border sm:border-light-50/5",
+              "px-5 md:p-7",
+              "pt-[max(1.25rem,env(safe-area-inset-top))] sm:pt-5",
+              "pb-[max(1.25rem,env(safe-area-inset-bottom))] sm:pb-5",
               fullHeight &&
-                "flex flex-col h-[calc(100dvh-1.5rem)] sm:h-[calc(100dvh-3rem)] md:h-[min(85vh,800px)]"
+                "flex flex-col h-[100dvh] sm:h-[calc(100dvh-3rem)] md:h-[min(85vh,800px)]"
             )}
           >
             {/* Sidebar hangs OUTSIDE the panel visually via absolute

--- a/frontend/components/landing/HeroSection.tsx
+++ b/frontend/components/landing/HeroSection.tsx
@@ -5,6 +5,7 @@ import Badge from "@/components/basic/Badge";
 import AIIcon from "@/components/icons/AIIcon";
 import Heading from "@/components/basic/Heading";
 import HeroStatsLine from "@/components/landing/HeroStatsLine";
+import NewsNotification from "@/components/landing/NewsNotification";
 import SearchWrapper from "@/components/landing/SearchWrapper";
 
 // Hero is a single centred flex column. Each child sits in normal
@@ -26,20 +27,10 @@ const HeroSection = () => {
       <div className="relative min-h-[38rem] sm:min-h-[44rem] md:min-h-[48rem] flex flex-col justify-center px-4 md:px-24 py-10 sm:py-14 md:py-20">
         <div className="max-w-4xl w-full mx-auto flex flex-col items-center gap-6 md:gap-8">
           {/* News line — typeset (no chrome), accent eyebrow + serif
-           * italic body. Sits closest to the top edge. */}
-          <div className="flex items-center gap-2 md:gap-3 leading-none">
-            <span className="font-mono italic text-[10px] md:text-xs uppercase tracking-[0.22em] text-accent-500">
-              News
-            </span>
-            <span className="block h-3 w-px bg-accent-500/40" aria-hidden />
-            <span className="font-serif italic text-xs md:text-sm text-light-200">
-              FoodAtlas Knowledge Graph{" "}
-              <strong className="not-italic font-semibold text-white">
-                v4.1
-              </strong>{" "}
-              released
-            </span>
-          </div>
+           * italic body. Sits closest to the top edge. Version is
+           * derived from the downloads manifest so it stays in sync
+           * with the latest published bundle. */}
+          <NewsNotification />
 
           {/* Credentials */}
           <div className="flex gap-2 md:gap-3">

--- a/frontend/components/landing/NewsNotification.tsx
+++ b/frontend/components/landing/NewsNotification.tsx
@@ -1,0 +1,44 @@
+import NextLink from "next/link";
+
+import { getLatestBundle } from "@/utils/fetching";
+
+// Server-rendered news line for the hero. Fetches the newest bundle
+// from the downloads manifest and links to /food-composition-downloads.
+// Falls back to a static string if the manifest is unreachable so a
+// flaky S3 read never breaks the landing page.
+const FALLBACK_VERSION = "v4.1";
+const DOWNLOADS_HREF = "/food-composition-downloads";
+
+const NewsNotification = async () => {
+  const latest = await getLatestBundle();
+  const version = latest?.version ?? FALLBACK_VERSION;
+
+  return (
+    <NextLink
+      href={DOWNLOADS_HREF}
+      aria-label={`View food composition downloads — ${version} release`}
+      className="group flex items-center gap-2 md:gap-3 leading-none rounded"
+    >
+      <span className="font-mono italic text-[10px] md:text-xs uppercase tracking-[0.22em] text-accent-500">
+        News
+      </span>
+      <span
+        className="block h-3 w-px bg-accent-500/40"
+        aria-hidden
+      />
+      <span
+        className="font-serif italic text-xs md:text-sm text-light-200 transition duration-300 ease-in-out group-hover:text-accent-500 group-hover:underline group-hover:decoration-1 group-hover:underline-offset-4"
+      >
+        FoodAtlas Knowledge Graph{" "}
+        <strong className="not-italic font-semibold text-white group-hover:text-accent-500 transition duration-300 ease-in-out">
+          {version}
+        </strong>{" "}
+        released
+      </span>
+    </NextLink>
+  );
+};
+
+NewsNotification.displayName = "NewsNotification";
+
+export default NewsNotification;

--- a/frontend/components/navigation/Footer.tsx
+++ b/frontend/components/navigation/Footer.tsx
@@ -122,12 +122,23 @@ const Footer = () => {
               <FaYoutube className="h-8 w-8 md:h-9 md:w-9" />
             </a>
           </div>
-          {/* copyright */}
+          {/* copyright — two paragraphs (grant blurb + copyright line)
+           * instead of one <p> with <br/><br/>, which was hitting a
+           * hydration mismatch on iOS Safari for the <br> children.
+           * suppressHydrationWarning on the year span in case
+           * Date().getFullYear() differs between the build-server
+           * clock (SSR) and the client clock. */}
           <p className="text-center mt-10 text-xs text-light-400 leading-relaxed">
             This work is supported by AFRI Competitive Grant no.
             2020-67021-32855/project accession no. 1024262 from the USDA
-            National Institute of Food and Agriculture. <br />
-            <br />Ⓒ {new Date().getFullYear()} AIFS. All rights reserved.
+            National Institute of Food and Agriculture.
+          </p>
+          <p className="text-center mt-3 text-xs text-light-400 leading-relaxed">
+            Ⓒ{" "}
+            <span suppressHydrationWarning>
+              {new Date().getFullYear()}
+            </span>{" "}
+            AIFS. All rights reserved.
           </p>
         </div>
       </div>

--- a/frontend/components/navigation/Navbar.tsx
+++ b/frontend/components/navigation/Navbar.tsx
@@ -65,8 +65,13 @@ const Navbar = ({ className }: NavbarProps) => {
     setIsVisible(true);
     setIsFocused(true);
     setIsNavMenuOpen(false);
-    // Wait one paint so the fade-in / re-anchor has taken effect.
-    requestAnimationFrame(() => inputRef.current?.focus());
+    // Wait one paint so the fade-in / re-anchor has taken effect,
+    // then focus without letting Safari scroll the page to bring the
+    // input into view — we've already anchored it below the navbar,
+    // any Safari-driven scroll would just fight our position.
+    requestAnimationFrame(() =>
+      inputRef.current?.focus({ preventScroll: true }),
+    );
   };
 
   return (

--- a/frontend/components/search/SearchBar.tsx
+++ b/frontend/components/search/SearchBar.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useContext, useEffect, useState } from "react";
+import { useContext, useEffect, useRef, useState } from "react";
+import { flushSync } from "react-dom";
 import { usePathname, useRouter } from "next/navigation";
 import { ThreeDot } from "react-loading-indicators";
 import { MdClose, MdSearch } from "react-icons/md";
@@ -103,6 +104,62 @@ const SearchBar = () => {
     }
   }, [pathname, isFocused, isVisible, setIsVisible]);
 
+  // Cooldown after an outside-tap dismiss. When the fly-up collapses
+  // the input snaps back to its docked position, and the residual
+  // tap can land on it and refocus. During the cooldown window,
+  // bounce any incoming focus by immediately blurring.
+  const outsideDismissRef = useRef(false);
+
+  // Dismiss on outside tap. iOS Safari is inconsistent: sometimes it
+  // dismisses the keyboard WITHOUT firing blur on the input, leaving
+  // the fly-up stuck open. Update `isFocused` directly here instead
+  // of relying on the blur-event chain. `preventDefault` blocks the
+  // subsequent mouse/click cascade so the residual tap can't land
+  // on the now-docked input and refocus it.
+  useEffect(() => {
+    if (!isFocused) return;
+    const dismiss = (e: Event) => {
+      const content = document.getElementById("search-component");
+      if (!content || content.contains(e.target as Node)) return;
+      e.preventDefault();
+      outsideDismissRef.current = true;
+      inputRef.current?.blur();
+      setSelectedSuggestion(-1);
+      setIsFocused(false);
+      window.setTimeout(() => {
+        outsideDismissRef.current = false;
+      }, 400);
+    };
+    document.addEventListener("pointerdown", dismiss);
+    return () => document.removeEventListener("pointerdown", dismiss);
+  }, [isFocused, inputRef, setIsFocused, setSelectedSuggestion]);
+
+  // Detect keyboard dismissal that happens OUTSIDE our webview — e.g.
+  // taps on Safari's URL bar or its side gutters, or the keyboard's
+  // own down-arrow key. Those never reach our pointerdown listener,
+  // but they do shrink+grow the visualViewport. Track "keyboard is
+  // open" via a viewport shrink, then dismiss the fly-up when it
+  // grows back to (approximately) the pre-keyboard height.
+  useEffect(() => {
+    if (!isFocused) return;
+    const vv = window.visualViewport;
+    if (!vv) return;
+    const initialHeight = vv.height;
+    let keyboardOpen = false;
+    const onResize = () => {
+      const shrunk = initialHeight - vv.height;
+      if (shrunk > 100) {
+        keyboardOpen = true;
+      } else if (keyboardOpen && shrunk < 20) {
+        inputRef.current?.blur();
+        setSelectedSuggestion(-1);
+        setIsFocused(false);
+      }
+    };
+    vv.addEventListener("resize", onResize);
+    return () => vv.removeEventListener("resize", onResize);
+  }, [isFocused, inputRef, setIsFocused, setSelectedSuggestion]);
+
   // Set the static placeholder once. The SearchContext still owns the
   // value so the input can read it through the same prop as before;
   // removing the typewriter loop just leaves a single useEffect.
@@ -183,13 +240,46 @@ const SearchBar = () => {
   };
 
   const handleFocus = () => {
+    // If focus arrives during the outside-dismiss cooldown, it's the
+    // residual click from the same tap that just dismissed us —
+    // bounce it instead of re-opening the fly-up.
+    if (outsideDismissRef.current) {
+      inputRef.current?.blur();
+      return;
+    }
     // Track focus directly off the input's onFocus event. The previous
     // approach polled `document.activeElement` through a useEffect with
     // a non-reactive dependency, which only re-synced on unrelated
     // re-renders — so after a programmatic blur (Esc, X) clicking the
     // input back wouldn't re-flip `isFocused` until the user typed.
-    setSelectedSuggestion(-1);
-    setIsFocused(true);
+    //
+    // `flushSync` forces React to apply the fly-up class synchronously
+    // before this handler returns; without it iOS Safari sees the
+    // input at its pre-fly-up position when computing "scroll into
+    // view" and yanks the page down.
+    flushSync(() => {
+      setSelectedSuggestion(-1);
+      setIsFocused(true);
+    });
+    // Fallback: on iOS Safari the keyboard-appear animation still
+    // triggers a scroll even with `interactive-widget=resizes-content`
+    // (which only lands on iOS 16.4+). Reset scrollY across BOTH the
+    // window scroll event AND the visualViewport resize event — the
+    // latter is what fires when the soft keyboard opens.
+    if (typeof window !== "undefined") {
+      const y = window.scrollY;
+      const reset = () => {
+        if (window.scrollY !== y) window.scrollTo(0, y);
+      };
+      window.addEventListener("scroll", reset, { passive: true });
+      window.visualViewport?.addEventListener("resize", reset);
+      window.visualViewport?.addEventListener("scroll", reset);
+      window.setTimeout(() => {
+        window.removeEventListener("scroll", reset);
+        window.visualViewport?.removeEventListener("resize", reset);
+        window.visualViewport?.removeEventListener("scroll", reset);
+      }, 800);
+    }
   };
 
   const handleBlur = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -226,12 +316,16 @@ const SearchBar = () => {
     >
       <div
         className={`z-50 w-full absolute px-4 md:px-24 ${
-          // When focused, the overlay sits with a half-navbar-height
-          // gap under the navbar bottom — 48 + 24 = 72 mobile,
-          // 56 + 28 = 84 desktop. Tailwind `important: true` makes
-          // the class win over inline `top: offsetTop` on the docked
-          // state, so the same responsive values apply on every page.
-          isFocused ? "absolute inset-0 top-[72px] md:top-[84px] -right-4" : ""
+          // When focused, use `fixed` positioning so the overlay is
+          // tied to the viewport, not the document. iOS Safari's
+          // "scroll input into view" logic sees a fixed-positioned
+          // input as already-in-view at its viewport-space top,
+          // whereas an `absolute` input at the same visual position
+          // still has a document-space Y that Safari tries to scroll
+          // to — yanking the page down on tap. Same top values as
+          // before (72 mobile / 84 desktop = navbar bottom + half a
+          // navbar height).
+          isFocused ? "fixed inset-0 top-[72px] md:top-[84px] -right-4" : ""
         } ${isResultsPage ? "" : "duration-[250ms]"}`}
         ref={containerRef}
         style={{ top: offsetTop || 50 }}
@@ -313,6 +407,28 @@ const SearchBar = () => {
                   aria-label="Search foods, chemicals and diseases"
                   onChange={handleInputChange}
                   onFocus={handleFocus}
+                  // Chrome + Safari (desktop and mobile) both scroll
+                  // the focused input into view on click. That's what
+                  // makes the page appear to "fly up" — content shifts
+                  // under the fixed navbar. Preempt by preventing the
+                  // default (which is what triggers the focus + auto-
+                  // scroll) and calling focus manually with
+                  // `preventScroll: true`.
+                  onMouseDown={(e) => {
+                    if (document.activeElement === e.currentTarget) return;
+                    e.preventDefault();
+                    e.currentTarget.focus({ preventScroll: true });
+                  }}
+                  // iOS Safari's touch→focus path can bypass mousedown
+                  // entirely, so mirror the preempt here. preventDefault
+                  // on touchend (not touchstart) — touchstart preventDefault
+                  // kills scroll gestures, whereas touchend only blocks the
+                  // synthesized focus-triggered scroll.
+                  onTouchEnd={(e) => {
+                    if (document.activeElement === e.currentTarget) return;
+                    e.preventDefault();
+                    e.currentTarget.focus({ preventScroll: true });
+                  }}
                   // @ts-ignore
                   onBlur={handleBlur}
                   onKeyDown={handleKeyDown}

--- a/frontend/utils/fetching.ts
+++ b/frontend/utils/fetching.ts
@@ -1,4 +1,4 @@
-import { MacroAndMicroData, Metadata, TaxonomyData } from "@/types";
+import { DownloadEntry, MacroAndMicroData, Metadata, TaxonomyData } from "@/types";
 
 // API base URL. On the server we hit the upstream ALB directly (it may be
 // HTTP — that's fine server-side). On the client we route through a
@@ -262,6 +262,33 @@ export async function getDownloadEntries() {
   const { data } = await response.json();
 
   return data;
+}
+
+// Newest bundle for the home-page notification. Returns null on any
+// error so the notification can fall back to a static string rather
+// than propagating a 500 (staging manifest is occasionally missing).
+export async function getLatestBundle(): Promise<DownloadEntry | null> {
+  try {
+    const response = await fetch(`${apiBase()}/download`, {
+      headers: {
+        Authorization: `Bearer ${process.env.NEXT_PUBLIC_API_KEY}`,
+      },
+      next: { revalidate: 300 },
+    });
+    if (!response.ok) return null;
+    const { data } = await response.json();
+    if (!Array.isArray(data) || data.length === 0) return null;
+    // release_date is ISO YYYY-MM-DD, so string sort is chronological.
+    // Version is the tiebreaker to keep the pick deterministic when two
+    // bundles ship on the same day.
+    const sorted = [...data].sort((a, b) => {
+      const d = String(b.release_date).localeCompare(String(a.release_date));
+      return d !== 0 ? d : String(b.version).localeCompare(String(a.version));
+    });
+    return sorted[0];
+  } catch {
+    return null;
+  }
 }
 
 // Shared list-fetch params for the four paginated bioactivity endpoints —


### PR DESCRIPTION
## Summary
Round 2 of mobile-optimization work, bundled ahead of Monday review. Two independent tracks in one PR:

**Dynamic home notification** (subagent's work, verified by build)
- Replaces the hardcoded "v4.1 release" line with a `NewsNotification` server component that reads the newest entry from `bundles/index.json` (same source as `/food-composition-downloads`).
- Sorts by `release_date` desc, tiebreaks on `version`, picks newest.
- Fetched server-side via the existing `/download` endpoint (no new S3 code, no new endpoint) — inherits Next fetch cache.
- Whole row is a `<Link>` to `/food-composition-downloads`; on hover, serif body + bold version turn `text-accent-500` with underline (mirrors `Link.tsx`).
- Fallback: renders "v4.1" if fetch returns null — row still valid.

**iOS Safari mobile fixes** (in-session, verified on iPhone LAN)
- SearchBar focus-scroll: viewport `interactive-widget=resizes-content`, `preventScroll: true` on programmatic focus, `onMouseDown`/`onTouchEnd` preempt, `flushSync` sync fly-up, and a scroll/visualViewport reset window. Kills the "background bolts up then snaps back" flicker on landing and entity pages.
- SearchBar outside-tap dismiss: document-level `pointerdown` listener sets `isFocused=false` directly (iOS sometimes eats the blur event), with a 400ms cooldown ref to bounce residual focus. Plus a `visualViewport.resize` fallback that catches keyboard dismissal via Safari-chrome taps or the keyboard's own down-arrow key.
- Modal edge-to-edge: viewport `viewport-fit=cover`, panel becomes a `min-h-[100dvh]` sheet on mobile (no rounding/border, safe-area padding). Card look preserved at `sm:` and up.
- Footer hydration: split copyright `<p>` (was one `<p>` with `<br /><br />` — iOS Safari flagged a mismatch), `suppressHydrationWarning` on the `getFullYear()` span.

## Known state
- **Modal viewport-fit** — the code change is in, but Lukas rain-checked visual confirmation on iPhone till Monday. If the edge-to-edge sheet looks wrong on Monday's retest, the fix is a one-line adjustment (padding tighter, or revert to the wrapper-padding version).
- **SearchBar** — all three flows (focus scroll, in-page outside tap, Safari-chrome outside tap) tested and confirmed working on iPhone Safari + desktop Chrome. Minor stutter at the beginning of the fly-up animation acknowledged and accepted.

## Test plan
- [ ] Landing page — search notification shows latest bundle version, hover reveals link styling, click navigates to `/food-composition-downloads`.
- [ ] Landing page — tap SearchBar input; no background/navbar shift.
- [ ] Landing page — while focused, tap in blurred backdrop area (below input); fly-up dismisses.
- [ ] Landing page — while focused, tap Safari's URL bar area (left/right gutters); fly-up dismisses.
- [ ] Any entity page (e.g. `/food/strawberry`) — open Data Points modal on iPhone; modal covers the dynamic island area with the panel background, content sits inside safe-area padding.
- [ ] Footer year — no hydration console warning on first load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)